### PR TITLE
feat: add xPyD ecosystem integration (M7)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -63,6 +63,10 @@ def main(argv: list[str] | None = None) -> None:
     )
     bc.add_argument("--csv", default=None, help="Path to export CSV results")
 
+    det = sub.add_parser("detect", help="Detect xPyD endpoint type")
+    det.add_argument("url", help="Endpoint URL to probe")
+    det.add_argument("--timeout", type=float, default=10.0, help="Request timeout in seconds")
+
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
     kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
@@ -87,6 +91,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_compare_output(args)
     elif args.command == "compare-logprobs":
         asyncio.run(_run_compare_logprobs(args))
+    elif args.command == "detect":
+        asyncio.run(_run_detect(args))
     elif args.command == "check-kv":
         _run_check_kv(args)
     elif args.command == "diagnose":
@@ -199,6 +205,14 @@ async def _run_diagnose(args: argparse.Namespace) -> None:
 
     if not report.overall_pass:
         sys.exit(1)
+
+
+async def _run_detect(args: argparse.Namespace) -> None:
+    """Run endpoint type detection."""
+    from xpyd_acc.ecosystem import detect_endpoint_type, format_detect_report
+
+    info = await detect_endpoint_type(args.url, timeout=args.timeout)
+    print(format_detect_report(info))
 
 
 def _run_check_kv(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/ecosystem.py
+++ b/src/xpyd_acc/ecosystem.py
@@ -1,0 +1,256 @@
+"""Integration with xPyD ecosystem: endpoint detection and proxy config helpers."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+class EndpointType(str, Enum):
+    """Type of an xPyD endpoint."""
+
+    AGGREGATED = "aggregated"
+    DISAGGREGATED = "disaggregated"
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class EndpointInfo:
+    """Information about a detected endpoint."""
+
+    url: str
+    endpoint_type: EndpointType = EndpointType.UNKNOWN
+    model: str | None = None
+    version: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_aggregated(self) -> bool:
+        return self.endpoint_type == EndpointType.AGGREGATED
+
+    @property
+    def is_disaggregated(self) -> bool:
+        return self.endpoint_type == EndpointType.DISAGGREGATED
+
+
+async def detect_endpoint_type(
+    url: str,
+    *,
+    timeout: float = 10.0,
+) -> EndpointInfo:
+    """Probe an endpoint and classify it as aggregated, disaggregated, or unknown.
+
+    Detection strategy:
+    1. Try GET /health or /v1/models to confirm endpoint is alive.
+    2. Try GET /info or /v1/info for xPyD-specific metadata.
+    3. Look for disaggregation markers in the response (e.g. "mode", "type",
+       "disaggregated", "prefill", "decode" keys).
+    """
+    info = EndpointInfo(url=url)
+    base = url.rstrip("/")
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        # Step 1: health check
+        alive = False
+        for path in ("/health", "/v1/models"):
+            try:
+                resp = await client.get(f"{base}{path}")
+                if resp.status_code < 500:
+                    alive = True
+                    if path == "/v1/models":
+                        _parse_models_response(resp, info)
+                    break
+            except httpx.HTTPError:
+                continue
+
+        if not alive:
+            return info
+
+        # Step 2: probe info endpoints for xPyD metadata
+        for path in ("/info", "/v1/info", "/v1/config"):
+            try:
+                resp = await client.get(f"{base}{path}")
+                if resp.status_code == 200:
+                    data = resp.json()
+                    info.metadata.update(data)
+                    _classify_from_metadata(data, info)
+                    if info.endpoint_type != EndpointType.UNKNOWN:
+                        return info
+            except (httpx.HTTPError, json.JSONDecodeError, ValueError):
+                continue
+
+        # Step 3: heuristic — if /health is up but no info endpoint,
+        # treat as aggregated (standard OpenAI-compatible server)
+        if alive and info.endpoint_type == EndpointType.UNKNOWN:
+            info.endpoint_type = EndpointType.AGGREGATED
+
+    return info
+
+
+def _parse_models_response(resp: httpx.Response, info: EndpointInfo) -> None:
+    """Extract model name from /v1/models response."""
+    try:
+        data = resp.json()
+        models = data.get("data", [])
+        if models and isinstance(models, list):
+            info.model = models[0].get("id")
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+
+def _classify_from_metadata(data: dict[str, Any], info: EndpointInfo) -> None:
+    """Classify endpoint type from metadata dict."""
+    if data.get("version"):
+        info.version = str(data["version"])
+
+    # Look for explicit type/mode fields
+    for key in ("type", "mode", "endpoint_type", "server_type"):
+        val = str(data.get(key, "")).lower()
+        if "disagg" in val or "pd" in val:
+            info.endpoint_type = EndpointType.DISAGGREGATED
+            return
+        if "agg" in val and "disagg" not in val:
+            info.endpoint_type = EndpointType.AGGREGATED
+            return
+
+    # Look for disaggregation markers (prefill/decode split)
+    all_text = json.dumps(data).lower()
+    disagg_markers = ("prefill_url", "decode_url", "prefill_endpoint", "decode_endpoint")
+    if any(marker in all_text for marker in disagg_markers):
+        info.endpoint_type = EndpointType.DISAGGREGATED
+        return
+
+
+@dataclass
+class ProxyEndpoint:
+    """A single endpoint extracted from proxy config."""
+
+    name: str
+    url: str
+    endpoint_type: EndpointType = EndpointType.UNKNOWN
+
+
+@dataclass
+class ProxyConfig:
+    """Helper to parse xPyD-proxy configuration and extract endpoints."""
+
+    endpoints: list[ProxyEndpoint] = field(default_factory=list)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> ProxyConfig:
+        """Load proxy config from a JSON or YAML file."""
+        p = Path(path)
+        text = p.read_text()
+        if p.suffix in (".yaml", ".yml"):
+            # Lightweight YAML subset: only support JSON-compatible YAML
+            # For full YAML, users should install PyYAML
+            try:
+                import yaml  # type: ignore[import-untyped]
+
+                data = yaml.safe_load(text)
+            except ImportError:
+                msg = "PyYAML is required to load YAML config files"
+                raise ImportError(msg) from None
+        else:
+            data = json.loads(text)
+
+        return cls.from_dict(data)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProxyConfig:
+        """Parse proxy config from a dict."""
+        config = cls(raw=data)
+
+        # Support multiple config formats
+        # Format 1: {"endpoints": [{"name": ..., "url": ...}, ...]}
+        if "endpoints" in data and isinstance(data["endpoints"], list):
+            for ep in data["endpoints"]:
+                if isinstance(ep, dict) and "url" in ep:
+                    config.endpoints.append(
+                        ProxyEndpoint(
+                            name=ep.get("name", ep["url"]),
+                            url=ep["url"],
+                            endpoint_type=_parse_type(ep.get("type", "")),
+                        )
+                    )
+
+        # Format 2: {"prefill_url": ..., "decode_url": ...}
+        if "prefill_url" in data and "decode_url" in data:
+            config.endpoints.append(
+                ProxyEndpoint(
+                    name="prefill",
+                    url=data["prefill_url"],
+                    endpoint_type=EndpointType.DISAGGREGATED,
+                )
+            )
+            config.endpoints.append(
+                ProxyEndpoint(
+                    name="decode",
+                    url=data["decode_url"],
+                    endpoint_type=EndpointType.DISAGGREGATED,
+                )
+            )
+
+        # Format 3: {"upstream": "http://..."}
+        if "upstream" in data and isinstance(data["upstream"], str):
+            config.endpoints.append(
+                ProxyEndpoint(
+                    name="upstream",
+                    url=data["upstream"],
+                )
+            )
+
+        return config
+
+    def get_baseline(self) -> ProxyEndpoint | None:
+        """Get the aggregated/baseline endpoint, if any."""
+        for ep in self.endpoints:
+            if ep.endpoint_type == EndpointType.AGGREGATED:
+                return ep
+            if ep.name in ("baseline", "aggregated", "upstream"):
+                return ep
+        return self.endpoints[0] if self.endpoints else None
+
+    def get_target(self) -> ProxyEndpoint | None:
+        """Get the disaggregated/target endpoint, if any."""
+        for ep in self.endpoints:
+            if ep.endpoint_type == EndpointType.DISAGGREGATED:
+                return ep
+            if ep.name in ("target", "disaggregated", "pd"):
+                return ep
+        return self.endpoints[1] if len(self.endpoints) > 1 else None
+
+
+def _parse_type(val: str) -> EndpointType:
+    """Parse an endpoint type string."""
+    v = val.lower()
+    if "disagg" in v or "pd" in v:
+        return EndpointType.DISAGGREGATED
+    if "agg" in v and "disagg" not in v:
+        return EndpointType.AGGREGATED
+    return EndpointType.UNKNOWN
+
+
+def format_detect_report(info: EndpointInfo) -> str:
+    """Format endpoint detection result for terminal output."""
+    lines = [
+        "═" * 60,
+        "  xPyD Endpoint Detection Report",
+        "═" * 60,
+        f"  URL:    {info.url}",
+        f"  Type:   {info.endpoint_type.value}",
+    ]
+    if info.model:
+        lines.append(f"  Model:  {info.model}")
+    if info.version:
+        lines.append(f"  Version: {info.version}")
+    if info.metadata:
+        lines.append(f"  Metadata keys: {', '.join(info.metadata.keys())}")
+    lines.append("═" * 60)
+    return "\n".join(lines)

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,0 +1,244 @@
+"""Tests for xPyD ecosystem integration module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from xpyd_acc.ecosystem import (
+    EndpointInfo,
+    EndpointType,
+    ProxyConfig,
+    detect_endpoint_type,
+    format_detect_report,
+)
+
+
+class TestEndpointInfo:
+    def test_defaults(self) -> None:
+        info = EndpointInfo(url="http://localhost:8000")
+        assert info.endpoint_type == EndpointType.UNKNOWN
+        assert info.model is None
+        assert info.version is None
+        assert info.metadata == {}
+
+    def test_is_aggregated(self) -> None:
+        info = EndpointInfo(url="http://x", endpoint_type=EndpointType.AGGREGATED)
+        assert info.is_aggregated
+        assert not info.is_disaggregated
+
+    def test_is_disaggregated(self) -> None:
+        info = EndpointInfo(url="http://x", endpoint_type=EndpointType.DISAGGREGATED)
+        assert info.is_disaggregated
+        assert not info.is_aggregated
+
+
+class TestDetectEndpointType:
+    @pytest.mark.asyncio
+    async def test_unreachable_endpoint(self) -> None:
+        """Unreachable endpoint returns UNKNOWN."""
+        with patch("xpyd_acc.ecosystem.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            mock_client.get.side_effect = httpx.ConnectError("refused")
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            info = await detect_endpoint_type("http://localhost:9999")
+            assert info.endpoint_type == EndpointType.UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_aggregated_from_health(self) -> None:
+        """Endpoint with /health but no /info is classified as aggregated."""
+        with patch("xpyd_acc.ecosystem.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            health_resp = httpx.Response(200, json={"status": "ok"})
+            info_resp = httpx.Response(404)
+
+            async def mock_get(url: str) -> httpx.Response:
+                if "/health" in url:
+                    return health_resp
+                return info_resp
+
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            info = await detect_endpoint_type("http://localhost:8000")
+            assert info.endpoint_type == EndpointType.AGGREGATED
+
+    @pytest.mark.asyncio
+    async def test_disaggregated_from_info(self) -> None:
+        """Endpoint with type=disaggregated in /info response."""
+        with patch("xpyd_acc.ecosystem.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            health_resp = httpx.Response(200, json={"status": "ok"})
+            info_data = {"type": "disaggregated", "version": "1.2.0"}
+            info_resp = httpx.Response(200, json=info_data)
+
+            async def mock_get(url: str) -> httpx.Response:
+                if "/health" in url:
+                    return health_resp
+                if "/info" in url and "/v1/" not in url:
+                    return info_resp
+                return httpx.Response(404)
+
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            info = await detect_endpoint_type("http://localhost:8000")
+            assert info.endpoint_type == EndpointType.DISAGGREGATED
+            assert info.version == "1.2.0"
+
+    @pytest.mark.asyncio
+    async def test_disaggregated_from_pd_mode(self) -> None:
+        """Endpoint with mode=pd is classified as disaggregated."""
+        with patch("xpyd_acc.ecosystem.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            health_resp = httpx.Response(200, json={"status": "ok"})
+            info_resp = httpx.Response(200, json={"mode": "pd"})
+
+            async def mock_get(url: str) -> httpx.Response:
+                if "/health" in url:
+                    return health_resp
+                if "/info" in url and "/v1/" not in url:
+                    return info_resp
+                return httpx.Response(404)
+
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            info = await detect_endpoint_type("http://localhost:8000")
+            assert info.endpoint_type == EndpointType.DISAGGREGATED
+
+    @pytest.mark.asyncio
+    async def test_model_extraction_from_v1_models(self) -> None:
+        """Model name extracted from /v1/models when /health fails."""
+        with patch("xpyd_acc.ecosystem.httpx.AsyncClient") as mock_cls:
+            mock_client = AsyncMock()
+            models_resp = httpx.Response(
+                200,
+                json={"data": [{"id": "llama-7b"}]},
+            )
+
+            async def mock_get(url: str) -> httpx.Response:
+                if "/health" in url:
+                    return httpx.Response(503)
+                if "/v1/models" in url:
+                    return models_resp
+                return httpx.Response(404)
+
+            mock_client.get = mock_get
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_cls.return_value = mock_client
+
+            info = await detect_endpoint_type("http://localhost:8000")
+            assert info.model == "llama-7b"
+
+
+class TestProxyConfig:
+    def test_from_dict_endpoints_format(self) -> None:
+        data = {
+            "endpoints": [
+                {"name": "baseline", "url": "http://agg:8000", "type": "aggregated"},
+                {"name": "target", "url": "http://pd:8000", "type": "disaggregated"},
+            ]
+        }
+        config = ProxyConfig.from_dict(data)
+        assert len(config.endpoints) == 2
+        assert config.endpoints[0].endpoint_type == EndpointType.AGGREGATED
+        assert config.endpoints[1].endpoint_type == EndpointType.DISAGGREGATED
+
+    def test_from_dict_prefill_decode_format(self) -> None:
+        data = {"prefill_url": "http://p:8000", "decode_url": "http://d:8000"}
+        config = ProxyConfig.from_dict(data)
+        assert len(config.endpoints) == 2
+        assert config.endpoints[0].name == "prefill"
+        assert config.endpoints[1].name == "decode"
+        assert all(ep.endpoint_type == EndpointType.DISAGGREGATED for ep in config.endpoints)
+
+    def test_from_dict_upstream_format(self) -> None:
+        data = {"upstream": "http://server:8000"}
+        config = ProxyConfig.from_dict(data)
+        assert len(config.endpoints) == 1
+        assert config.endpoints[0].url == "http://server:8000"
+
+    def test_get_baseline_and_target(self) -> None:
+        data = {
+            "endpoints": [
+                {"name": "baseline", "url": "http://agg:8000", "type": "aggregated"},
+                {"name": "target", "url": "http://pd:8000", "type": "disaggregated"},
+            ]
+        }
+        config = ProxyConfig.from_dict(data)
+        baseline = config.get_baseline()
+        target = config.get_target()
+        assert baseline is not None
+        assert baseline.url == "http://agg:8000"
+        assert target is not None
+        assert target.url == "http://pd:8000"
+
+    def test_get_baseline_fallback(self) -> None:
+        """Falls back to first endpoint when no explicit baseline."""
+        data = {
+            "endpoints": [
+                {"name": "ep1", "url": "http://a:8000"},
+                {"name": "ep2", "url": "http://b:8000"},
+            ]
+        }
+        config = ProxyConfig.from_dict(data)
+        assert config.get_baseline() is not None
+        assert config.get_baseline().url == "http://a:8000"  # type: ignore[union-attr]
+
+    def test_get_target_fallback(self) -> None:
+        """Falls back to second endpoint when no explicit target."""
+        data = {
+            "endpoints": [
+                {"name": "ep1", "url": "http://a:8000"},
+                {"name": "ep2", "url": "http://b:8000"},
+            ]
+        }
+        config = ProxyConfig.from_dict(data)
+        assert config.get_target() is not None
+        assert config.get_target().url == "http://b:8000"  # type: ignore[union-attr]
+
+    def test_empty_config(self) -> None:
+        config = ProxyConfig.from_dict({})
+        assert config.endpoints == []
+        assert config.get_baseline() is None
+        assert config.get_target() is None
+
+    def test_from_file_json(self, tmp_path: Path) -> None:
+        data = {"endpoints": [{"name": "x", "url": "http://x:8000"}]}
+        f = tmp_path / "config.json"
+        f.write_text(json.dumps(data))
+        config = ProxyConfig.from_file(f)
+        assert len(config.endpoints) == 1
+
+
+class TestFormatDetectReport:
+    def test_basic_report(self) -> None:
+        info = EndpointInfo(
+            url="http://localhost:8000",
+            endpoint_type=EndpointType.AGGREGATED,
+            model="llama-7b",
+        )
+        report = format_detect_report(info)
+        assert "localhost:8000" in report
+        assert "aggregated" in report
+        assert "llama-7b" in report
+
+    def test_unknown_report(self) -> None:
+        info = EndpointInfo(url="http://x")
+        report = format_detect_report(info)
+        assert "unknown" in report


### PR DESCRIPTION
## Summary

Add native integration with xPyD ecosystem endpoints.

### Changes
- `EndpointInfo` dataclass with type detection (aggregated/disaggregated/unknown)
- `detect_endpoint_type()` async function that probes endpoints via /health, /v1/models, /info
- `ProxyConfig` helper to parse xPyD-proxy config (JSON/YAML) and extract endpoints
- CLI: `xpyd-acc detect <url>` subcommand to probe and report endpoint type
- 17 new tests with full coverage

### Acceptance Criteria
- [x] `EndpointInfo` dataclass with type detection
- [x] `detect_endpoint_type()` probes endpoint and classifies it
- [x] `ProxyConfig` helper to parse xPyD-proxy config and extract endpoints
- [x] CLI: `xpyd-acc detect` subcommand
- [x] All new code has tests
- [x] Lint passes (ruff + isort)

Closes #14