### PR TITLE
feat: add batch dataset comparison (M6)

### DIFF
--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -1,0 +1,364 @@
+"""Batch dataset comparison: run prompts on two endpoints, find divergences."""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import io
+import json
+import statistics
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class DatasetSample:
+    """A single sample from a dataset."""
+
+    id: str
+    prompt: str
+    expected: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SampleResult:
+    """Result of comparing one sample across two endpoints."""
+
+    sample_id: str
+    prompt: str
+    baseline_output: str
+    target_output: str
+    exact_match: bool
+    first_divergence_index: int | None  # token index of first divergence
+    baseline_logprob_at_divergence: float | None
+    target_logprob_at_divergence: float | None
+    logprob_gap: float | None  # top1 - top2 gap at divergence point
+    classification: str  # "match", "likely_bug", "likely_uncertainty", "unknown"
+    context_length: int  # number of prompt tokens (approximated)
+
+    def is_divergent(self) -> bool:
+        """Whether this sample diverged."""
+        return not self.exact_match
+
+
+@dataclass
+class BatchReport:
+    """Statistical report from a batch comparison run."""
+
+    total_samples: int
+    divergent_samples: int
+    match_samples: int
+    divergence_rate: float
+    results: list[SampleResult]
+    # Stats on divergent samples only
+    divergence_index_mean: float | None = None
+    divergence_index_median: float | None = None
+    logprob_gap_mean: float | None = None
+    logprob_gap_median: float | None = None
+    likely_bugs: int = 0
+    likely_uncertainty: int = 0
+    unknown_classification: int = 0
+    # Divergence by context length buckets
+    divergence_by_context_length: dict[str, dict[str, int]] = field(default_factory=dict)
+
+
+def load_dataset(path: str | Path) -> list[DatasetSample]:
+    """Load dataset from JSONL file.
+
+    Each line should be a JSON object with at least a "prompt" field.
+    Optional fields: "id", "expected", and any other metadata.
+    """
+    path = Path(path)
+    samples: list[DatasetSample] = []
+    with path.open() as f:
+        for i, line in enumerate(f):
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if "prompt" not in obj:
+                msg = f"Line {i + 1}: missing 'prompt' field"
+                raise ValueError(msg)
+            sample_id = str(obj.get("id", i))
+            prompt = obj["prompt"]
+            expected = obj.get("expected")
+            metadata = {k: v for k, v in obj.items() if k not in ("id", "prompt", "expected")}
+            samples.append(DatasetSample(
+                id=sample_id,
+                prompt=prompt,
+                expected=expected,
+                metadata=metadata,
+            ))
+    return samples
+
+
+def _tokenize(text: str) -> list[str]:
+    """Simple whitespace tokenizer."""
+    return text.split()
+
+
+def _find_first_divergence(baseline_tokens: list[str], target_tokens: list[str]) -> int | None:
+    """Find index of first differing token. None if identical."""
+    for i, (b, t) in enumerate(zip(baseline_tokens, target_tokens)):
+        if b != t:
+            return i
+    if len(baseline_tokens) != len(target_tokens):
+        return min(len(baseline_tokens), len(target_tokens))
+    return None
+
+
+def classify_divergence(
+    logprob_gap: float | None,
+    *,
+    threshold: float = 0.1,
+) -> str:
+    """Classify divergence as likely bug or uncertainty.
+
+    If the gap between top-1 and top-2 logprob at the divergence point is large,
+    it's likely a real bug. If small, it's likely normal model uncertainty.
+    """
+    if logprob_gap is None:
+        return "unknown"
+    if logprob_gap >= threshold:
+        return "likely_bug"
+    return "likely_uncertainty"
+
+
+def _context_length_bucket(length: int) -> str:
+    """Bucket context length for grouping."""
+    if length <= 50:
+        return "0-50"
+    if length <= 200:
+        return "51-200"
+    if length <= 500:
+        return "201-500"
+    if length <= 1000:
+        return "501-1000"
+    return "1000+"
+
+
+async def _collect_output(
+    url: str,
+    prompt: str,
+    *,
+    model: str = "default",
+    max_tokens: int = 64,
+    api_key: str = "no-key",
+) -> tuple[str, list[dict[str, Any]]]:
+    """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list).
+
+    Returns a tuple of (generated_text, logprobs_per_token).
+    Each logprob entry has: {"token": str, "logprob": float, "top_logprobs": [...]}.
+    """
+    import httpx
+
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "logprobs": True,
+        "top_logprobs": 5,
+    }
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(f"{url}/v1/chat/completions", json=payload, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+
+    choice = data["choices"][0]
+    text = choice["message"]["content"]
+    logprobs_content = choice.get("logprobs", {}).get("content", [])
+    return text, logprobs_content
+
+
+async def run_batch(
+    samples: list[DatasetSample],
+    baseline_url: str,
+    target_url: str,
+    *,
+    model: str = "default",
+    max_tokens: int = 64,
+    api_key: str = "no-key",
+    logprob_gap_threshold: float = 0.1,
+    concurrency: int = 5,
+) -> BatchReport:
+    """Run all samples against both endpoints and produce a report."""
+    semaphore = asyncio.Semaphore(concurrency)
+    results: list[SampleResult] = []
+
+    async def process_sample(sample: DatasetSample) -> SampleResult:
+        async with semaphore:
+            baseline_text, baseline_lp = await _collect_output(
+                baseline_url, sample.prompt, model=model,
+                max_tokens=max_tokens, api_key=api_key,
+            )
+            target_text, target_lp = await _collect_output(
+                target_url, sample.prompt, model=model,
+                max_tokens=max_tokens, api_key=api_key,
+            )
+
+        b_tokens = _tokenize(baseline_text)
+        t_tokens = _tokenize(target_text)
+        exact = baseline_text == target_text
+        div_idx = _find_first_divergence(b_tokens, t_tokens)
+
+        b_lp_at_div: float | None = None
+        t_lp_at_div: float | None = None
+        gap: float | None = None
+
+        if div_idx is not None and div_idx < len(target_lp):
+            lp_entry = target_lp[div_idx]
+            t_lp_at_div = lp_entry.get("logprob")
+            top_lps = lp_entry.get("top_logprobs", [])
+            if len(top_lps) >= 2:
+                gap = abs(top_lps[0].get("logprob", 0) - top_lps[1].get("logprob", 0))
+        if div_idx is not None and div_idx < len(baseline_lp):
+            b_lp_at_div = baseline_lp[div_idx].get("logprob")
+
+        classification = "match" if exact else classify_divergence(
+            gap, threshold=logprob_gap_threshold,
+        )
+        ctx_len = len(_tokenize(sample.prompt))
+
+        return SampleResult(
+            sample_id=sample.id,
+            prompt=sample.prompt,
+            baseline_output=baseline_text,
+            target_output=target_text,
+            exact_match=exact,
+            first_divergence_index=div_idx,
+            baseline_logprob_at_divergence=b_lp_at_div,
+            target_logprob_at_divergence=t_lp_at_div,
+            logprob_gap=gap,
+            classification=classification,
+            context_length=ctx_len,
+        )
+
+    tasks = [process_sample(s) for s in samples]
+    results = await asyncio.gather(*tasks)
+    results = list(results)
+
+    return compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
+
+
+def compute_report(
+    results: list[SampleResult],
+    *,
+    logprob_gap_threshold: float = 0.1,
+) -> BatchReport:
+    """Compute statistical report from sample results."""
+    total = len(results)
+    divergent = [r for r in results if r.is_divergent()]
+    div_count = len(divergent)
+    match_count = total - div_count
+    rate = div_count / total if total > 0 else 0.0
+
+    div_indices = [
+        r.first_divergence_index for r in divergent
+        if r.first_divergence_index is not None
+    ]
+    gaps = [r.logprob_gap for r in divergent if r.logprob_gap is not None]
+
+    report = BatchReport(
+        total_samples=total,
+        divergent_samples=div_count,
+        match_samples=match_count,
+        divergence_rate=rate,
+        results=results,
+    )
+
+    if div_indices:
+        report.divergence_index_mean = statistics.mean(div_indices)
+        report.divergence_index_median = statistics.median(div_indices)
+    if gaps:
+        report.logprob_gap_mean = statistics.mean(gaps)
+        report.logprob_gap_median = statistics.median(gaps)
+
+    report.likely_bugs = sum(1 for r in divergent if r.classification == "likely_bug")
+    report.likely_uncertainty = sum(
+        1 for r in divergent if r.classification == "likely_uncertainty"
+    )
+    report.unknown_classification = sum(1 for r in divergent if r.classification == "unknown")
+
+    # Context length buckets
+    buckets: dict[str, dict[str, int]] = {}
+    for r in results:
+        bucket = _context_length_bucket(r.context_length)
+        if bucket not in buckets:
+            buckets[bucket] = {"total": 0, "divergent": 0}
+        buckets[bucket]["total"] += 1
+        if r.is_divergent():
+            buckets[bucket]["divergent"] += 1
+    report.divergence_by_context_length = buckets
+
+    return report
+
+
+def export_csv(report: BatchReport, path: str | Path | None = None) -> str:
+    """Export results as CSV. Returns CSV string. If path given, also writes to file."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([
+        "sample_id", "exact_match", "first_divergence_index",
+        "logprob_gap", "classification", "context_length",
+        "baseline_output", "target_output",
+    ])
+    for r in report.results:
+        writer.writerow([
+            r.sample_id,
+            r.exact_match,
+            r.first_divergence_index if r.first_divergence_index is not None else "",
+            f"{r.logprob_gap:.6f}" if r.logprob_gap is not None else "",
+            r.classification,
+            r.context_length,
+            r.baseline_output,
+            r.target_output,
+        ])
+    csv_str = output.getvalue()
+    if path is not None:
+        Path(path).write_text(csv_str)
+    return csv_str
+
+
+def format_report(report: BatchReport) -> str:
+    """Format batch report as human-readable text."""
+    lines = [
+        "=== Batch Comparison Report ===",
+        f"Total samples: {report.total_samples}",
+        f"Matches: {report.match_samples}",
+        f"Divergent: {report.divergent_samples} ({report.divergence_rate:.1%})",
+        "",
+    ]
+
+    if report.divergent_samples > 0:
+        lines.append("--- Classification ---")
+        lines.append(f"  Likely bugs:        {report.likely_bugs}")
+        lines.append(f"  Likely uncertainty:  {report.likely_uncertainty}")
+        lines.append(f"  Unknown:            {report.unknown_classification}")
+        lines.append("")
+
+        if report.divergence_index_mean is not None:
+            lines.append("--- Divergence Point ---")
+            lines.append(f"  Mean token index:   {report.divergence_index_mean:.1f}")
+            lines.append(f"  Median token index: {report.divergence_index_median:.1f}")
+            lines.append("")
+
+        if report.logprob_gap_mean is not None:
+            lines.append("--- Logprob Gap at Divergence ---")
+            lines.append(f"  Mean:   {report.logprob_gap_mean:.6f}")
+            lines.append(f"  Median: {report.logprob_gap_median:.6f}")
+            lines.append("")
+
+        if report.divergence_by_context_length:
+            lines.append("--- Divergence by Context Length ---")
+            for bucket in sorted(report.divergence_by_context_length.keys()):
+                stats = report.divergence_by_context_length[bucket]
+                rate = stats["divergent"] / stats["total"] if stats["total"] > 0 else 0
+                lines.append(
+                    f"  {bucket:>10s}: {stats['divergent']}/{stats['total']} ({rate:.1%})"
+                )
+
+    return "\n".join(lines)

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -49,6 +49,20 @@ def main(argv: list[str] | None = None) -> None:
     oc.add_argument("--target-text", help="Target output text (inline)")
     oc.add_argument("--target-file", help="Path to file with target output")
 
+    bc = sub.add_parser("batch-compare", help="Run batch dataset comparison")
+    bc.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    bc.add_argument("--target", required=True, help="Target endpoint URL")
+    bc.add_argument("--dataset", required=True, help="Path to JSONL dataset file")
+    bc.add_argument("--model", default="default", help="Model name")
+    bc.add_argument("--max-tokens", type=int, default=64, help="Max tokens to generate")
+    bc.add_argument("--api-key", default="no-key", help="API key for endpoints")
+    bc.add_argument("--concurrency", type=int, default=5, help="Max concurrent requests")
+    bc.add_argument(
+        "--logprob-gap-threshold", type=float, default=0.1,
+        help="Logprob gap threshold for bug vs uncertainty (default: 0.1)",
+    )
+    bc.add_argument("--csv", default=None, help="Path to export CSV results")
+
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
     kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
@@ -67,7 +81,9 @@ def main(argv: list[str] | None = None) -> None:
         parser.print_help()
         return
 
-    if args.command == "compare-output":
+    if args.command == "batch-compare":
+        asyncio.run(_run_batch_compare(args))
+    elif args.command == "compare-output":
         _run_compare_output(args)
     elif args.command == "compare-logprobs":
         asyncio.run(_run_compare_logprobs(args))
@@ -77,6 +93,35 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_diagnose(args))
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
+
+
+async def _run_batch_compare(args: argparse.Namespace) -> None:
+    """Run batch dataset comparison."""
+    from xpyd_acc.batch_compare import export_csv, format_report, load_dataset, run_batch
+
+    samples = load_dataset(args.dataset)
+    print(f"Loaded {len(samples)} samples from {args.dataset}")
+
+    report = await run_batch(
+        samples,
+        args.baseline,
+        args.target,
+        model=args.model,
+        max_tokens=args.max_tokens,
+        api_key=args.api_key,
+        logprob_gap_threshold=args.logprob_gap_threshold,
+        concurrency=args.concurrency,
+    )
+
+    print()
+    print(format_report(report))
+
+    if args.csv:
+        export_csv(report, args.csv)
+        print(f"\nCSV exported to {args.csv}")
+
+    if report.divergent_samples > 0:
+        sys.exit(1)
 
 
 def _run_compare_output(args: argparse.Namespace) -> None:

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -1,0 +1,253 @@
+"""Tests for batch dataset comparison."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from xpyd_acc.batch_compare import (
+    BatchReport,
+    SampleResult,
+    _context_length_bucket,
+    _find_first_divergence,
+    classify_divergence,
+    compute_report,
+    export_csv,
+    format_report,
+    load_dataset,
+)
+
+
+class TestLoadDataset:
+    def test_basic(self, tmp_path: Path) -> None:
+        data = tmp_path / "data.jsonl"
+        data.write_text(
+            '{"prompt": "What is 2+2?", "expected": "4"}\n'
+            '{"id": "q2", "prompt": "Hello", "expected": "Hi"}\n'
+        )
+        samples = load_dataset(data)
+        assert len(samples) == 2
+        assert samples[0].id == "0"
+        assert samples[0].prompt == "What is 2+2?"
+        assert samples[0].expected == "4"
+        assert samples[1].id == "q2"
+        assert samples[1].prompt == "Hello"
+
+    def test_empty_lines(self, tmp_path: Path) -> None:
+        data = tmp_path / "data.jsonl"
+        data.write_text('\n{"prompt": "test"}\n\n')
+        samples = load_dataset(data)
+        assert len(samples) == 1
+
+    def test_missing_prompt(self, tmp_path: Path) -> None:
+        data = tmp_path / "data.jsonl"
+        data.write_text('{"expected": "4"}\n')
+        try:
+            load_dataset(data)
+            assert False, "Should raise ValueError"  # noqa: B011
+        except ValueError as e:
+            assert "missing 'prompt'" in str(e)
+
+    def test_metadata(self, tmp_path: Path) -> None:
+        data = tmp_path / "data.jsonl"
+        data.write_text('{"prompt": "test", "dataset": "gsm8k", "difficulty": "easy"}\n')
+        samples = load_dataset(data)
+        assert samples[0].metadata["dataset"] == "gsm8k"
+        assert samples[0].metadata["difficulty"] == "easy"
+
+    def test_empty_file(self, tmp_path: Path) -> None:
+        data = tmp_path / "data.jsonl"
+        data.write_text("")
+        samples = load_dataset(data)
+        assert len(samples) == 0
+
+
+class TestFindFirstDivergence:
+    def test_identical(self) -> None:
+        assert _find_first_divergence(["a", "b"], ["a", "b"]) is None
+
+    def test_first_token(self) -> None:
+        assert _find_first_divergence(["a", "b"], ["x", "b"]) == 0
+
+    def test_second_token(self) -> None:
+        assert _find_first_divergence(["a", "b"], ["a", "x"]) == 1
+
+    def test_different_length(self) -> None:
+        assert _find_first_divergence(["a", "b", "c"], ["a", "b"]) == 2
+
+    def test_empty(self) -> None:
+        assert _find_first_divergence([], []) is None
+
+    def test_one_empty(self) -> None:
+        assert _find_first_divergence(["a"], []) == 0
+
+
+class TestClassifyDivergence:
+    def test_match(self) -> None:
+        assert classify_divergence(None) == "unknown"
+
+    def test_likely_bug(self) -> None:
+        assert classify_divergence(0.5, threshold=0.1) == "likely_bug"
+
+    def test_likely_uncertainty(self) -> None:
+        assert classify_divergence(0.05, threshold=0.1) == "likely_uncertainty"
+
+    def test_threshold_edge(self) -> None:
+        assert classify_divergence(0.1, threshold=0.1) == "likely_bug"
+
+
+class TestContextLengthBucket:
+    def test_short(self) -> None:
+        assert _context_length_bucket(10) == "0-50"
+
+    def test_medium(self) -> None:
+        assert _context_length_bucket(100) == "51-200"
+
+    def test_long(self) -> None:
+        assert _context_length_bucket(1500) == "1000+"
+
+
+class TestComputeReport:
+    def _make_result(
+        self,
+        *,
+        exact: bool = True,
+        div_idx: int | None = None,
+        gap: float | None = None,
+        ctx_len: int = 10,
+        classification: str = "match",
+    ) -> SampleResult:
+        return SampleResult(
+            sample_id="s1",
+            prompt="test prompt",
+            baseline_output="out",
+            target_output="out" if exact else "different",
+            exact_match=exact,
+            first_divergence_index=div_idx,
+            baseline_logprob_at_divergence=None,
+            target_logprob_at_divergence=None,
+            logprob_gap=gap,
+            classification=classification,
+            context_length=ctx_len,
+        )
+
+    def test_all_match(self) -> None:
+        results = [self._make_result(), self._make_result()]
+        report = compute_report(results)
+        assert report.total_samples == 2
+        assert report.divergent_samples == 0
+        assert report.divergence_rate == 0.0
+
+    def test_some_divergent(self) -> None:
+        results = [
+            self._make_result(),
+            self._make_result(exact=False, div_idx=3, gap=0.5, classification="likely_bug"),
+            self._make_result(
+                exact=False, div_idx=7, gap=0.02,
+                classification="likely_uncertainty",
+            ),
+        ]
+        report = compute_report(results)
+        assert report.total_samples == 3
+        assert report.divergent_samples == 2
+        assert report.likely_bugs == 1
+        assert report.likely_uncertainty == 1
+        assert report.divergence_index_mean == 5.0
+        assert report.logprob_gap_mean is not None
+
+    def test_empty(self) -> None:
+        report = compute_report([])
+        assert report.total_samples == 0
+        assert report.divergence_rate == 0.0
+
+
+class TestExportCsv:
+    def test_csv_content(self) -> None:
+        results = [
+            SampleResult(
+                sample_id="s1",
+                prompt="test",
+                baseline_output="hello",
+                target_output="world",
+                exact_match=False,
+                first_divergence_index=0,
+                baseline_logprob_at_divergence=-0.5,
+                target_logprob_at_divergence=-0.8,
+                logprob_gap=0.3,
+                classification="likely_bug",
+                context_length=5,
+            ),
+        ]
+        report = compute_report(results)
+        csv_str = export_csv(report)
+        assert "sample_id" in csv_str
+        assert "s1" in csv_str
+        assert "likely_bug" in csv_str
+
+    def test_csv_to_file(self, tmp_path: Path) -> None:
+        results = [
+            SampleResult(
+                sample_id="s1",
+                prompt="test",
+                baseline_output="a",
+                target_output="a",
+                exact_match=True,
+                first_divergence_index=None,
+                baseline_logprob_at_divergence=None,
+                target_logprob_at_divergence=None,
+                logprob_gap=None,
+                classification="match",
+                context_length=5,
+            ),
+        ]
+        report = compute_report(results)
+        out = tmp_path / "out.csv"
+        export_csv(report, out)
+        assert out.exists()
+        content = out.read_text()
+        assert "s1" in content
+
+
+class TestFormatReport:
+    def test_all_match(self) -> None:
+        report = BatchReport(
+            total_samples=5,
+            divergent_samples=0,
+            match_samples=5,
+            divergence_rate=0.0,
+            results=[],
+        )
+        text = format_report(report)
+        assert "Matches: 5" in text
+        assert "Divergent: 0" in text
+
+    def test_with_divergence(self) -> None:
+        report = BatchReport(
+            total_samples=10,
+            divergent_samples=3,
+            match_samples=7,
+            divergence_rate=0.3,
+            results=[],
+            divergence_index_mean=5.0,
+            divergence_index_median=4.0,
+            logprob_gap_mean=0.25,
+            logprob_gap_median=0.2,
+            likely_bugs=2,
+            likely_uncertainty=1,
+            unknown_classification=0,
+            divergence_by_context_length={"0-50": {"total": 5, "divergent": 1}},
+        )
+        text = format_report(report)
+        assert "Likely bugs:" in text
+        assert "30.0%" in text
+
+
+class TestCliParsing:
+    def test_batch_compare_args(self) -> None:
+        """Test that batch-compare subcommand is registered."""
+        from xpyd_acc.cli import main
+
+        # Just verify parsing doesn't crash with --help
+        try:
+            main(["batch-compare", "--help"])
+        except SystemExit:
+            pass  # --help causes SystemExit(0)


### PR DESCRIPTION
## Summary
Implements M6: Batch Dataset Comparison from the roadmap.

### Added
- `src/xpyd_acc/batch_compare.py`: Full batch comparison module with:
  - JSONL dataset loader with pluggable fields (prompt, expected, metadata)
  - Async batch runner with configurable concurrency
  - Per-sample divergence detection: exact match, first divergence token index
  - Logprob sensitivity analysis: classify divergence as bug vs model uncertainty
  - Statistical report: divergence rate, index distribution, logprob gap stats, context length buckets
  - CSV export for manual review
- CLI `batch-compare` subcommand with all options
- `tests/test_batch_compare.py`: 26 unit tests covering dataset loading, divergence detection, classification, statistics, CSV export, report formatting, and CLI parsing

### Results
- All 76 tests pass
- ruff + isort clean

Closes #11