### PR TITLE
feat: add automated diagnostic pipeline (M4)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -23,7 +23,24 @@ def main(argv: list[str] | None = None) -> None:
     lp.add_argument("--max-tokens", type=int, default=64, help="Max tokens to generate")
     lp.add_argument("--api-key", default="no-key", help="API key for both endpoints")
 
-    sub.add_parser("diagnose", help="Run full diagnostic pipeline")
+    diag = sub.add_parser("diagnose", help="Run full diagnostic pipeline")
+    diag.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    diag.add_argument("--target", required=True, help="Target endpoint URL")
+    diag.add_argument("--prompt", required=True, help="Prompt to send")
+    diag.add_argument("--model", default="default", help="Model name")
+    diag.add_argument("--max-tokens", type=int, default=64, help="Max tokens to generate")
+    diag.add_argument("--api-key", default="no-key", help="API key for endpoints")
+    diag.add_argument("--kv-baseline", default=None, help="Path to baseline KV cache (.npz)")
+    diag.add_argument("--kv-target", default=None, help="Path to target KV cache (.npz)")
+    diag.add_argument(
+        "--kv-max-abs-threshold", type=float, default=1e-3,
+        help="KV cache max absolute diff threshold (default: 1e-3)",
+    )
+    diag.add_argument(
+        "--kv-cosine-threshold", type=float, default=0.999,
+        help="KV cache cosine similarity threshold (default: 0.999)",
+    )
+    diag.add_argument("--json", action="store_true", help="Output report as JSON")
 
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
@@ -47,6 +64,8 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_compare_logprobs(args))
     elif args.command == "check-kv":
         _run_check_kv(args)
+    elif args.command == "diagnose":
+        asyncio.run(_run_diagnose(args))
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -70,6 +89,34 @@ async def _run_compare_logprobs(args: argparse.Namespace) -> None:
     print(comparator.format_report(report))
 
     if not report.match:
+        sys.exit(1)
+
+
+async def _run_diagnose(args: argparse.Namespace) -> None:
+    """Run the full diagnostic pipeline."""
+    from xpyd_acc.diagnose import DiagnosticPipeline, format_rich_report
+
+    pipeline = DiagnosticPipeline(
+        baseline_url=args.baseline,
+        target_url=args.target,
+        prompt=args.prompt,
+        model=args.model,
+        api_key=args.api_key,
+        max_tokens=args.max_tokens,
+        kv_baseline_path=args.kv_baseline,
+        kv_target_path=args.kv_target,
+        kv_max_abs_threshold=args.kv_max_abs_threshold,
+        kv_cosine_threshold=args.kv_cosine_threshold,
+    )
+
+    report = await pipeline.run()
+
+    if args.json:
+        print(report.to_json())
+    else:
+        print(format_rich_report(report))
+
+    if not report.overall_pass:
         sys.exit(1)
 
 

