### PR TITLE
feat: Token Timing Analysis (M16)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -123,6 +123,10 @@ def main(argv: list[str] | None = None) -> None:
         "--skip-healthcheck", action="store_true", default=False,
         help="Skip pre-flight endpoint health check",
     )
+    cs.add_argument(
+        "--timing", action="store_true", default=False,
+        help="Enable token timing analysis (TTFT, inter-token latency)",
+    )
 
     hc = sub.add_parser("healthcheck", help="Check endpoint health")
     hc.add_argument("url", nargs="+", help="Endpoint URL(s) to check")
@@ -395,9 +399,12 @@ async def _run_diagnose(args: argparse.Namespace) -> None:
 
 async def _run_compare_streaming(args: argparse.Namespace) -> None:
     """Run streaming comparison between two endpoints."""
+    import time as time_mod
+
     from xpyd_acc.streaming import (
         StreamingCollector,
         StreamingComparator,
+        collect_stream,
         format_streaming_report,
     )
 
@@ -410,18 +417,46 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
     print(f"Streaming from baseline: {args.baseline}")
     print(f"Streaming from target:   {args.target}")
 
-    comparator = StreamingComparator()
-    report = await comparator.compare(
-        baseline, target, args.prompt,
-        max_tokens=args.max_tokens,
-        timeout=args.timeout,
-    )
+    if args.timing:
+        # Collect with timing info
+        baseline_start = time_mod.monotonic()
+        baseline_tokens = await collect_stream(
+            baseline, args.prompt, max_tokens=args.max_tokens, timeout=args.timeout,
+        )
+        baseline_elapsed = time_mod.monotonic() - baseline_start
 
-    print()
-    print(format_streaming_report(report))
+        target_start = time_mod.monotonic()
+        target_tokens = await collect_stream(
+            target, args.prompt, max_tokens=args.max_tokens, timeout=args.timeout,
+        )
+        target_elapsed = time_mod.monotonic() - target_start
 
