### PR TITLE
feat: add Rich progress bars for batch comparison

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,9 +84,10 @@
 - CLI flags: `--retries`, `--retry-delay`
 - TOML config support in `[defaults]` section
 
-## M12: Progress Bars for Batch Comparison
+## M12: Progress Bars for Batch Comparison ✅
 - Rich progress bars during batch dataset runs
 - Per-sample progress tracking with ETA
+- `--no-progress` CLI flag and auto-disable for non-TTY
 
 ## M13: Streaming Output Comparison
 - Compare SSE streaming responses token-by-token

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -9,7 +9,7 @@ import json
 import statistics
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 @dataclass
@@ -228,10 +228,17 @@ async def run_batch(
     concurrency: int = 5,
     retries: int = 3,
     retry_delay: float = 1.0,
+    on_progress: Callable[[int, int], None] | None = None,
 ) -> BatchReport:
-    """Run all samples against both endpoints and produce a report."""
+    """Run all samples against both endpoints and produce a report.
+
+    Args:
+        on_progress: Optional callback called after each sample completes.
+            Receives (completed_count, total_count).
+    """
     semaphore = asyncio.Semaphore(concurrency)
     results: list[SampleResult] = []
+    completed = 0
 
     async def process_sample(sample: DatasetSample) -> SampleResult:
         async with semaphore:
@@ -283,7 +290,17 @@ async def run_batch(
             context_length=ctx_len,
         )
 
-    tasks = [process_sample(s) for s in samples]
+    total = len(samples)
+
+    async def _tracked_sample(sample: DatasetSample) -> SampleResult:
+        nonlocal completed
+        result = await process_sample(sample)
+        completed += 1
+        if on_progress is not None:
+            on_progress(completed, total)
+        return result
+
+    tasks = [_tracked_sample(s) for s in samples]
     results = await asyncio.gather(*tasks)
     results = list(results)
 

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -98,6 +98,10 @@ def main(argv: list[str] | None = None) -> None:
         "--retry-delay", type=float, default=None,
         help="Base retry delay in seconds (default: 1.0)",
     )
+    bc.add_argument(
+        "--no-progress", action="store_true", default=False,
+        help="Disable progress bar during batch comparison",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -184,18 +188,56 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
     samples = load_dataset(args.dataset)
     print(f"Loaded {len(samples)} samples from {args.dataset}")
 
-    report = await run_batch(
-        samples,
-        args.baseline,
-        args.target,
-        model=args.model,
-        max_tokens=args.max_tokens,
-        api_key=args.api_key,
-        logprob_gap_threshold=args.logprob_gap_threshold,
-        concurrency=args.concurrency,
-        retries=args.retries,
-        retry_delay=args.retry_delay,
-    )
+    # Set up Rich progress bar unless disabled or non-TTY
+    use_progress = not args.no_progress and sys.stderr.isatty()
+    progress_ctx = None
+    task_id = None
+
+    if use_progress:
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            TextColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+        )
+
+        progress_ctx = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("•"),
+            TimeElapsedColumn(),
+            TextColumn("•"),
+            TimeRemainingColumn(),
+        )
+
+    def on_progress(completed: int, total: int) -> None:
+        if progress_ctx is not None and task_id is not None:
+            progress_ctx.update(task_id, completed=completed)
+
+    if progress_ctx is not None:
+        progress_ctx.start()
+        task_id = progress_ctx.add_task("Comparing samples", total=len(samples))
+
+    try:
+        report = await run_batch(
+            samples,
+            args.baseline,
+            args.target,
+            model=args.model,
+            max_tokens=args.max_tokens,
+            api_key=args.api_key,
+            logprob_gap_threshold=args.logprob_gap_threshold,
+            concurrency=args.concurrency,
+            retries=args.retries,
+            retry_delay=args.retry_delay,
+            on_progress=on_progress if use_progress else None,
+        )
+    finally:
+        if progress_ctx is not None:
+            progress_ctx.stop()
 
     print()
     print(format_report(report))

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -284,3 +284,63 @@ class TestCliParsing:
             main(["batch-compare", "--help"])
         except SystemExit:
             pass  # --help causes SystemExit(0)
+
+
+class TestOnProgressCallback:
+    """Test that run_batch invokes the on_progress callback."""
+
+    def test_progress_callback_called(self) -> None:
+        """Verify on_progress is called once per sample with correct counts."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from xpyd_acc.batch_compare import DatasetSample, run_batch
+
+        samples = [
+            DatasetSample(id="0", prompt="hello"),
+            DatasetSample(id="1", prompt="world"),
+            DatasetSample(id="2", prompt="test"),
+        ]
+
+        mock_output = ("response text", [])
+
+        progress_calls: list[tuple[int, int]] = []
+
+        def track_progress(completed: int, total: int) -> None:
+            progress_calls.append((completed, total))
+
+        with patch("xpyd_acc.batch_compare._collect_output", new_callable=AsyncMock) as mock_co:
+            mock_co.return_value = mock_output
+            report = asyncio.run(run_batch(
+                samples,
+                "http://baseline",
+                "http://target",
+                on_progress=track_progress,
+            ))
+
+        assert report.total_samples == 3
+        # Should have 3 progress calls, one per sample
+        assert len(progress_calls) == 3
+        # All calls should have total=3
+        assert all(t == 3 for _, t in progress_calls)
+        # Final call should have completed=3
+        completed_values = sorted(c for c, _ in progress_calls)
+        assert completed_values[-1] == 3
+
+    def test_no_progress_callback(self) -> None:
+        """Verify run_batch works fine without on_progress."""
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+
+        from xpyd_acc.batch_compare import DatasetSample, run_batch
+
+        samples = [DatasetSample(id="0", prompt="hello")]
+        mock_output = ("response", [])
+
+        with patch("xpyd_acc.batch_compare._collect_output", new_callable=AsyncMock) as mock_co:
+            mock_co.return_value = mock_output
+            report = asyncio.run(run_batch(
+                samples, "http://baseline", "http://target",
+            ))
+
+        assert report.total_samples == 1


### PR DESCRIPTION
## Summary
Add Rich progress bars to the `batch-compare` command for visual feedback during batch dataset runs.

## Changes
- **`batch_compare.py`**: Add `on_progress` callback parameter to `run_batch()` — called after each sample completes with `(completed, total)` counts
- **`cli.py`**: Wire up Rich progress bar with completed/total, percentage, elapsed time, and ETA. Add `--no-progress` flag. Auto-disable when stderr is not a TTY.
- **`tests/test_batch_compare.py`**: Add tests verifying progress callback is invoked correctly and that `run_batch` works without a callback
- **`ROADMAP.md`**: Mark M12 complete

## Testing
All 136 tests pass. Lint clean (ruff + isort).

Closes #29