### PR TITLE
feat: HTTP retry with exponential backoff for endpoint requests

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,3 +76,18 @@
 - `xpyd-acc --version` prints version string
 - `batch-compare --json <path>` exports full BatchReport as JSON
 - `BatchReport.to_json()` method for programmatic serialization
+
+## M11: HTTP Retry with Exponential Backoff
+- Reusable async retry decorator for all HTTP requests
+- Retry on: connection errors, timeouts, HTTP 429/502/503/504
+- Exponential backoff with jitter, Retry-After header support
+- CLI flags: `--retries`, `--retry-delay`
+- TOML config support in `[defaults]` section
+
+## M12: Progress Bars for Batch Comparison
+- Rich progress bars during batch dataset runs
+- Per-sample progress tracking with ETA
+
+## M13: Streaming Output Comparison
+- Compare SSE streaming responses token-by-token
+- Real-time divergence detection during streaming

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -180,6 +180,8 @@ async def _collect_output(
     model: str = "default",
     max_tokens: int = 64,
     api_key: str = "no-key",
+    retries: int = 3,
+    retry_delay: float = 1.0,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list).
 
@@ -187,6 +189,8 @@ async def _collect_output(
     Each logprob entry has: {"token": str, "logprob": float, "top_logprobs": [...]}.
     """
     import httpx
+
+    from xpyd_acc.retry import retry_async
 
     payload = {
         "model": model,
@@ -197,15 +201,19 @@ async def _collect_output(
     }
     headers = {"Authorization": f"Bearer {api_key}"}
 
-    async with httpx.AsyncClient(timeout=120.0) as client:
-        resp = await client.post(f"{url}/v1/chat/completions", json=payload, headers=headers)
-        resp.raise_for_status()
-        data = resp.json()
+    async def _do_request() -> tuple[str, list[dict[str, Any]]]:
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            resp = await client.post(
+                f"{url}/v1/chat/completions", json=payload, headers=headers,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        choice = data["choices"][0]
+        text = choice["message"]["content"]
+        logprobs_content = choice.get("logprobs", {}).get("content", [])
+        return text, logprobs_content
 
-    choice = data["choices"][0]
-    text = choice["message"]["content"]
-    logprobs_content = choice.get("logprobs", {}).get("content", [])
-    return text, logprobs_content
+    return await retry_async(_do_request, retries=retries, base_delay=retry_delay)
 
 
 async def run_batch(
@@ -218,6 +226,8 @@ async def run_batch(
     api_key: str = "no-key",
     logprob_gap_threshold: float = 0.1,
     concurrency: int = 5,
+    retries: int = 3,
+    retry_delay: float = 1.0,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report."""
     semaphore = asyncio.Semaphore(concurrency)
@@ -228,10 +238,12 @@ async def run_batch(
             baseline_text, baseline_lp = await _collect_output(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
+                retries=retries, retry_delay=retry_delay,
             )
             target_text, target_lp = await _collect_output(
                 target_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
+                retries=retries, retry_delay=retry_delay,
             )
 
         b_tokens = _tokenize(baseline_text)

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -39,6 +39,11 @@ def main(argv: list[str] | None = None) -> None:
     lp.add_argument("--model", default=None, help="Model name (default: default)")
     lp.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
     lp.add_argument("--api-key", default=None, help="API key for both endpoints")
+    lp.add_argument("--retries", type=int, default=None, help="Max retry attempts (default: 3)")
+    lp.add_argument(
+        "--retry-delay", type=float, default=None,
+        help="Base retry delay in seconds (default: 1.0)",
+    )
 
     diag = sub.add_parser("diagnose", help="Run full diagnostic pipeline")
     diag.add_argument("--baseline", required=True, help="Baseline endpoint URL")
@@ -47,6 +52,11 @@ def main(argv: list[str] | None = None) -> None:
     diag.add_argument("--model", default=None, help="Model name (default: default)")
     diag.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
     diag.add_argument("--api-key", default=None, help="API key for endpoints")
+    diag.add_argument("--retries", type=int, default=None, help="Max retry attempts (default: 3)")
+    diag.add_argument(
+        "--retry-delay", type=float, default=None,
+        help="Base retry delay in seconds (default: 1.0)",
+    )
     diag.add_argument("--kv-baseline", default=None, help="Path to baseline KV cache (.npz)")
     diag.add_argument("--kv-target", default=None, help="Path to target KV cache (.npz)")
     diag.add_argument(
@@ -83,6 +93,11 @@ def main(argv: list[str] | None = None) -> None:
     )
     bc.add_argument("--csv", default=None, help="Path to export CSV results")
     bc.add_argument("--json", default=None, dest="json_path", help="Path to export JSON results")
+    bc.add_argument("--retries", type=int, default=None, help="Max retry attempts (default: 3)")
+    bc.add_argument(
+        "--retry-delay", type=float, default=None,
+        help="Base retry delay in seconds (default: 1.0)",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -133,6 +148,8 @@ def main(argv: list[str] | None = None) -> None:
         "concurrency": 5,
         "logprob_gap_threshold": 0.1,
         "output": "report.html",
+        "retries": 3,
+        "retry_delay": 1.0,
         "max_abs_threshold": 1e-3,
         "cosine_threshold": 0.999,
         "kv_max_abs_threshold": 1e-3,
@@ -176,6 +193,8 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         api_key=args.api_key,
         logprob_gap_threshold=args.logprob_gap_threshold,
         concurrency=args.concurrency,
+        retries=args.retries,
+        retry_delay=args.retry_delay,
     )
 
     print()
@@ -229,10 +248,16 @@ async def _run_compare_logprobs(args: argparse.Namespace) -> None:
     target_collector = LogprobsCollector(args.target, api_key=args.api_key, model=args.model)
 
     print(f"Collecting logprobs from baseline: {args.baseline}")
-    baseline_result = await baseline_collector.collect(args.prompt, max_tokens=args.max_tokens)
+    baseline_result = await baseline_collector.collect(
+        args.prompt, max_tokens=args.max_tokens,
+        retries=args.retries, retry_delay=args.retry_delay,
+    )
 
     print(f"Collecting logprobs from target: {args.target}")
-    target_result = await target_collector.collect(args.prompt, max_tokens=args.max_tokens)
+    target_result = await target_collector.collect(
+        args.prompt, max_tokens=args.max_tokens,
+        retries=args.retries, retry_delay=args.retry_delay,
+    )
 
     comparator = LogprobsComparator()
     report = comparator.compare(baseline_result, target_result)

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -31,6 +31,8 @@ class DefaultsConfig:
     model: str = "default"
     api_key: str = "no-key"
     max_tokens: int = 64
+    retries: int = 3
+    retry_delay: float = 1.0
 
 
 @dataclass
@@ -137,6 +139,8 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
         "model": config.defaults.model,
         "api_key": config.defaults.api_key,
         "max_tokens": config.defaults.max_tokens,
+        "retries": config.defaults.retries,
+        "retry_delay": config.defaults.retry_delay,
     }
 
     for key, config_val in defaults_map.items():

--- a/src/xpyd_acc/logprobs.py
+++ b/src/xpyd_acc/logprobs.py
@@ -62,8 +62,12 @@ class LogprobsCollector:
         max_tokens: int = 64,
         *,
         timeout: float = 30.0,
+        retries: int = 3,
+        retry_delay: float = 1.0,
     ) -> LogprobsResult:
         """Send prompt and collect logprobs from the completions endpoint."""