--- a/src/xpyd_acc/diagnose.py
+++ b/src/xpyd_acc/diagnose.py
@@ -1,0 +1,266 @@
+"""Automated diagnostic pipeline for PD disaggregation accuracy."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+
+from xpyd_acc.kvcache import KVCacheComparator, KVCacheLoader
+from xpyd_acc.logprobs import (
+    ComparisonReport,
+    LogprobsCollector,
+    LogprobsComparator,
+)
+
+
+class StepStatus(str, Enum):
+    """Status of a diagnostic step."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
+@dataclass
+class DiagnosticStep:
+    """Result of a single diagnostic step."""
+
+    name: str
+    description: str
+    status: StepStatus
+    detail: str = ""
+    data: dict | None = None
+
+
+@dataclass
+class DiagnosticReport:
+    """Full diagnostic report across all steps."""
+
+    steps: list[DiagnosticStep] = field(default_factory=list)
+    overall_pass: bool = True
+
+    def to_json(self) -> str:
+        """Serialize report to JSON string."""
+        return json.dumps(asdict(self), indent=2, default=str)
+
+
+class DiagnosticPipeline:
+    """Run all diagnostic checks in sequence."""
+
+    def __init__(
+        self,
+        baseline_url: str,
+        target_url: str,
+        prompt: str,
+        *,
+        model: str = "default",
+        api_key: str = "no-key",
+        max_tokens: int = 64,
+        kv_baseline_path: str | None = None,
+        kv_target_path: str | None = None,
+        kv_max_abs_threshold: float = 1e-3,
+        kv_cosine_threshold: float = 0.999,
+    ) -> None:
+        self.baseline_url = baseline_url
+        self.target_url = target_url
+        self.prompt = prompt
+        self.model = model
+        self.api_key = api_key
+        self.max_tokens = max_tokens
+        self.kv_baseline_path = kv_baseline_path
+        self.kv_target_path = kv_target_path
+        self.kv_max_abs_threshold = kv_max_abs_threshold
+        self.kv_cosine_threshold = kv_cosine_threshold
+
+    async def run(self) -> DiagnosticReport:
+        """Execute all diagnostic steps and return the report."""
+        report = DiagnosticReport()
+
+        # Step 1: First-token logprobs comparison
+        step1 = await self._step_first_token()
+        report.steps.append(step1)
+        if step1.status == StepStatus.FAIL:
+            report.overall_pass = False
+
+        # Step 2: KV cache comparison (if dumps provided)
+        step2 = self._step_kv_cache()
+        report.steps.append(step2)
+        if step2.status == StepStatus.FAIL:
+            report.overall_pass = False
+
+        # Step 3: Full sequence logprobs comparison
+        step3 = await self._step_full_sequence()
+        report.steps.append(step3)
+        if step3.status == StepStatus.FAIL:
+            report.overall_pass = False
+
+        return report
+
+    async def _step_first_token(self) -> DiagnosticStep:
+        """Step 1: Compare first token between baseline and target."""
+        try:
+            comparison = await self._collect_and_compare(max_tokens=1)
+        except Exception as e:
+            return DiagnosticStep(
+                name="first_token",
+                description="Baseline vs target: first token match",
+                status=StepStatus.FAIL,
+                detail=f"Error: {e}",
+            )
+
+        if comparison.match:
+            return DiagnosticStep(
+                name="first_token",
+                description="Baseline vs target: first token match",
+                status=StepStatus.PASS,
+                detail="First token matches between endpoints",
+            )
+
+        d = comparison.divergence
+        detail = (
+            f"First token diverges: expected {d.expected_token!r}, "
+            f"got {d.actual_token!r} (logprob diff: {d.prob_diff:.6f})"
+        ) if d else "No tokens generated"
+
+        return DiagnosticStep(
+            name="first_token",
+            description="Baseline vs target: first token match",
+            status=StepStatus.FAIL,
+            detail=detail,
+        )
+
+    def _step_kv_cache(self) -> DiagnosticStep:
+        """Step 2: Compare KV cache dumps if available."""
+        if not self.kv_baseline_path or not self.kv_target_path:
+            return DiagnosticStep(
+                name="kv_cache",
+                description="KV cache numerical accuracy",
+                status=StepStatus.SKIP,
+                detail="No KV cache dumps provided (use --kv-baseline and --kv-target)",
+            )
+
+        try:
+            baseline = KVCacheLoader.load(self.kv_baseline_path)
+            target = KVCacheLoader.load(self.kv_target_path)
+        except Exception as e:
+            return DiagnosticStep(
+                name="kv_cache",
+                description="KV cache numerical accuracy",
+                status=StepStatus.FAIL,
+                detail=f"Error loading KV cache: {e}",
+            )
+
+        comparator = KVCacheComparator(
+            max_abs_threshold=self.kv_max_abs_threshold,
+            cosine_threshold=self.kv_cosine_threshold,
+        )
+        kv_report = comparator.compare(
+            baseline, target,
+            baseline_path=self.kv_baseline_path,
+            target_path=self.kv_target_path,
+        )
+
+        if kv_report.match:
+            return DiagnosticStep(
+                name="kv_cache",
+                description="KV cache numerical accuracy",
+                status=StepStatus.PASS,
+                detail=f"All {len(kv_report.layers)} layers within tolerance",
+                data={"divergent_layers": []},
+            )
+
+        return DiagnosticStep(
+            name="kv_cache",
+            description="KV cache numerical accuracy",
+            status=StepStatus.FAIL,
+            detail=(
+                f"{len(kv_report.divergent_layers)} divergent layer(s): "
+                + ", ".join(kv_report.divergent_layers)
+            ),
+            data={"divergent_layers": kv_report.divergent_layers},
+        )
+
+    async def _step_full_sequence(self) -> DiagnosticStep:
+        """Step 3: Full sequence logprobs comparison."""
+        try:
+            comparison = await self._collect_and_compare(max_tokens=self.max_tokens)
+        except Exception as e:
+            return DiagnosticStep(
+                name="full_sequence",
+                description="Baseline vs target: full sequence match",
+                status=StepStatus.FAIL,
+                detail=f"Error: {e}",
+            )
+
+        if comparison.match:
+            return DiagnosticStep(
+                name="full_sequence",
+                description="Baseline vs target: full sequence match",
+                status=StepStatus.PASS,
+                detail=f"All {comparison.total_tokens_compared} tokens match",
+            )
+
+        d = comparison.divergence
+        detail = (
+            f"Divergence at token {d.token_index}: "
+            f"expected {d.expected_token!r}, got {d.actual_token!r} "
+            f"(logprob diff: {d.prob_diff:.6f})"
+        ) if d else "Comparison failed"
+
+        return DiagnosticStep(
+            name="full_sequence",
+            description="Baseline vs target: full sequence match",
+            status=StepStatus.FAIL,
+            detail=detail,
+            data={
+                "divergence_index": d.token_index if d else None,
+                "total_tokens": comparison.total_tokens_compared,
+            },
+        )
+
+    async def _collect_and_compare(self, max_tokens: int) -> ComparisonReport:
+        """Collect logprobs from both endpoints and compare."""
+        baseline_collector = LogprobsCollector(
+            self.baseline_url, api_key=self.api_key, model=self.model,
+        )
+        target_collector = LogprobsCollector(
+            self.target_url, api_key=self.api_key, model=self.model,
+        )
+
+        baseline_result = await baseline_collector.collect(self.prompt, max_tokens=max_tokens)
+        target_result = await target_collector.collect(self.prompt, max_tokens=max_tokens)
+
+        comparator = LogprobsComparator()
+        return comparator.compare(baseline_result, target_result)
+
+
+def format_rich_report(report: DiagnosticReport) -> str:
+    """Format diagnostic report with rich terminal symbols."""
+    status_icons = {
+        StepStatus.PASS: "✅",
+        StepStatus.FAIL: "❌",
+        StepStatus.SKIP: "⏭️",
+    }
+
+    lines = [
+        "╔══════════════════════════════════════╗",
+        "║    xPyD-acc Diagnostic Report        ║",
+        "╚══════════════════════════════════════╝",
+        "",
+    ]
+
+    for i, step in enumerate(report.steps, 1):
+        icon = status_icons[step.status]
+        lines.append(f"  Step {i}: {step.description}")
+        lines.append(f"    {icon} {step.status.value.upper()} — {step.detail}")
+        lines.append("")
+
+    lines.append("─" * 40)
+    if report.overall_pass:
+        lines.append("✅ ALL CHECKS PASSED")
+    else:
+        failed = sum(1 for s in report.steps if s.status == StepStatus.FAIL)
+        lines.append(f"❌ {failed} CHECK(S) FAILED")
+
+    return "\n".join(lines)

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -1,0 +1,270 @@
+"""Tests for the diagnostic pipeline."""
+
+from __future__ import annotations
+
+import tempfile
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from xpyd_acc.diagnose import (
+    DiagnosticPipeline,
+    DiagnosticReport,
+    DiagnosticStep,
+    StepStatus,
+    format_rich_report,
+)
+from xpyd_acc.logprobs import LogprobsResult, TokenLogprob
+
+
+def _make_logprobs_result(
+    endpoint: str, tokens: list[tuple[str, float]],
+) -> LogprobsResult:
+    """Helper to build a LogprobsResult."""
+    return LogprobsResult(
+        endpoint=endpoint,
+        model="test-model",
+        tokens=[
+            TokenLogprob(index=i, token=tok, logprob=lp)
+            for i, (tok, lp) in enumerate(tokens)
+        ],
+    )
+
+
+def _mock_collect_factory(tokens_a: list[tuple[str, float]], tokens_b: list[tuple[str, float]]):
+    """Return a side_effect function that returns different results per endpoint."""
+    call_count = 0
+
+    async def _collect(prompt, max_tokens=64):
+        nonlocal call_count
+        call_count += 1
+        if call_count % 2 == 1:  # odd calls = baseline
+            return _make_logprobs_result("http://baseline", tokens_a[:max_tokens])
+        return _make_logprobs_result("http://target", tokens_b[:max_tokens])
+
+    return _collect
+
+
+class TestDiagnosticPipeline:
+    """Tests for DiagnosticPipeline."""
+
+    @pytest.mark.asyncio
+    async def test_all_pass_no_kv(self):
+        """All steps pass when endpoints return identical tokens, no KV dumps."""
+        tokens = [("Hello", -0.1), ("world", -0.2)]
+
+        pipeline = DiagnosticPipeline(
+            baseline_url="http://baseline:8000",
+            target_url="http://target:8000",
+            prompt="test",
+            max_tokens=2,
+        )
+
+        mock_collect = _mock_collect_factory(tokens, tokens)
+        with patch(
+            "xpyd_acc.diagnose.LogprobsCollector.collect",
+            side_effect=mock_collect,
+        ):
+            report = await pipeline.run()
+
+        assert report.overall_pass is True
+        assert len(report.steps) == 3
+        assert report.steps[0].status == StepStatus.PASS  # first token
+        assert report.steps[1].status == StepStatus.SKIP  # KV skipped
+        assert report.steps[2].status == StepStatus.PASS  # full sequence
+
+    @pytest.mark.asyncio
+    async def test_first_token_divergence(self):
+        """First token diverges → step 1 fails."""
+        tokens_a = [("Hello", -0.1)]
+        tokens_b = [("World", -0.5)]
+
+        pipeline = DiagnosticPipeline(
+            baseline_url="http://baseline:8000",
+            target_url="http://target:8000",
+            prompt="test",
+            max_tokens=1,
+        )
+
+        mock_collect = _mock_collect_factory(tokens_a, tokens_b)
+        with patch(
+            "xpyd_acc.diagnose.LogprobsCollector.collect",
+            side_effect=mock_collect,
+        ):
+            report = await pipeline.run()
+
+        assert report.overall_pass is False
+        assert report.steps[0].status == StepStatus.FAIL
+        assert "Hello" in report.steps[0].detail
+
+    @pytest.mark.asyncio
+    async def test_kv_cache_pass(self):
+        """KV cache step passes when dumps match."""
+        tokens = [("Hi", -0.1)]
+
+        with tempfile.NamedTemporaryFile(suffix=".npz") as f_base, \
+             tempfile.NamedTemporaryFile(suffix=".npz") as f_tgt:
+            arr = np.random.randn(2, 4, 8).astype(np.float32)
+            np.savez(f_base.name, layer_0=arr)
+            np.savez(f_tgt.name, layer_0=arr)
+
+            pipeline = DiagnosticPipeline(
+                baseline_url="http://baseline:8000",
+                target_url="http://target:8000",
+                prompt="test",
+                max_tokens=1,
+                kv_baseline_path=f_base.name,
+                kv_target_path=f_tgt.name,
+            )
+
+            mock_collect = _mock_collect_factory(tokens, tokens)
+            with patch(
+                "xpyd_acc.diagnose.LogprobsCollector.collect",
+                side_effect=mock_collect,
+            ):
+                report = await pipeline.run()
+
+        assert report.steps[1].status == StepStatus.PASS
+        assert report.steps[1].name == "kv_cache"
+
+    @pytest.mark.asyncio
+    async def test_kv_cache_fail(self):
+        """KV cache step fails when dumps diverge."""
+        tokens = [("Hi", -0.1)]
+
+        with tempfile.NamedTemporaryFile(suffix=".npz") as f_base, \
+             tempfile.NamedTemporaryFile(suffix=".npz") as f_tgt:
+            arr_a = np.zeros((2, 4, 8), dtype=np.float32)
+            arr_b = np.ones((2, 4, 8), dtype=np.float32)
+            np.savez(f_base.name, layer_0=arr_a)
+            np.savez(f_tgt.name, layer_0=arr_b)
+
+            pipeline = DiagnosticPipeline(
+                baseline_url="http://baseline:8000",
+                target_url="http://target:8000",
+                prompt="test",
+                max_tokens=1,
+                kv_baseline_path=f_base.name,
+                kv_target_path=f_tgt.name,
+            )
+
+            mock_collect = _mock_collect_factory(tokens, tokens)
+            with patch(
+                "xpyd_acc.diagnose.LogprobsCollector.collect",
+                side_effect=mock_collect,
+            ):
+                report = await pipeline.run()
+
+        assert report.overall_pass is False
+        assert report.steps[1].status == StepStatus.FAIL
+        assert "layer_0" in report.steps[1].detail
+
+    @pytest.mark.asyncio
+    async def test_full_sequence_divergence(self):
+        """Full sequence diverges at token 2."""
+        tokens_a = [("A", -0.1), ("B", -0.2), ("C", -0.3)]
+        tokens_b = [("A", -0.1), ("B", -0.2), ("X", -0.9)]
+
+        pipeline = DiagnosticPipeline(
+            baseline_url="http://baseline:8000",
+            target_url="http://target:8000",
+            prompt="test",
+            max_tokens=3,
+        )
+
+        mock_collect = _mock_collect_factory(tokens_a, tokens_b)
+        with patch(
+            "xpyd_acc.diagnose.LogprobsCollector.collect",
+            side_effect=mock_collect,
+        ):
+            report = await pipeline.run()
+
+        assert report.overall_pass is False
+        # First token should pass (both "A")
+        assert report.steps[0].status == StepStatus.PASS
+        # Full sequence should fail
+        assert report.steps[2].status == StepStatus.FAIL
+        assert "token 2" in report.steps[2].detail
+
+    @pytest.mark.asyncio
+    async def test_connection_error_handled(self):
+        """Network errors are caught and reported as failures."""
+        pipeline = DiagnosticPipeline(
+            baseline_url="http://nonexistent:9999",
+            target_url="http://nonexistent:9999",
+            prompt="test",
+        )
+
+        # Don't mock — let it fail with connection error
+        report = await pipeline.run()
+
+        assert report.overall_pass is False
+        assert report.steps[0].status == StepStatus.FAIL
+        assert "Error" in report.steps[0].detail
+
+    @pytest.mark.asyncio
+    async def test_json_export(self):
+        """Report serializes to valid JSON."""
+        tokens = [("Hi", -0.1)]
+
+        pipeline = DiagnosticPipeline(
+            baseline_url="http://baseline:8000",
+            target_url="http://target:8000",
+            prompt="test",
+            max_tokens=1,
+        )
+
+        mock_collect = _mock_collect_factory(tokens, tokens)
+        with patch(
+            "xpyd_acc.diagnose.LogprobsCollector.collect",
+            side_effect=mock_collect,
+        ):
+            report = await pipeline.run()
+
+        import json
+        data = json.loads(report.to_json())
+        assert "steps" in data
+        assert "overall_pass" in data
+        assert len(data["steps"]) == 3
+
+
+class TestFormatRichReport:
+    """Tests for format_rich_report."""
+
+    def test_all_pass(self):
+        """Report with all passing steps."""
+        report = DiagnosticReport(
+            steps=[
+                DiagnosticStep("a", "Step A", StepStatus.PASS, "OK"),
+                DiagnosticStep("b", "Step B", StepStatus.PASS, "OK"),
+            ],
+            overall_pass=True,
+        )
+        text = format_rich_report(report)
+        assert "ALL CHECKS PASSED" in text
+        assert "✅" in text
+
+    def test_with_failure(self):
+        """Report with a failure."""
+        report = DiagnosticReport(
+            steps=[
+                DiagnosticStep("a", "Step A", StepStatus.PASS, "OK"),
+                DiagnosticStep("b", "Step B", StepStatus.FAIL, "Bad"),
+            ],
+            overall_pass=False,
+        )
+        text = format_rich_report(report)
+        assert "FAILED" in text
+        assert "❌" in text
+
+    def test_with_skip(self):
+        """Report with a skipped step."""
+        report = DiagnosticReport(
+            steps=[
+                DiagnosticStep("a", "Step A", StepStatus.SKIP, "No data"),
+            ],
+            overall_pass=True,
+        )
+        text = format_rich_report(report)
+        assert "SKIP" in text


### PR DESCRIPTION
## Summary

Implement `xpyd-acc diagnose` command — the automated diagnostic pipeline from Milestone 4.

## Changes

- **`src/xpyd_acc/diagnose.py`**: New module with `DiagnosticPipeline`, `DiagnosticReport`, and `format_rich_report`
- **`src/xpyd_acc/cli.py`**: Wire up `diagnose` subcommand with full CLI args
- **`tests/test_diagnose.py`**: 10 new tests covering all pipeline scenarios

## How it works

The pipeline runs 3 sequential diagnostic steps:
1. **First-token comparison** — sends prompt to both endpoints, compares first generated token
2. **KV cache check** — compares numpy KV cache dumps if provided (skip otherwise)
3. **Full sequence comparison** — compares all generated tokens via logprobs

Rich terminal output shows ✅/❌/⏭️ per step. `--json` flag exports full structured report.

## Testing

All 29 tests pass (19 existing + 10 new). Lint clean (ruff + isort).

Closes #7