### PR TITLE
feat: add output comparison utilities (M5)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -42,6 +42,13 @@ def main(argv: list[str] | None = None) -> None:
     )
     diag.add_argument("--json", action="store_true", help="Output report as JSON")
 
+    oc = sub.add_parser("compare-output", help="Compare text outputs from two endpoints")
+    oc_input = oc.add_mutually_exclusive_group(required=True)
+    oc_input.add_argument("--baseline-text", help="Baseline output text (inline)")
+    oc_input.add_argument("--baseline-file", help="Path to file with baseline output")
+    oc.add_argument("--target-text", help="Target output text (inline)")
+    oc.add_argument("--target-file", help="Path to file with target output")
+
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
     kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
@@ -60,7 +67,9 @@ def main(argv: list[str] | None = None) -> None:
         parser.print_help()
         return
 
-    if args.command == "compare-logprobs":
+    if args.command == "compare-output":
+        _run_compare_output(args)
+    elif args.command == "compare-logprobs":
         asyncio.run(_run_compare_logprobs(args))
     elif args.command == "check-kv":
         _run_check_kv(args)
@@ -68,6 +77,33 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_diagnose(args))
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
+
+
+def _run_compare_output(args: argparse.Namespace) -> None:
+    """Run text output comparison."""
+    from pathlib import Path
+
+    from xpyd_acc.output_compare import OutputComparator
+
+    if args.baseline_text is not None:
+        baseline = args.baseline_text
+    else:
+        baseline = Path(args.baseline_file).read_text()
+
+    if args.target_text is not None:
+        target = args.target_text
+    elif args.target_file is not None:
+        target = Path(args.target_file).read_text()
+    else:
+        print("Error: provide --target-text or --target-file", file=sys.stderr)
+        sys.exit(1)
+
+    comparator = OutputComparator()
+    report = comparator.compare(baseline, target)
+    print(OutputComparator.format_report(report))
+
+    if not report.exact_match:
+        sys.exit(1)
 
 
 async def _run_compare_logprobs(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/output_compare.py
+++ b/src/xpyd_acc/output_compare.py
@@ -1,0 +1,200 @@
+"""Output comparison utilities: text diff, edit distance, token-level diff, semantic similarity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TokenDiff:
+    """A single diff entry between two token sequences."""
+
+    tag: str  # "equal", "replace", "insert", "delete"
+    baseline_tokens: list[str]
+    target_tokens: list[str]
+    baseline_range: tuple[int, int]  # (start, end) indices
+    target_range: tuple[int, int]
+
+
+@dataclass
+class OutputComparisonReport:
+    """Full comparison report between two outputs."""
+
+    baseline_text: str
+    target_text: str
+    exact_match: bool
+    edit_distance: int
+    normalized_edit_distance: float  # 0.0 = identical, 1.0 = completely different
+    token_diffs: list[TokenDiff] = field(default_factory=list)
+    semantic_similarity: float | None = None  # None if not computed
+    baseline_token_count: int = 0
+    target_token_count: int = 0
+
+    def summary(self) -> str:
+        """One-line summary."""
+        if self.exact_match:
+            return "✅ EXACT MATCH"
+        return (
+            f"❌ MISMATCH — edit_distance={self.edit_distance}, "
+            f"normalized={self.normalized_edit_distance:.4f}, "
+            f"tokens: {self.baseline_token_count} vs {self.target_token_count}"
+        )
+
+
+def levenshtein_distance(s1: str, s2: str) -> int:
+    """Compute Levenshtein edit distance between two strings."""
+    if len(s1) < len(s2):
+        return levenshtein_distance(s2, s1)
+    if len(s2) == 0:
+        return len(s1)
+
+    prev_row = list(range(len(s2) + 1))
+    for i, c1 in enumerate(s1):
+        curr_row = [i + 1]
+        for j, c2 in enumerate(s2):
+            cost = 0 if c1 == c2 else 1
+            curr_row.append(min(
+                curr_row[j] + 1,        # insert
+                prev_row[j + 1] + 1,    # delete
+                prev_row[j] + cost,     # replace
+            ))
+        prev_row = curr_row
+    return prev_row[-1]
+
+
+def tokenize_simple(text: str) -> list[str]:
+    """Simple whitespace tokenizer. Splits on whitespace, keeps punctuation attached."""
+    return text.split()
+
+
+def compute_token_diffs(baseline_tokens: list[str], target_tokens: list[str]) -> list[TokenDiff]:
+    """Compute token-level diffs using SequenceMatcher."""
+    import difflib
+
+    matcher = difflib.SequenceMatcher(None, baseline_tokens, target_tokens)
+    diffs: list[TokenDiff] = []
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        diffs.append(TokenDiff(
+            tag=tag,
+            baseline_tokens=baseline_tokens[i1:i2],
+            target_tokens=target_tokens[j1:j2],
+            baseline_range=(i1, i2),
+            target_range=(j1, j2),
+        ))
+    return diffs
+
+
+def reassemble_streaming_chunks(chunks: list[str]) -> str:
+    """Reassemble streaming output chunks into a single string."""
+    return "".join(chunks)
+
+
+class OutputComparator:
+    """Compare two text outputs with multiple methods."""
+
+    def compare(
+        self,
+        baseline: str,
+        target: str,
+        *,
+        baseline_embeddings: list[float] | None = None,
+        target_embeddings: list[float] | None = None,
+    ) -> OutputComparisonReport:
+        """Run full comparison between baseline and target text."""
+        exact = baseline == target
+        edit_dist = levenshtein_distance(baseline, target)
+        max_len = max(len(baseline), len(target))
+        norm_dist = edit_dist / max_len if max_len > 0 else 0.0
+
+        b_tokens = tokenize_simple(baseline)
+        t_tokens = tokenize_simple(target)
+        token_diffs = compute_token_diffs(b_tokens, t_tokens)
+
+        sem_sim: float | None = None
+        if baseline_embeddings is not None and target_embeddings is not None:
+            sem_sim = _cosine_similarity(baseline_embeddings, target_embeddings)
+
+        return OutputComparisonReport(
+            baseline_text=baseline,
+            target_text=target,
+            exact_match=exact,
+            edit_distance=edit_dist,
+            normalized_edit_distance=norm_dist,
+            token_diffs=token_diffs,
+            semantic_similarity=sem_sim,
+            baseline_token_count=len(b_tokens),
+            target_token_count=len(t_tokens),
+        )
+
+    def compare_streaming(
+        self,
+        baseline_chunks: list[str],
+        target_chunks: list[str],
+        *,
+        baseline_embeddings: list[float] | None = None,
+        target_embeddings: list[float] | None = None,
+    ) -> OutputComparisonReport:
+        """Compare streaming outputs by first reassembling chunks."""
+        baseline = reassemble_streaming_chunks(baseline_chunks)
+        target = reassemble_streaming_chunks(target_chunks)
+        return self.compare(
+            baseline, target,
+            baseline_embeddings=baseline_embeddings,
+            target_embeddings=target_embeddings,
+        )
+
+    @staticmethod
+    def format_report(report: OutputComparisonReport) -> str:
+        """Format comparison report as human-readable text."""
+        lines = [
+            "=== Output Comparison Report ===",
+            f"Exact match: {'Yes' if report.exact_match else 'No'}",
+            f"Edit distance: {report.edit_distance} "
+            f"(normalized: {report.normalized_edit_distance:.4f})",
+            f"Baseline tokens: {report.baseline_token_count}",
+            f"Target tokens:   {report.target_token_count}",
+        ]
+
+        if report.semantic_similarity is not None:
+            lines.append(f"Semantic similarity: {report.semantic_similarity:.6f}")
+
+        if not report.exact_match:
+            lines.append("")
+            lines.append("--- Token Diffs ---")
+            for d in report.token_diffs:
+                if d.tag == "equal":
+                    continue
+                if d.tag == "replace":
+                    lines.append(
+                        f"  [{d.baseline_range[0]}:{d.baseline_range[1]}] "
+                        f"REPLACE {d.baseline_tokens!r} → {d.target_tokens!r}"
+                    )
+                elif d.tag == "delete":
+                    lines.append(
+                        f"  [{d.baseline_range[0]}:{d.baseline_range[1]}] "
+                        f"DELETE {d.baseline_tokens!r}"
+                    )
+                elif d.tag == "insert":
+                    lines.append(
+                        f"  [{d.target_range[0]}:{d.target_range[1]}] "
+                        f"INSERT {d.target_tokens!r}"
+                    )
+
+        return "\n".join(lines)
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two vectors."""
+    import math
+
+    if len(a) != len(b):
+        msg = f"Embedding dimension mismatch: {len(a)} vs {len(b)}"
+        raise ValueError(msg)
+
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/tests/test_output_compare.py
+++ b/tests/test_output_compare.py
@@ -1,0 +1,133 @@
+"""Tests for output comparison utilities."""
+
+from __future__ import annotations
+
+from xpyd_acc.output_compare import (
+    OutputComparator,
+    levenshtein_distance,
+    reassemble_streaming_chunks,
+    tokenize_simple,
+)
+
+
+class TestLevenshteinDistance:
+    def test_identical(self) -> None:
+        assert levenshtein_distance("hello", "hello") == 0
+
+    def test_empty(self) -> None:
+        assert levenshtein_distance("", "") == 0
+        assert levenshtein_distance("abc", "") == 3
+        assert levenshtein_distance("", "abc") == 3
+
+    def test_single_edit(self) -> None:
+        assert levenshtein_distance("cat", "hat") == 1
+        assert levenshtein_distance("cat", "cats") == 1
+        assert levenshtein_distance("cats", "cat") == 1
+
+    def test_multiple_edits(self) -> None:
+        assert levenshtein_distance("kitten", "sitting") == 3
+
+
+class TestTokenizeSimple:
+    def test_basic(self) -> None:
+        assert tokenize_simple("hello world") == ["hello", "world"]
+
+    def test_empty(self) -> None:
+        assert tokenize_simple("") == []
+
+    def test_punctuation(self) -> None:
+        assert tokenize_simple("hello, world!") == ["hello,", "world!"]
+
+
+class TestReassembleStreamingChunks:
+    def test_basic(self) -> None:
+        assert reassemble_streaming_chunks(["hel", "lo ", "world"]) == "hello world"
+
+    def test_empty(self) -> None:
+        assert reassemble_streaming_chunks([]) == ""
+
+    def test_single(self) -> None:
+        assert reassemble_streaming_chunks(["full text"]) == "full text"
+
+
+class TestOutputComparator:
+    def test_exact_match(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("hello world", "hello world")
+        assert report.exact_match is True
+        assert report.edit_distance == 0
+        assert report.normalized_edit_distance == 0.0
+
+    def test_mismatch(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("the cat sat", "the dog sat")
+        assert report.exact_match is False
+        assert report.edit_distance > 0
+        # Token diff should show "cat" → "dog"
+        replace_diffs = [d for d in report.token_diffs if d.tag == "replace"]
+        assert len(replace_diffs) == 1
+        assert replace_diffs[0].baseline_tokens == ["cat"]
+        assert replace_diffs[0].target_tokens == ["dog"]
+
+    def test_empty_inputs(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("", "")
+        assert report.exact_match is True
+        assert report.edit_distance == 0
+
+    def test_semantic_similarity(self) -> None:
+        comp = OutputComparator()
+        emb_a = [1.0, 0.0, 0.0]
+        emb_b = [1.0, 0.0, 0.0]
+        report = comp.compare("a", "b", baseline_embeddings=emb_a, target_embeddings=emb_b)
+        assert report.semantic_similarity is not None
+        assert abs(report.semantic_similarity - 1.0) < 1e-6
+
+    def test_semantic_similarity_orthogonal(self) -> None:
+        comp = OutputComparator()
+        emb_a = [1.0, 0.0]
+        emb_b = [0.0, 1.0]
+        report = comp.compare("a", "b", baseline_embeddings=emb_a, target_embeddings=emb_b)
+        assert report.semantic_similarity is not None
+        assert abs(report.semantic_similarity) < 1e-6
+
+    def test_no_embeddings(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("a", "b")
+        assert report.semantic_similarity is None
+
+    def test_streaming_compare(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare_streaming(
+            ["hello ", "world"],
+            ["hello ", "world"],
+        )
+        assert report.exact_match is True
+
+    def test_streaming_mismatch(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare_streaming(
+            ["the ", "cat"],
+            ["the ", "dog"],
+        )
+        assert report.exact_match is False
+
+    def test_format_report_match(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("same text", "same text")
+        text = OutputComparator.format_report(report)
+        assert "Exact match: Yes" in text
+
+    def test_format_report_mismatch(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("hello world", "hello mars")
+        text = OutputComparator.format_report(report)
+        assert "Exact match: No" in text
+        assert "REPLACE" in text
+
+    def test_summary(self) -> None:
+        comp = OutputComparator()
+        report = comp.compare("a", "a")
+        assert "EXACT MATCH" in report.summary()
+        report2 = comp.compare("a", "b")
+        assert "MISMATCH" in report2.summary()


### PR DESCRIPTION
## Summary
Implements M5: Output Comparison Utilities from the roadmap.

### Added
- `src/xpyd_acc/output_compare.py`: OutputComparator class with:
  - Exact match check
  - Levenshtein edit distance (character-level)
  - Token-level diff visualization using SequenceMatcher
  - Optional semantic similarity via cosine similarity on embeddings
  - Streaming output reassembly and comparison
- CLI `compare-output` subcommand with `--baseline-text`/`--baseline-file` and `--target-text`/`--target-file` options
- `tests/test_output_compare.py`: 16 unit tests covering all functionality

### Results
- All 50 tests pass
- ruff + isort clean

Closes #9