### PR TITLE
feat: add logprobs comparison tool (M2)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+import sys
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -11,12 +13,47 @@ def main(argv: list[str] | None = None) -> None:
         description="PD disaggregation accuracy diagnostic tool",
     )
     sub = parser.add_subparsers(dest="command")
+
+    # compare-logprobs
+    lp = sub.add_parser("compare-logprobs", help="Compare logprobs between two endpoints")
+    lp.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    lp.add_argument("--target", required=True, help="Target endpoint URL")
+    lp.add_argument("--prompt", required=True, help="Prompt to send")
+    lp.add_argument("--model", default="default", help="Model name")
+    lp.add_argument("--max-tokens", type=int, default=64, help="Max tokens to generate")
+    lp.add_argument("--api-key", default="no-key", help="API key for both endpoints")
+
     sub.add_parser("diagnose", help="Run full diagnostic pipeline")
-    sub.add_parser("compare-logprobs", help="Compare logprobs between two endpoints")
     sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
 
     args = parser.parse_args(argv)
     if not args.command:
         parser.print_help()
         return
-    print(f"xpyd-acc {args.command} — not yet implemented")
+
+    if args.command == "compare-logprobs":
+        asyncio.run(_run_compare_logprobs(args))
+    else:
+        print(f"xpyd-acc {args.command} — not yet implemented")
+
+
+async def _run_compare_logprobs(args: argparse.Namespace) -> None:
+    """Run logprobs comparison between two endpoints."""
+    from xpyd_acc.logprobs import LogprobsCollector, LogprobsComparator
+
+    baseline_collector = LogprobsCollector(args.baseline, api_key=args.api_key, model=args.model)
+    target_collector = LogprobsCollector(args.target, api_key=args.api_key, model=args.model)
+
+    print(f"Collecting logprobs from baseline: {args.baseline}")
+    baseline_result = await baseline_collector.collect(args.prompt, max_tokens=args.max_tokens)
+
+    print(f"Collecting logprobs from target: {args.target}")
+    target_result = await target_collector.collect(args.prompt, max_tokens=args.max_tokens)
+
+    comparator = LogprobsComparator()
+    report = comparator.compare(baseline_result, target_result)
+    print()
+    print(comparator.format_report(report))
+
+    if not report.match:
+        sys.exit(1)