-    if not report.match:
-        sys.exit(1)
+        from xpyd_acc.streaming import compare_token_lists
+        from xpyd_acc.timing import compare_timing, compute_timing_stats, format_timing_report
+
+        stream_report = compare_token_lists(
+            baseline_tokens, target_tokens, elapsed=baseline_elapsed + target_elapsed,
+        )
+        print()
+        print(format_streaming_report(stream_report))
+
+        baseline_stats = compute_timing_stats(baseline_tokens, baseline_start)
+        target_stats = compute_timing_stats(target_tokens, target_start)
+        timing_report = compare_timing(baseline_stats, target_stats)
+        print()
+        print(format_timing_report(timing_report))
+    else:
+        comparator = StreamingComparator()
+        report = await comparator.compare(
+            baseline, target, args.prompt,
+            max_tokens=args.max_tokens,
+            timeout=args.timeout,
+        )
+        print()
+        print(format_streaming_report(report))
+
+        if not report.match:
+            sys.exit(1)
 
 
 async def _run_detect(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/timing.py
+++ b/src/xpyd_acc/timing.py
@@ -1,0 +1,179 @@
+"""Token timing analysis for comparing TTFT and inter-token latency between endpoints."""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass, field
+
+from xpyd_acc.streaming import StreamToken
+
+
+@dataclass
+class TimingStats:
+    """Latency statistics for a single endpoint's streaming response."""
+
+    ttft: float  # time to first token (seconds)
+    total_tokens: int
+    total_duration: float  # wall-clock seconds from start to last token
+    itl_values: list[float] = field(default_factory=list)  # inter-token latencies
+
+    @property
+    def itl_p50(self) -> float | None:
+        """Median inter-token latency."""
+        if not self.itl_values:
+            return None
+        return _percentile(self.itl_values, 50)
+
+    @property
+    def itl_p95(self) -> float | None:
+        """95th percentile inter-token latency."""
+        if not self.itl_values:
+            return None
+        return _percentile(self.itl_values, 95)
+
+    @property
+    def itl_p99(self) -> float | None:
+        """99th percentile inter-token latency."""
+        if not self.itl_values:
+            return None
+        return _percentile(self.itl_values, 99)
+
+    @property
+    def itl_mean(self) -> float | None:
+        """Mean inter-token latency."""
+        if not self.itl_values:
+            return None
+        return statistics.mean(self.itl_values)
+
+    @property
+    def itl_min(self) -> float | None:
+        """Minimum inter-token latency."""
+        if not self.itl_values:
+            return None
+        return min(self.itl_values)
+
+    @property
+    def itl_max(self) -> float | None:
+        """Maximum inter-token latency."""
+        if not self.itl_values:
+            return None
+        return max(self.itl_values)
+
+
+@dataclass
+class TimingComparisonReport:
+    """Comparison of timing between baseline and target endpoints."""
+
+    baseline: TimingStats
+    target: TimingStats
+    ttft_diff: float  # target.ttft - baseline.ttft (positive = target slower)
+    ttft_ratio: float  # target.ttft / baseline.ttft
+
+
+def _percentile(data: list[float], pct: float) -> float:
+    """Compute percentile using linear interpolation."""
+    if not data:
+        raise ValueError("Cannot compute percentile of empty list")
+    sorted_data = sorted(data)
+    n = len(sorted_data)
+    if n == 1:
+        return sorted_data[0]
+    # Linear interpolation
+    k = (pct / 100.0) * (n - 1)
+    f = int(k)
+    c = f + 1
+    if c >= n:
+        return sorted_data[-1]
+    d = k - f
+    return sorted_data[f] + d * (sorted_data[c] - sorted_data[f])
+
+
+def compute_timing_stats(
+    tokens: list[StreamToken],
+    request_start: float,
+) -> TimingStats:
+    """Compute timing statistics from a list of StreamTokens.
+
+    Args:
+        tokens: Tokens with monotonic timestamps.
+        request_start: Monotonic time when the request was initiated.
+
+    Returns:
+        TimingStats with TTFT and inter-token latency stats.
+    """
+    if not tokens:
+        return TimingStats(
+            ttft=0.0,
+            total_tokens=0,
+            total_duration=0.0,
+            itl_values=[],
+        )
+
+    ttft = tokens[0].timestamp - request_start
+    total_duration = tokens[-1].timestamp - request_start
+
+    itl_values: list[float] = []
+    for i in range(1, len(tokens)):
+        itl = tokens[i].timestamp - tokens[i - 1].timestamp
+        itl_values.append(itl)
+
+    return TimingStats(
+        ttft=ttft,
+        total_tokens=len(tokens),
+        total_duration=total_duration,
+        itl_values=itl_values,
+    )
+
+
+def compare_timing(
+    baseline: TimingStats,
+    target: TimingStats,
+) -> TimingComparisonReport:
+    """Compare timing stats between baseline and target.
+
+    Args:
+        baseline: Timing stats for the baseline endpoint.
+        target: Timing stats for the target endpoint.
+
+    Returns:
+        TimingComparisonReport with comparison metrics.
+    """
+    ttft_diff = target.ttft - baseline.ttft
+    ttft_ratio = target.ttft / baseline.ttft if baseline.ttft > 0 else float("inf")
+
+    return TimingComparisonReport(
+        baseline=baseline,
+        target=target,
+        ttft_diff=ttft_diff,
+        ttft_ratio=ttft_ratio,
+    )
+
+
+def format_timing_report(report: TimingComparisonReport) -> str:
+    """Format a timing comparison report as human-readable text."""
+    lines = [
+        "=== Token Timing Analysis ===",
+        "",
+        "--- TTFT (Time to First Token) ---",
+        f"  Baseline: {report.baseline.ttft * 1000:.1f} ms",
+        f"  Target:   {report.target.ttft * 1000:.1f} ms",
+        f"  Diff:     {report.ttft_diff * 1000:+.1f} ms ({report.ttft_ratio:.2f}x)",
+        "",
+    ]
+
+    for label, stats in [("Baseline", report.baseline), ("Target", report.target)]:
+        lines.append(f"--- {label} Inter-Token Latency ---")
+        lines.append(f"  Total tokens: {stats.total_tokens}")
+        lines.append(f"  Duration:     {stats.total_duration * 1000:.1f} ms")
+        if stats.itl_values:
+            lines.append(f"  ITL mean:     {stats.itl_mean * 1000:.2f} ms")
+            lines.append(f"  ITL p50:      {stats.itl_p50 * 1000:.2f} ms")
+            lines.append(f"  ITL p95:      {stats.itl_p95 * 1000:.2f} ms")
+            lines.append(f"  ITL p99:      {stats.itl_p99 * 1000:.2f} ms")
+            lines.append(f"  ITL min:      {stats.itl_min * 1000:.2f} ms")
+            lines.append(f"  ITL max:      {stats.itl_max * 1000:.2f} ms")
+        else:
+            lines.append("  ITL:          N/A (≤1 token)")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,137 @@
+"""Tests for token timing analysis module."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_acc.streaming import StreamToken
+from xpyd_acc.timing import (
+    TimingStats,
+    _percentile,
+    compare_timing,
+    compute_timing_stats,
+    format_timing_report,
+)
+
+
+def _make_token(index: int, token: str, ts: float) -> StreamToken:
+    return StreamToken(index=index, token=token, timestamp=ts)
+
+
+class TestPercentile:
+    """Test the _percentile helper."""
+
+    def test_single_value(self) -> None:
+        assert _percentile([5.0], 50) == 5.0
+        assert _percentile([5.0], 99) == 5.0
+
+    def test_two_values(self) -> None:
+        assert _percentile([1.0, 3.0], 50) == 2.0
+
+    def test_p50_odd(self) -> None:
+        assert _percentile([1.0, 2.0, 3.0], 50) == 2.0
+
+    def test_p95(self) -> None:
+        data = list(range(1, 101))  # 1..100
+        result = _percentile([float(x) for x in data], 95)
+        assert result == pytest.approx(95.05, abs=0.1)
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _percentile([], 50)
+
+
+class TestComputeTimingStats:
+    """Test compute_timing_stats."""
+
+    def test_empty_tokens(self) -> None:
+        stats = compute_timing_stats([], request_start=100.0)
+        assert stats.ttft == 0.0
+        assert stats.total_tokens == 0
+        assert stats.total_duration == 0.0
+        assert stats.itl_values == []
+        assert stats.itl_p50 is None
+        assert stats.itl_p95 is None
+        assert stats.itl_p99 is None
+        assert stats.itl_mean is None
+        assert stats.itl_min is None
+        assert stats.itl_max is None
+
+    def test_single_token(self) -> None:
+        tokens = [_make_token(0, "Hello", ts=100.5)]
+        stats = compute_timing_stats(tokens, request_start=100.0)
+        assert stats.ttft == pytest.approx(0.5)
+        assert stats.total_tokens == 1
+        assert stats.total_duration == pytest.approx(0.5)
+        assert stats.itl_values == []
+        assert stats.itl_p50 is None
+
+    def test_multiple_tokens(self) -> None:
+        tokens = [
+            _make_token(0, "A", ts=10.1),   # TTFT = 0.1s
+            _make_token(1, "B", ts=10.15),   # ITL = 0.05s
+            _make_token(2, "C", ts=10.25),   # ITL = 0.10s
+            _make_token(3, "D", ts=10.30),   # ITL = 0.05s
+        ]
+        stats = compute_timing_stats(tokens, request_start=10.0)
+        assert stats.ttft == pytest.approx(0.1)
+        assert stats.total_tokens == 4
+        assert stats.total_duration == pytest.approx(0.3)
+        assert len(stats.itl_values) == 3
+        assert stats.itl_mean == pytest.approx(0.0667, abs=0.001)
+        assert stats.itl_min == pytest.approx(0.05, abs=0.001)
+        assert stats.itl_max == pytest.approx(0.10, abs=0.001)
+        assert stats.itl_p50 is not None
+
+
+class TestCompareTiming:
+    """Test compare_timing."""
+
+    def test_basic_comparison(self) -> None:
+        baseline = TimingStats(
+            ttft=0.1, total_tokens=10, total_duration=0.5,
+            itl_values=[0.04, 0.05, 0.04, 0.05, 0.04, 0.05, 0.04, 0.05, 0.04],
+        )
+        target = TimingStats(
+            ttft=0.2, total_tokens=10, total_duration=0.8,
+            itl_values=[0.06, 0.07, 0.06, 0.07, 0.06, 0.07, 0.06, 0.07, 0.06],
+        )
+        report = compare_timing(baseline, target)
+        assert report.ttft_diff == pytest.approx(0.1)
+        assert report.ttft_ratio == pytest.approx(2.0)
+
+    def test_zero_baseline_ttft(self) -> None:
+        baseline = TimingStats(ttft=0.0, total_tokens=1, total_duration=0.0, itl_values=[])
+        target = TimingStats(ttft=0.1, total_tokens=1, total_duration=0.1, itl_values=[])
+        report = compare_timing(baseline, target)
+        assert report.ttft_ratio == float("inf")
+
+
+class TestFormatTimingReport:
+    """Test format_timing_report."""
+
+    def test_basic_format(self) -> None:
+        baseline = TimingStats(
+            ttft=0.1, total_tokens=5, total_duration=0.5,
+            itl_values=[0.05, 0.10, 0.15, 0.10],
+        )
+        target = TimingStats(
+            ttft=0.2, total_tokens=5, total_duration=0.8,
+            itl_values=[0.10, 0.15, 0.20, 0.15],
+        )
+        report = compare_timing(baseline, target)
+        text = format_timing_report(report)
+        assert "Token Timing Analysis" in text
+        assert "TTFT" in text
+        assert "Baseline" in text
+        assert "Target" in text
+        assert "ITL p50" in text
+        assert "ITL p95" in text
+        assert "ITL p99" in text
+
+    def test_no_itl_tokens(self) -> None:
+        baseline = TimingStats(ttft=0.1, total_tokens=1, total_duration=0.1, itl_values=[])
+        target = TimingStats(ttft=0.2, total_tokens=1, total_duration=0.2, itl_values=[])
+        report = compare_timing(baseline, target)
+        text = format_timing_report(report)
+        assert "N/A" in text


### PR DESCRIPTION
## Summary
Add token timing analysis module for measuring and comparing TTFT and inter-token latency between endpoints.

Closes #37

## Changes
- **`src/xpyd_acc/timing.py`**: New module with `compute_timing_stats()`, `compare_timing()`, `format_timing_report()`
- **`src/xpyd_acc/cli.py`**: Add `--timing` flag to `compare-streaming` subcommand
- **`tests/test_timing.py`**: Full test coverage (12 tests)

## Details
- TTFT (time to first token) measurement for both endpoints
- Inter-token latency stats: mean, p50, p95, p99, min, max
- Timing comparison report with diff and ratio
- Human-readable formatted output

## Testing
- All 181 tests pass
- ruff + isort clean