### PR TITLE
feat: add KV cache comparison tool (M3)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -24,7 +24,19 @@ def main(argv: list[str] | None = None) -> None:
     lp.add_argument("--api-key", default="no-key", help="API key for both endpoints")
 
     sub.add_parser("diagnose", help="Run full diagnostic pipeline")
-    sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
+
+    kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
+    kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
+    kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
+    kv.add_argument(
+        "--max-abs-threshold", type=float, default=1e-3,
+        help="Max absolute diff threshold for divergence (default: 1e-3)",
+    )
+    kv.add_argument(
+        "--cosine-threshold", type=float, default=0.999,
+        help="Cosine similarity threshold for divergence (default: 0.999)",
+    )
+    kv.add_argument("--json", action="store_true", help="Output report as JSON")
 
     args = parser.parse_args(argv)
     if not args.command:
@@ -33,6 +45,8 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.command == "compare-logprobs":
         asyncio.run(_run_compare_logprobs(args))
+    elif args.command == "check-kv":
+        _run_check_kv(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -54,6 +68,32 @@ async def _run_compare_logprobs(args: argparse.Namespace) -> None:
     report = comparator.compare(baseline_result, target_result)
     print()
     print(comparator.format_report(report))
+
+    if not report.match:
+        sys.exit(1)
+
+
+def _run_check_kv(args: argparse.Namespace) -> None:
+    """Run KV cache comparison between two npz dumps."""
+    from xpyd_acc.kvcache import KVCacheComparator, KVCacheLoader
+
+    baseline = KVCacheLoader.load(args.baseline)
+    target = KVCacheLoader.load(args.target)
+
+    comparator = KVCacheComparator(
+        max_abs_threshold=args.max_abs_threshold,
+        cosine_threshold=args.cosine_threshold,
+    )
+    report = comparator.compare(
+        baseline, target,
+        baseline_path=args.baseline,
+        target_path=args.target,
+    )
+
+    if args.json:
+        print(report.to_json())
+    else:
+        print(KVCacheComparator.format_report(report))
 
     if not report.match:
         sys.exit(1)

--- a/src/xpyd_acc/kvcache.py
+++ b/src/xpyd_acc/kvcache.py
@@ -1,0 +1,167 @@
+"""KV cache loading, comparison, and divergence reporting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass
+class LayerMetrics:
+    """Numerical comparison metrics for a single KV cache layer."""
+
+    layer_name: str
+    max_abs_diff: float
+    mean_abs_diff: float
+    cosine_similarity: float
+    divergent: bool
+
+
+@dataclass
+class KVCacheReport:
+    """Full comparison report across all layers."""
+
+    baseline_path: str
+    target_path: str
+    layers: list[LayerMetrics] = field(default_factory=list)
+    divergent_layers: list[str] = field(default_factory=list)
+    match: bool = True
+
+    def to_json(self) -> str:
+        """Serialize report to JSON string."""
+        return json.dumps(asdict(self), indent=2)
+
+
+class KVCacheLoader:
+    """Load KV cache dumps from numpy npz files."""
+
+    @staticmethod
+    def load(path: str | Path) -> dict[str, np.ndarray]:
+        """Load an npz file and return a dict of layer_name -> array."""
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"KV cache file not found: {path}")
+        data = np.load(str(path))
+        return dict(data)
+
+
+class KVCacheComparator:
+    """Compare two KV cache dumps layer by layer."""
+
+    def __init__(
+        self,
+        max_abs_threshold: float = 1e-3,
+        cosine_threshold: float = 0.999,
+    ) -> None:
+        self.max_abs_threshold = max_abs_threshold
+        self.cosine_threshold = cosine_threshold
+
+    def compare(
+        self,
+        baseline: dict[str, np.ndarray],
+        target: dict[str, np.ndarray],
+        baseline_path: str = "",
+        target_path: str = "",
+    ) -> KVCacheReport:
+        """Compare two KV cache dicts and produce a report."""
+        all_keys = sorted(set(baseline.keys()) | set(target.keys()))
+        report = KVCacheReport(baseline_path=baseline_path, target_path=target_path)
+
+        for key in all_keys:
+            if key not in baseline:
+                metrics = LayerMetrics(
+                    layer_name=key,
+                    max_abs_diff=float("inf"),
+                    mean_abs_diff=float("inf"),
+                    cosine_similarity=0.0,
+                    divergent=True,
+                )
+            elif key not in target:
+                metrics = LayerMetrics(
+                    layer_name=key,
+                    max_abs_diff=float("inf"),
+                    mean_abs_diff=float("inf"),
+                    cosine_similarity=0.0,
+                    divergent=True,
+                )
+            else:
+                metrics = self._compare_arrays(key, baseline[key], target[key])
+
+            report.layers.append(metrics)
+            if metrics.divergent:
+                report.divergent_layers.append(key)
+                report.match = False
+
+        return report
+
+    def _compare_arrays(self, name: str, a: np.ndarray, b: np.ndarray) -> LayerMetrics:
+        """Compare two arrays and compute metrics."""
+        if a.shape != b.shape:
+            return LayerMetrics(
+                layer_name=name,
+                max_abs_diff=float("inf"),
+                mean_abs_diff=float("inf"),
+                cosine_similarity=0.0,
+                divergent=True,
+            )
+
+        diff = np.abs(a.astype(np.float64) - b.astype(np.float64))
+        max_abs = float(np.max(diff))
+        mean_abs = float(np.mean(diff))
+
+        # Cosine similarity on flattened vectors
+        a_flat = a.flatten().astype(np.float64)
+        b_flat = b.flatten().astype(np.float64)
+        norm_a = np.linalg.norm(a_flat)
+        norm_b = np.linalg.norm(b_flat)
+
+        if norm_a == 0.0 and norm_b == 0.0:
+            cosine_sim = 1.0
+        elif norm_a == 0.0 or norm_b == 0.0:
+            cosine_sim = 0.0
+        else:
+            cosine_sim = float(np.dot(a_flat, b_flat) / (norm_a * norm_b))
+
+        divergent = max_abs > self.max_abs_threshold or cosine_sim < self.cosine_threshold
+
+        return LayerMetrics(
+            layer_name=name,
+            max_abs_diff=max_abs,
+            mean_abs_diff=mean_abs,
+            cosine_similarity=cosine_sim,
+            divergent=divergent,
+        )
+
+    @staticmethod
+    def format_report(report: KVCacheReport) -> str:
+        """Format report as human-readable text."""
+        lines = [
+            "=== KV Cache Comparison Report ===",
+            f"Baseline: {report.baseline_path}",
+            f"Target:   {report.target_path}",
+            f"Layers:   {len(report.layers)}",
+            "",
+        ]
+
+        for m in report.layers:
+            status = "❌" if m.divergent else "✅"
+            lines.append(
+                f"  {status} {m.layer_name}: "
+                f"max_abs={m.max_abs_diff:.6e}, "
+                f"mean_abs={m.mean_abs_diff:.6e}, "
+                f"cosine={m.cosine_similarity:.6f}"
+            )
+
+        lines.append("")
+        if report.match:
+            lines.append("✅ MATCH — all layers within tolerance")
+        else:
+            lines.append(
+                f"❌ DIVERGENCE — {len(report.divergent_layers)} layer(s): "
+                + ", ".join(report.divergent_layers)
+            )
+
+        return "\n".join(lines)

--- a/tests/test_kvcache.py
+++ b/tests/test_kvcache.py
@@ -1,0 +1,113 @@
+"""Tests for KV cache comparison module."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from xpyd_acc.kvcache import KVCacheComparator, KVCacheLoader
+
+
+@pytest.fixture()
+def tmp_dir():
+    """Provide a temporary directory."""
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+def _save_npz(path: Path, layers: dict[str, np.ndarray]) -> Path:
+    """Save a dict of arrays as npz."""
+    np.savez(str(path), **layers)
+    return path
+
+
+class TestKVCacheLoader:
+    def test_load_valid(self, tmp_dir: Path) -> None:
+        data = {"layer_0": np.ones((2, 4)), "layer_1": np.zeros((2, 4))}
+        p = _save_npz(tmp_dir / "cache.npz", data)
+        loaded = KVCacheLoader.load(p)
+        assert set(loaded.keys()) == {"layer_0", "layer_1"}
+        np.testing.assert_array_equal(loaded["layer_0"], data["layer_0"])
+
+    def test_load_missing_file(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            KVCacheLoader.load("/nonexistent/path.npz")
+
+
+class TestKVCacheComparator:
+    def test_identical_caches(self, tmp_dir: Path) -> None:
+        data = {"layer_0": np.random.randn(4, 8), "layer_1": np.random.randn(4, 8)}
+        comparator = KVCacheComparator()
+        report = comparator.compare(data, data)
+        assert report.match is True
+        assert len(report.divergent_layers) == 0
+        assert len(report.layers) == 2
+
+    def test_divergent_caches(self) -> None:
+        baseline = {"layer_0": np.zeros((4, 8))}
+        target = {"layer_0": np.ones((4, 8))}
+        comparator = KVCacheComparator()
+        report = comparator.compare(baseline, target)
+        assert report.match is False
+        assert "layer_0" in report.divergent_layers
+        assert report.layers[0].max_abs_diff == 1.0
+
+    def test_within_threshold(self) -> None:
+        baseline = {"layer_0": np.ones((4, 8))}
+        target = {"layer_0": np.ones((4, 8)) + 1e-5}
+        comparator = KVCacheComparator(max_abs_threshold=1e-3, cosine_threshold=0.999)
+        report = comparator.compare(baseline, target)
+        assert report.match is True
+
+    def test_mismatched_layers(self) -> None:
+        baseline = {"layer_0": np.ones((4, 8))}
+        target = {"layer_1": np.ones((4, 8))}
+        comparator = KVCacheComparator()
+        report = comparator.compare(baseline, target)
+        assert report.match is False
+        assert len(report.divergent_layers) == 2  # both missing in the other
+
+    def test_mismatched_shapes(self) -> None:
+        baseline = {"layer_0": np.ones((4, 8))}
+        target = {"layer_0": np.ones((4, 16))}
+        comparator = KVCacheComparator()
+        report = comparator.compare(baseline, target)
+        assert report.match is False
+        assert report.layers[0].divergent is True
+
+    def test_empty_caches(self) -> None:
+        comparator = KVCacheComparator()
+        report = comparator.compare({}, {})
+        assert report.match is True
+        assert len(report.layers) == 0
+
+    def test_zero_vectors(self) -> None:
+        baseline = {"layer_0": np.zeros((4, 8))}
+        target = {"layer_0": np.zeros((4, 8))}
+        comparator = KVCacheComparator()
+        report = comparator.compare(baseline, target)
+        assert report.match is True
+        assert report.layers[0].cosine_similarity == 1.0
+
+    def test_format_report(self) -> None:
+        baseline = {"layer_0": np.zeros((4, 8))}
+        target = {"layer_0": np.ones((4, 8))}
+        comparator = KVCacheComparator()
+        report = comparator.compare(baseline, target, "base.npz", "target.npz")
+        text = KVCacheComparator.format_report(report)
+        assert "DIVERGENCE" in text
+        assert "layer_0" in text
+
+    def test_json_export(self) -> None:
+        baseline = {"layer_0": np.ones((2, 2))}
+        comparator = KVCacheComparator()
+        report = comparator.compare(baseline, baseline)
+        json_str = report.to_json()
+        import json
+
+        data = json.loads(json_str)
+        assert data["match"] is True
+        assert len(data["layers"]) == 1


### PR DESCRIPTION
## Summary
Implements Milestone 3: KV Cache Comparison Tool.

### Changes
- **`src/xpyd_acc/kvcache.py`**: New module with `KVCacheLoader`, `KVCacheComparator`, and data classes
  - Loads npz files with layer-keyed arrays
  - Computes per-layer: max absolute diff, mean absolute diff, cosine similarity
  - Flags layers exceeding configurable thresholds
  - Structured report with JSON export
- **`src/xpyd_acc/cli.py`**: Integrated `check-kv` subcommand with `--baseline`, `--target`, `--max-abs-threshold`, `--cosine-threshold`, `--json` flags
- **`tests/test_kvcache.py`**: 11 test cases covering identical/divergent/mismatched/empty caches, shape mismatch, zero vectors, report formatting, JSON export

Closes #4