+        from xpyd_acc.retry import retry_async
+
         url = f"{self.base_url}/v1/chat/completions"
         headers = {"Authorization": f"Bearer {self.api_key}"}
         payload = {
@@ -74,11 +78,13 @@ class LogprobsCollector:
             "top_logprobs": 1,
         }
 
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.post(url, json=payload, headers=headers)
-            resp.raise_for_status()
-            data = resp.json()
+        async def _do_request() -> dict:
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                resp = await client.post(url, json=payload, headers=headers)
+                resp.raise_for_status()
+                return resp.json()
 
+        data = await retry_async(_do_request, retries=retries, base_delay=retry_delay)
         return self._parse_response(data)
 
     def _parse_response(self, data: dict) -> LogprobsResult:

--- a/src/xpyd_acc/retry.py
+++ b/src/xpyd_acc/retry.py
@@ -1,0 +1,98 @@
+"""Reusable async HTTP retry with exponential backoff and jitter."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import Any, Callable, TypeVar
+
+import httpx
+
+T = TypeVar("T")
+
+#: HTTP status codes that trigger a retry.
+RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
+
+
+class RetriesExhausted(Exception):
+    """All retry attempts failed."""
+
+    def __init__(self, attempts: int, last_error: Exception) -> None:
+        self.attempts = attempts
+        self.last_error = last_error
+        super().__init__(f"All {attempts} attempts failed. Last error: {last_error}")
+
+
+async def retry_async(
+    func: Callable[..., Any],
+    *args: Any,
+    retries: int = 3,
+    base_delay: float = 1.0,
+    **kwargs: Any,
+) -> Any:
+    """Call *func* with retries on transient HTTP errors.
+
+    Retries on:
+    - ``httpx.ConnectError``, ``httpx.TimeoutException``
+    - HTTP responses with status in ``RETRYABLE_STATUS_CODES``
+
+    When a 429 response includes a ``Retry-After`` header the wait honours that
+    value instead of the computed backoff.
+
+    Args:
+        func: Async callable to invoke.
+        retries: Maximum number of attempts (total, not extra retries).
+        base_delay: Base delay in seconds for exponential backoff.
+        *args, **kwargs: Forwarded to *func*.
+
+    Returns:
+        The return value of *func*.
+
+    Raises:
+        RetriesExhausted: If all attempts fail.
+    """
+    if retries < 1:
+        retries = 1
+
+    last_error: Exception | None = None
+
+    for attempt in range(retries):
+        try:
+            return await func(*args, **kwargs)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code not in RETRYABLE_STATUS_CODES:
+                raise
+            last_error = exc
+            delay = _compute_delay(exc.response, attempt, base_delay)
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            last_error = exc
+            delay = _backoff(attempt, base_delay)
+        else:
+            break  # pragma: no cover – unreachable but keeps linter happy
+
+        if attempt < retries - 1:
+            await asyncio.sleep(delay)
+
+    raise RetriesExhausted(retries, last_error)  # type: ignore[arg-type]
+
+
+def _compute_delay(
+    response: httpx.Response,
+    attempt: int,
+    base_delay: float,
+) -> float:
+    """Compute wait time, honouring ``Retry-After`` when present."""
+    retry_after = response.headers.get("retry-after")
+    if retry_after is not None:
+        try:
+            return max(float(retry_after), 0)
+        except ValueError:
+            pass
+    return _backoff(attempt, base_delay)
+
+
+def _backoff(attempt: int, base_delay: float) -> float:
+    """Exponential backoff with jitter."""
+    delay = base_delay * (2 ** attempt)
+    jitter = random.uniform(0, delay * 0.25)  # noqa: S311
+    return delay + jitter

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,99 @@
+"""Tests for xpyd_acc.retry module."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from xpyd_acc.retry import RETRYABLE_STATUS_CODES, RetriesExhausted, retry_async
+
+
+def _make_error(status: int) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://test")
+    resp = httpx.Response(status, request=req)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=req, response=resp)
+
+
+def _make_error_with_retry_after(
+    status: int, retry_after: str,
+) -> httpx.HTTPStatusError:
+    req = httpx.Request("POST", "http://test")
+    resp = httpx.Response(status, request=req, headers={"Retry-After": retry_after})
+    return httpx.HTTPStatusError(f"HTTP {status}", request=req, response=resp)
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_first_try() -> None:
+    func = AsyncMock(return_value="ok")
+    result = await retry_async(func, retries=3, base_delay=0.01)
+    assert result == "ok"
+    assert func.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_after_transient_timeout() -> None:
+    func = AsyncMock(side_effect=[httpx.TimeoutException("timeout"), "ok"])
+    result = await retry_async(func, retries=3, base_delay=0.01)
+    assert result == "ok"
+    assert func.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_after_connect_error() -> None:
+    func = AsyncMock(side_effect=[httpx.ConnectError("refused"), "ok"])
+    result = await retry_async(func, retries=3, base_delay=0.01)
+    assert result == "ok"
+    assert func.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_on_429_status() -> None:
+    func = AsyncMock(side_effect=[_make_error(429), "ok"])
+    result = await retry_async(func, retries=3, base_delay=0.01)
+    assert result == "ok"
+    assert func.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_on_502_status() -> None:
+    func = AsyncMock(side_effect=[_make_error(502), "ok"])
+    result = await retry_async(func, retries=3, base_delay=0.01)
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_retry_400() -> None:
+    func = AsyncMock(side_effect=_make_error(400))
+    with pytest.raises(httpx.HTTPStatusError):
+        await retry_async(func, retries=3, base_delay=0.01)
+    assert func.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_exhausted() -> None:
+    func = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+    with pytest.raises(RetriesExhausted) as exc_info:
+        await retry_async(func, retries=3, base_delay=0.01)
+    assert exc_info.value.attempts == 3
+    assert func.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_respects_retry_after_header() -> None:
+    err = _make_error_with_retry_after(429, "0.01")
+    func = AsyncMock(side_effect=[err, "ok"])
+    # large base_delay proves Retry-After overrides backoff
+    result = await retry_async(func, retries=3, base_delay=100.0)
+    assert result == "ok"
+    assert func.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retryable_status_codes_coverage() -> None:
+    assert 429 in RETRYABLE_STATUS_CODES
+    assert 502 in RETRYABLE_STATUS_CODES
+    assert 503 in RETRYABLE_STATUS_CODES
+    assert 504 in RETRYABLE_STATUS_CODES
+    assert 400 not in RETRYABLE_STATUS_CODES


### PR DESCRIPTION
## Summary

Add a configurable retry mechanism with exponential backoff to all HTTP requests, improving resilience against transient endpoint failures.

## Changes

- **New `retry.py` module**: Reusable `retry_async()` wrapper with exponential backoff + jitter
- **Retryable errors**: `ConnectError`, `TimeoutException`, HTTP 429/502/503/504
- **Retry-After header**: Honored on 429 responses
- **Integration**: `LogprobsCollector.collect()`, `batch_compare._collect_output()`
- **CLI flags**: `--retries N` (default 3), `--retry-delay SECONDS` (default 1.0) on `compare-logprobs`, `diagnose`, `batch-compare`
- **Config**: `retries` and `retry_delay` in `[defaults]` TOML section
- **Tests**: 9 new tests covering all retry paths
- **Roadmap**: Added M11-M13 milestones for Phase 2

Closes #27