### PR TITLE
chore: mark M2 as complete in ROADMAP.md

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 ## M1: Project Skeleton ✅
 - Basic project structure, CLI stub, CI
 
-## M2: Logprobs Comparison Tool ⬜
+## M2: Logprobs Comparison Tool ✅
 - Send same prompt to two endpoints
 - Collect logprobs token by token
 - Find first divergence point


### PR DESCRIPTION
Update ROADMAP.md to mark M2 (Logprobs Comparison Tool) as ✅ complete.