### PR TITLE
feat: add --json export for batch-compare and --version flag

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -71,3 +71,8 @@
 - CLI flags override config values
 - Sections: defaults, batch, kv, report
 - Type-safe config with dataclasses
+
+## M10: JSON Export & Version Flag
+- `xpyd-acc --version` prints version string
+- `batch-compare --json <path>` exports full BatchReport as JSON
+- `BatchReport.to_json()` method for programmatic serialization

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -63,6 +63,40 @@ class BatchReport:
     # Divergence by context length buckets
     divergence_by_context_length: dict[str, dict[str, int]] = field(default_factory=dict)
 
+    def to_json(self) -> str:
+        """Serialize the report to a JSON string."""
+        data: dict[str, Any] = {
+            "total_samples": self.total_samples,
+            "divergent_samples": self.divergent_samples,
+            "match_samples": self.match_samples,
+            "divergence_rate": self.divergence_rate,
+            "divergence_index_mean": self.divergence_index_mean,
+            "divergence_index_median": self.divergence_index_median,
+            "logprob_gap_mean": self.logprob_gap_mean,
+            "logprob_gap_median": self.logprob_gap_median,
+            "likely_bugs": self.likely_bugs,
+            "likely_uncertainty": self.likely_uncertainty,
+            "unknown_classification": self.unknown_classification,
+            "divergence_by_context_length": self.divergence_by_context_length,
+            "results": [
+                {
+                    "sample_id": r.sample_id,
+                    "prompt": r.prompt,
+                    "baseline_output": r.baseline_output,
+                    "target_output": r.target_output,
+                    "exact_match": r.exact_match,
+                    "first_divergence_index": r.first_divergence_index,
+                    "baseline_logprob_at_divergence": r.baseline_logprob_at_divergence,
+                    "target_logprob_at_divergence": r.target_logprob_at_divergence,
+                    "logprob_gap": r.logprob_gap,
+                    "classification": r.classification,
+                    "context_length": r.context_length,
+                }
+                for r in self.results
+            ],
+        }
+        return json.dumps(data, indent=2)
+
 
 def load_dataset(path: str | Path) -> list[DatasetSample]:
     """Load dataset from JSONL file.

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -7,10 +7,23 @@ import asyncio
 import sys
 
 
+def _get_version() -> str:
+    """Return the package version."""
+    try:
+        from importlib.metadata import version
+        return version("xpyd-acc")
+    except Exception:
+        return "unknown"
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="xpyd-acc",
         description="PD disaggregation accuracy diagnostic tool",
+    )
+    parser.add_argument(
+        "-V", "--version", action="version",
+        version=f"%(prog)s {_get_version()}",
     )
     parser.add_argument(
         "--config", default=None,
@@ -69,6 +82,7 @@ def main(argv: list[str] | None = None) -> None:
         help="Logprob gap threshold for bug vs uncertainty (default: 0.1)",
     )
     bc.add_argument("--csv", default=None, help="Path to export CSV results")
+    bc.add_argument("--json", default=None, dest="json_path", help="Path to export JSON results")
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -170,6 +184,11 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
     if args.csv:
         export_csv(report, args.csv)
         print(f"\nCSV exported to {args.csv}")
+
+    if args.json_path:
+        from pathlib import Path
+        Path(args.json_path).write_text(report.to_json())
+        print(f"\nJSON exported to {args.json_path}")
 
     if report.divergent_samples > 0:
         sys.exit(1)

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -241,6 +241,39 @@ class TestFormatReport:
         assert "30.0%" in text
 
 
+class TestBatchReportToJson:
+    def test_to_json_round_trip(self) -> None:
+        """Test that to_json() produces valid JSON with correct fields."""
+        import json as json_mod
+
+        results = [
+            SampleResult(
+                sample_id="0", prompt="hello", baseline_output="hi",
+                target_output="hi", exact_match=True,
+                first_divergence_index=None,
+                baseline_logprob_at_divergence=None,
+                target_logprob_at_divergence=None,
+                logprob_gap=None, classification="match",
+                context_length=1,
+            ),
+            SampleResult(
+                sample_id="1", prompt="world", baseline_output="a",
+                target_output="b", exact_match=False,
+                first_divergence_index=0,
+                baseline_logprob_at_divergence=-0.5,
+                target_logprob_at_divergence=-0.8,
+                logprob_gap=0.3, classification="likely_bug",
+                context_length=1,
+            ),
+        ]
+        report = compute_report(results)
+        data = json_mod.loads(report.to_json())
+        assert data["total_samples"] == 2
+        assert data["divergent_samples"] == 1
+        assert len(data["results"]) == 2
+        assert data["results"][1]["classification"] == "likely_bug"
+
+
 class TestCliParsing:
     def test_batch_compare_args(self) -> None:
         """Test that batch-compare subcommand is registered."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,13 @@ def test_help():
     assert result.returncode == 0
 
 
+def test_version_flag():
+    """Test that --version prints version and exits."""
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--version"])
+    assert exc_info.value.code == 0
+
+
 class TestCliConfigIntegration:
     """Tests for --config flag and auto-discovery in CLI."""
 


### PR DESCRIPTION
## Changes
- Add `BatchReport.to_json()` method for JSON serialization
- Add `--json <path>` flag to `batch-compare` CLI for JSON export
- Add `-V`/`--version` flag to top-level CLI
- Add M10 to ROADMAP.md
- Add unit tests for both features

All 125 tests pass, lint clean.

Closes #24