### PR TITLE
feat: add TOML configuration file support

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -64,3 +64,10 @@
   - Logprob heatmap at divergence points
   - Context length vs divergence rate chart
 - Terminal-friendly rich output for quick checks
+
+## M9: Configuration File Support ⬜
+- TOML config file (`xpyd-acc.toml`) for repeated runs
+- Auto-discovery in current directory
+- CLI flags override config values
+- Sections: defaults, batch, kv, report
+- Type-safe config with dataclasses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "pydantic>=2.0.0",
+    "tomli>=2.0.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]
@@ -34,7 +35,7 @@ line-length = 100
 target-version = "py310"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W"]
 
 [tool.isort]
 profile = "black"

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -12,6 +12,10 @@ def main(argv: list[str] | None = None) -> None:
         prog="xpyd-acc",
         description="PD disaggregation accuracy diagnostic tool",
     )
+    parser.add_argument(
+        "--config", default=None,
+        help="Path to TOML config file (auto-discovers xpyd-acc.toml in cwd if not set)",
+    )
     sub = parser.add_subparsers(dest="command")
 
     # compare-logprobs
@@ -88,6 +92,21 @@ def main(argv: list[str] | None = None) -> None:
     if not args.command:
         parser.print_help()
         return
+
+    # Load config file
+    from xpyd_acc.config import AppConfig, discover_config, load_config, merge_cli_args
+
+    config: AppConfig | None = None
+    if args.config:
+        config = load_config(args.config)
+    else:
+        config = discover_config()
+
+    if config is not None:
+        args_dict = vars(args)
+        merged = merge_cli_args(config, args_dict, args.command)
+        for key, val in merged.items():
+            setattr(args, key, val)
 
     if args.command == "batch-compare":
         asyncio.run(_run_batch_compare(args))

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -1,0 +1,178 @@
+"""TOML configuration file support for xpyd-acc.
+
+Loads settings from a TOML file and merges with CLI arguments.
+CLI flags always override config file values.
+"""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomllib
+    except ModuleNotFoundError:
+        import tomli as tomllib  # type: ignore[no-redef]
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+AUTO_CONFIG_NAME = "xpyd-acc.toml"
+
+
+@dataclass
+class DefaultsConfig:
+    """Default settings shared across subcommands."""
+
+    baseline: str | None = None
+    target: str | None = None
+    model: str = "default"
+    api_key: str = "no-key"
+    max_tokens: int = 64
+
+
+@dataclass
+class BatchConfig:
+    """Batch comparison settings."""
+
+    concurrency: int = 5
+    logprob_gap_threshold: float = 0.1
+    dataset: str | None = None
+    csv: str | None = None
+
+
+@dataclass
+class KVConfig:
+    """KV cache comparison settings."""
+
+    max_abs_threshold: float = 1e-3
+    cosine_threshold: float = 0.999
+
+
+@dataclass
+class ReportConfig:
+    """Report generation settings."""
+
+    output: str = "report.html"
+
+
+@dataclass
+class AppConfig:
+    """Top-level application configuration."""
+
+    defaults: DefaultsConfig = field(default_factory=DefaultsConfig)
+    batch: BatchConfig = field(default_factory=BatchConfig)
+    kv: KVConfig = field(default_factory=KVConfig)
+    report: ReportConfig = field(default_factory=ReportConfig)
+
+
+def _parse_section(data: dict[str, Any], cls: type) -> Any:
+    """Parse a dict into a dataclass, ignoring unknown keys."""
+    valid_fields = {f.name for f in cls.__dataclass_fields__.values()}
+    filtered = {k: v for k, v in data.items() if k in valid_fields}
+    return cls(**filtered)
+
+
+def load_config(path: str | Path) -> AppConfig:
+    """Load configuration from a TOML file.
+
+    Args:
+        path: Path to the TOML configuration file.
+
+    Returns:
+        Parsed AppConfig instance.
+
+    Raises:
+        FileNotFoundError: If the config file does not exist.
+        tomllib.TOMLDecodeError: If the file is not valid TOML.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+
+    defaults = _parse_section(raw.get("defaults", {}), DefaultsConfig)
+    batch = _parse_section(raw.get("batch", {}), BatchConfig)
+    kv = _parse_section(raw.get("kv", {}), KVConfig)
+    report = _parse_section(raw.get("report", {}), ReportConfig)
+
+    return AppConfig(defaults=defaults, batch=batch, kv=kv, report=report)
+
+
+def discover_config() -> AppConfig | None:
+    """Auto-discover xpyd-acc.toml in the current directory.
+
+    Returns:
+        AppConfig if found, None otherwise.
+    """
+    candidate = Path.cwd() / AUTO_CONFIG_NAME
+    if candidate.exists():
+        return load_config(candidate)
+    return None
+
+
+def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dict[str, Any]:
+    """Merge config file values with CLI arguments.
+
+    CLI arguments (non-None values) take precedence over config values.
+
+    Args:
+        config: Loaded AppConfig.
+        args: CLI argument dict (from argparse Namespace).
+        command: The subcommand name.
+
+    Returns:
+        Merged argument dict ready for use.
+    """
+    merged = dict(args)
+
+    # Apply defaults
+    defaults_map = {
+        "baseline": config.defaults.baseline,
+        "target": config.defaults.target,
+        "model": config.defaults.model,
+        "api_key": config.defaults.api_key,
+        "max_tokens": config.defaults.max_tokens,
+    }
+
+    for key, config_val in defaults_map.items():
+        if key in merged and merged[key] is None and config_val is not None:
+            merged[key] = config_val
+
+    # Apply command-specific config
+    if command == "batch-compare":
+        batch_map = {
+            "concurrency": config.batch.concurrency,
+            "logprob_gap_threshold": config.batch.logprob_gap_threshold,
+            "dataset": config.batch.dataset,
+            "csv": config.batch.csv,
+        }
+        for key, config_val in batch_map.items():
+            if key in merged and merged[key] is None and config_val is not None:
+                merged[key] = config_val
+
+    elif command in ("check-kv", "diagnose"):
+        kv_map: dict[str, Any] = {}
+        if command == "check-kv":
+            kv_map = {
+                "max_abs_threshold": config.kv.max_abs_threshold,
+                "cosine_threshold": config.kv.cosine_threshold,
+            }
+        else:
+            kv_map = {
+                "kv_max_abs_threshold": config.kv.max_abs_threshold,
+                "kv_cosine_threshold": config.kv.cosine_threshold,
+            }
+        for key, config_val in kv_map.items():
+            if key in merged and merged[key] is None and config_val is not None:
+                merged[key] = config_val
+
+    elif command == "report":
+        if "output" in merged and merged["output"] is None:
+            merged["output"] = config.report.output
+
+    return merged

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,171 @@
+"""Tests for TOML configuration file support."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.config import (
+    AppConfig,
+    BatchConfig,
+    DefaultsConfig,
+    KVConfig,
+    ReportConfig,
+    discover_config,
+    load_config,
+    merge_cli_args,
+)
+
+
+class TestLoadConfig:
+    def test_full_config(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""\
+[defaults]
+baseline = "http://agg:8000/v1"
+target = "http://pd:8000/v1"
+model = "llama-7b"
+api_key = "sk-test"
+max_tokens = 128
+
+[batch]
+concurrency = 10
+logprob_gap_threshold = 0.05
+dataset = "data/gsm8k.jsonl"
+csv = "results.csv"
+
+[kv]
+max_abs_threshold = 0.001
+cosine_threshold = 0.9999
+
+[report]
+output = "reports/latest.html"
+""")
+        config = load_config(config_file)
+        assert config.defaults.baseline == "http://agg:8000/v1"
+        assert config.defaults.target == "http://pd:8000/v1"
+        assert config.defaults.model == "llama-7b"
+        assert config.defaults.api_key == "sk-test"
+        assert config.defaults.max_tokens == 128
+        assert config.batch.concurrency == 10
+        assert config.batch.logprob_gap_threshold == 0.05
+        assert config.batch.dataset == "data/gsm8k.jsonl"
+        assert config.batch.csv == "results.csv"
+        assert config.kv.max_abs_threshold == 0.001
+        assert config.kv.cosine_threshold == 0.9999
+        assert config.report.output == "reports/latest.html"
+
+    def test_partial_config(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""\
+[defaults]
+baseline = "http://agg:8000"
+""")
+        config = load_config(config_file)
+        assert config.defaults.baseline == "http://agg:8000"
+        assert config.defaults.model == "default"  # default value
+        assert config.batch.concurrency == 5  # default value
+
+    def test_empty_config(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("")
+        config = load_config(config_file)
+        assert config.defaults.baseline is None
+        assert config.batch.concurrency == 5
+
+    def test_missing_file(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_config("/nonexistent/config.toml")
+
+    def test_invalid_toml(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "bad.toml"
+        config_file.write_text("this is not valid toml [[[")
+        with pytest.raises(Exception):  # noqa: B017
+            load_config(config_file)
+
+    def test_unknown_keys_ignored(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("""\
+[defaults]
+baseline = "http://agg:8000"
+unknown_key = "should be ignored"
+""")
+        config = load_config(config_file)
+        assert config.defaults.baseline == "http://agg:8000"
+
+
+class TestDiscoverConfig:
+    def test_discovers_in_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        config_file = tmp_path / "xpyd-acc.toml"
+        config_file.write_text("""\
+[defaults]
+model = "discovered-model"
+""")
+        monkeypatch.chdir(tmp_path)
+        config = discover_config()
+        assert config is not None
+        assert config.defaults.model == "discovered-model"
+
+    def test_no_config_in_cwd(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        config = discover_config()
+        assert config is None
+
+
+class TestMergeCliArgs:
+    def test_cli_overrides_config(self) -> None:
+        config = AppConfig(
+            defaults=DefaultsConfig(baseline="http://config:8000", model="config-model"),
+        )
+        args = {"baseline": "http://cli:8000", "model": None, "target": None}
+        merged = merge_cli_args(config, args, "compare-logprobs")
+        assert merged["baseline"] == "http://cli:8000"  # CLI wins
+        assert merged["model"] == "config-model"  # config fills None
+
+    def test_config_fills_none(self) -> None:
+        config = AppConfig(
+            defaults=DefaultsConfig(
+                baseline="http://config:8000",
+                target="http://target:8000",
+            ),
+        )
+        args = {"baseline": None, "target": None, "model": None}
+        merged = merge_cli_args(config, args, "compare-logprobs")
+        assert merged["baseline"] == "http://config:8000"
+        assert merged["target"] == "http://target:8000"
+
+    def test_batch_specific_merge(self) -> None:
+        config = AppConfig(
+            batch=BatchConfig(concurrency=20, dataset="data.jsonl"),
+        )
+        args = {"concurrency": None, "dataset": None, "csv": None, "baseline": None,
+                "target": None, "model": None, "api_key": None, "max_tokens": None}
+        merged = merge_cli_args(config, args, "batch-compare")
+        assert merged["concurrency"] == 20
+        assert merged["dataset"] == "data.jsonl"
+
+    def test_kv_specific_merge(self) -> None:
+        config = AppConfig(
+            kv=KVConfig(max_abs_threshold=0.01, cosine_threshold=0.99),
+        )
+        args = {"max_abs_threshold": None, "cosine_threshold": None,
+                "baseline": None, "target": None}
+        merged = merge_cli_args(config, args, "check-kv")
+        assert merged["max_abs_threshold"] == 0.01
+        assert merged["cosine_threshold"] == 0.99
+
+    def test_report_specific_merge(self) -> None:
+        config = AppConfig(
+            report=ReportConfig(output="custom.html"),
+        )
+        args = {"output": None, "input": "data.json"}
+        merged = merge_cli_args(config, args, "report")
+        assert merged["output"] == "custom.html"
+
+    def test_no_config_passthrough(self) -> None:
+        config = AppConfig()
+        args = {"baseline": "http://x:8000", "model": "m"}
+        merged = merge_cli_args(config, args, "compare-logprobs")
+        assert merged["baseline"] == "http://x:8000"
+        assert merged["model"] == "m"


### PR DESCRIPTION
## Summary
Add TOML configuration file support so users can define settings in `xpyd-acc.toml` instead of long CLI flag chains.

## Changes
- New `config.py` module: `load_config()`, `discover_config()`, `merge_cli_args()`
- CLI `--config` flag on all subcommands
- Auto-discovery of `xpyd-acc.toml` in cwd
- CLI flags override config values
- Type-safe config with dataclasses (defaults, batch, kv, report sections)
- Remove ruff `I` rule to fix isort/ruff import sorting conflict (isort handles imports)
- Comprehensive tests (119 total, all passing)

## Config format
```toml
[defaults]
baseline = "http://agg:8000/v1"
target = "http://pd:8000/v1"
model = "llama-7b"

[batch]
concurrency = 10
dataset = "data/gsm8k.jsonl"
```

Closes #20