--- a/src/xpyd_acc/logprobs.py
+++ b/src/xpyd_acc/logprobs.py
@@ -1,0 +1,178 @@
+"""Logprobs collection and comparison for two OpenAI-compatible endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import httpx
+
+
+@dataclass
+class TokenLogprob:
+    """A single token with its log probability."""
+
+    index: int
+    token: str
+    logprob: float
+
+
+@dataclass
+class LogprobsResult:
+    """Logprobs collected from one endpoint."""
+
+    endpoint: str
+    model: str
+    tokens: list[TokenLogprob] = field(default_factory=list)
+
+
+@dataclass
+class DivergencePoint:
+    """First point where two logprob sequences diverge."""
+
+    token_index: int
+    expected_token: str
+    actual_token: str
+    expected_logprob: float
+    actual_logprob: float
+    prob_diff: float
+
+
+@dataclass
+class ComparisonReport:
+    """Result of comparing logprobs from two endpoints."""
+
+    baseline: LogprobsResult
+    target: LogprobsResult
+    divergence: DivergencePoint | None
+    total_tokens_compared: int
+    match: bool
+
+
+class LogprobsCollector:
+    """Send a prompt to an OpenAI-compatible endpoint and collect per-token logprobs."""
+
+    def __init__(self, base_url: str, api_key: str = "no-key", model: str = "default") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+
+    async def collect(
+        self,
+        prompt: str,
+        max_tokens: int = 64,
+        *,
+        timeout: float = 30.0,
+    ) -> LogprobsResult:
+        """Send prompt and collect logprobs from the completions endpoint."""
+        url = f"{self.base_url}/v1/chat/completions"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        payload = {
+            "model": self.model,
+            "messages": [{"role": "user", "content": prompt}],
+            "max_tokens": max_tokens,
+            "logprobs": True,
+            "top_logprobs": 1,
+        }
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+
+        return self._parse_response(data)
+
+    def _parse_response(self, data: dict) -> LogprobsResult:
+        """Parse OpenAI-compatible chat completion response with logprobs."""
+        choice = data["choices"][0]
+        model = data.get("model", self.model)
+        logprobs_content = choice.get("logprobs", {}).get("content", [])
+
+        tokens: list[TokenLogprob] = []
+        for i, entry in enumerate(logprobs_content):
+            tokens.append(
+                TokenLogprob(
+                    index=i,
+                    token=entry["token"],
+                    logprob=entry["logprob"],
+                )
+            )
+
+        return LogprobsResult(endpoint=self.base_url, model=model, tokens=tokens)
+
+
+class LogprobsComparator:
+    """Compare logprob sequences from two endpoints and find divergence."""
+
+    def __init__(self, token_mismatch_threshold: float = 0.0) -> None:
+        self.token_mismatch_threshold = token_mismatch_threshold
+
+    def compare(self, baseline: LogprobsResult, target: LogprobsResult) -> ComparisonReport:
+        """Compare two logprob sequences. Find first divergence point."""
+        min_len = min(len(baseline.tokens), len(target.tokens))
+        divergence: DivergencePoint | None = None
+
+        for i in range(min_len):
+            bt = baseline.tokens[i]
+            tt = target.tokens[i]
+
+            if bt.token != tt.token:
+                divergence = DivergencePoint(
+                    token_index=i,
+                    expected_token=bt.token,
+                    actual_token=tt.token,
+                    expected_logprob=bt.logprob,
+                    actual_logprob=tt.logprob,
+                    prob_diff=abs(bt.logprob - tt.logprob),
+                )
+                break
+
+        # If tokens all match but lengths differ, that's also a divergence
+        if divergence is None and len(baseline.tokens) != len(target.tokens):
+            idx = min_len
+            expected = baseline.tokens[idx].token if idx < len(baseline.tokens) else "<end>"
+            actual = target.tokens[idx].token if idx < len(target.tokens) else "<end>"
+            expected_lp = baseline.tokens[idx].logprob if idx < len(baseline.tokens) else 0.0
+            actual_lp = target.tokens[idx].logprob if idx < len(target.tokens) else 0.0
+            divergence = DivergencePoint(
+                token_index=idx,
+                expected_token=expected,
+                actual_token=actual,
+                expected_logprob=expected_lp,
+                actual_logprob=actual_lp,
+                prob_diff=abs(expected_lp - actual_lp),
+            )
+
+        return ComparisonReport(
+            baseline=baseline,
+            target=target,
+            divergence=divergence,
+            total_tokens_compared=min_len,
+            match=divergence is None,
+        )
+
+    def format_report(self, report: ComparisonReport) -> str:
+        """Format a comparison report as human-readable text."""
+        lines = [
+            "=== Logprobs Comparison Report ===",
+            f"Baseline: {report.baseline.endpoint} ({report.baseline.model})",
+            f"Target:   {report.target.endpoint} ({report.target.model})",
+            f"Tokens compared: {report.total_tokens_compared}",
+            "",
+        ]
+
+        if report.match:
+            lines.append("✅ MATCH — no divergence found")
+        else:
+            assert report.divergence is not None
+            d = report.divergence
+            lines.extend([
+                "❌ DIVERGENCE DETECTED",
+                f"  Token index:    {d.token_index}",
+                f"  Expected token: {d.expected_token!r}",
+                f"  Actual token:   {d.actual_token!r}",
+                f"  Expected logprob: {d.expected_logprob:.6f}",
+                f"  Actual logprob:   {d.actual_logprob:.6f}",
+                f"  Prob diff:        {d.prob_diff:.6f}",
+            ])
+
+        return "\n".join(lines)

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -1,0 +1,143 @@
+"""Tests for logprobs collection and comparison."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xpyd_acc.logprobs import (
+    LogprobsCollector,
+    LogprobsComparator,
+    LogprobsResult,
+    TokenLogprob,
+)
+
+
+def _make_chat_response(tokens: list[tuple[str, float]], model: str = "test-model") -> dict:
+    """Build a mock OpenAI chat completion response with logprobs."""
+    content = [{"token": t, "logprob": lp} for t, lp in tokens]
+    return {
+        "model": model,
+        "choices": [
+            {
+                "logprobs": {"content": content},
+                "message": {"content": "".join(t for t, _ in tokens)},
+            }
+        ],
+    }
+
+
+def _make_result(
+    endpoint: str, tokens: list[tuple[str, float]], model: str = "m"
+) -> LogprobsResult:
+    return LogprobsResult(
+        endpoint=endpoint,
+        model=model,
+        tokens=[TokenLogprob(index=i, token=t, logprob=lp) for i, (t, lp) in enumerate(tokens)],
+    )
+
+
+class TestLogprobsCollector:
+    @pytest.mark.asyncio
+    async def test_collect_parses_response(self) -> None:
+        mock_tokens = [("Hello", -0.1), (" world", -0.05)]
+        mock_resp = _make_chat_response(mock_tokens, model="gpt-test")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_resp
+        mock_response.raise_for_status = lambda: None
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            collector = LogprobsCollector("http://localhost:8000", model="gpt-test")
+            result = await collector.collect("Hi")
+
+        assert result.model == "gpt-test"
+        assert len(result.tokens) == 2
+        assert result.tokens[0].token == "Hello"
+        assert result.tokens[0].logprob == pytest.approx(-0.1)
+        assert result.tokens[1].token == " world"
+
+    @pytest.mark.asyncio
+    async def test_collect_empty_logprobs(self) -> None:
+        mock_resp = {
+            "model": "m",
+            "choices": [{"logprobs": {"content": []}, "message": {"content": ""}}],
+        }
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_resp
+        mock_response.raise_for_status = lambda: None
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            collector = LogprobsCollector("http://localhost:8000")
+            result = await collector.collect("Hi")
+
+        assert len(result.tokens) == 0
+
+
+class TestLogprobsComparator:
+    def test_match(self) -> None:
+        baseline = _make_result("a", [("Hello", -0.1), (" world", -0.05)])
+        target = _make_result("b", [("Hello", -0.1), (" world", -0.05)])
+
+        cmp = LogprobsComparator()
+        report = cmp.compare(baseline, target)
+        assert report.match is True
+        assert report.divergence is None
+        assert report.total_tokens_compared == 2
+
+    def test_divergence_at_token(self) -> None:
+        baseline = _make_result("a", [("Hello", -0.1), (" world", -0.05)])
+        target = _make_result("b", [("Hello", -0.1), (" there", -0.2)])
+
+        cmp = LogprobsComparator()
+        report = cmp.compare(baseline, target)
+        assert report.match is False
+        assert report.divergence is not None
+        assert report.divergence.token_index == 1
+        assert report.divergence.expected_token == " world"
+        assert report.divergence.actual_token == " there"
+        assert report.divergence.prob_diff == pytest.approx(0.15)
+
+    def test_divergence_different_lengths(self) -> None:
+        baseline = _make_result("a", [("Hello", -0.1), (" world", -0.05)])
+        target = _make_result("b", [("Hello", -0.1)])
+
+        cmp = LogprobsComparator()
+        report = cmp.compare(baseline, target)
+        assert report.match is False
+        assert report.divergence is not None
+        assert report.divergence.token_index == 1
+        assert report.divergence.expected_token == " world"
+        assert report.divergence.actual_token == "<end>"
+
+    def test_format_report_match(self) -> None:
+        baseline = _make_result("http://a", [("Hi", -0.1)])
+        target = _make_result("http://b", [("Hi", -0.1)])
+        cmp = LogprobsComparator()
+        report = cmp.compare(baseline, target)
+        text = cmp.format_report(report)
+        assert "MATCH" in text
+
+    def test_format_report_divergence(self) -> None:
+        baseline = _make_result("http://a", [("Hi", -0.1)])
+        target = _make_result("http://b", [("Yo", -0.3)])
+        cmp = LogprobsComparator()
+        report = cmp.compare(baseline, target)
+        text = cmp.format_report(report)
+        assert "DIVERGENCE" in text
+        assert "Hi" in text
+        assert "Yo" in text


### PR DESCRIPTION
## Summary
Implement the Logprobs Comparison Tool (Milestone 2 from ROADMAP.md).

### Changes
- **`LogprobsCollector`**: Sends a prompt to an OpenAI-compatible chat completions endpoint and collects per-token logprobs
- **`LogprobsComparator`**: Compares two logprob sequences and finds the first divergence point
- **CLI `compare-logprobs`**: Wired up with `--baseline`, `--target`, `--prompt`, `--model`, `--max-tokens`, `--api-key` arguments
- **Divergence report**: Token index, expected vs actual token, logprob values, probability diff
- **7 unit tests** with mocked HTTP responses (all passing)

### Testing
```
pytest tests/ -v  # 8 passed
ruff check src tests  # All checks passed
isort --check src tests  # All checks passed
```

Closes #1