### PR TITLE
feat: Prompt Template Support (M17)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "httpx>=0.27.0",
     "rich>=13.0.0",
     "pydantic>=2.0.0",
+    "pyyaml>=6.0.0",
     "tomli>=2.0.0; python_version < '3.11'",
 ]
 

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -106,6 +106,10 @@ def main(argv: list[str] | None = None) -> None:
         "--skip-healthcheck", action="store_true", default=False,
         help="Skip pre-flight endpoint health check",
     )
+    bc.add_argument(
+        "--template", default=None,
+        help="Prompt template: built-in name (gsm8k, mmlu, etc.) or path to YAML/TOML file",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -242,6 +246,17 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
     from xpyd_acc.batch_compare import export_csv, format_report, load_dataset, run_batch
 
     samples = load_dataset(args.dataset)
+
+    # Apply template if specified
+    if args.template:
+        from xpyd_acc.templates import resolve_template
+
+        template = resolve_template(args.template)
+        print(f"Using template: {template.name}")
+        for sample in samples:
+            variables = {"prompt": sample.prompt, **sample.metadata}
+            sample.prompt = template.render(variables)
+
     print(f"Loaded {len(samples)} samples from {args.dataset}")
 
     if not args.skip_healthcheck:

--- a/src/xpyd_acc/templates.py
+++ b/src/xpyd_acc/templates.py
@@ -1,0 +1,241 @@
+"""Prompt template support for batch comparisons."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+import yaml  # type: ignore[import-untyped]
+
+
+@dataclass
+class PromptTemplate:
+    """A reusable prompt template with variable substitution."""
+
+    name: str
+    template: str
+    description: str = ""
+    variables: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Auto-detect variables from template if not provided."""
+        if not self.variables:
+            self.variables = self._extract_variables()
+
+    def _extract_variables(self) -> list[str]:
+        """Extract {variable} placeholders from template string."""
+        return sorted(set(re.findall(r"\{(\w+)\}", self.template)))
+
+    def render(self, variables: dict[str, str]) -> str:
+        """Render the template with the given variables.
+
+        Args:
+            variables: Mapping of variable names to values.
+
+        Returns:
+            Rendered prompt string.
+
+        Raises:
+            ValueError: If required variables are missing.
+        """
+        missing = [v for v in self.variables if v not in variables]
+        if missing:
+            msg = (
+                f"Template '{self.name}' missing required variables: {', '.join(missing)}"
+            )
+            raise ValueError(msg)
+        result = self.template
+        for key, value in variables.items():
+            result = result.replace(f"{{{key}}}", value)
+        return result
+
+    def validate(self) -> list[str]:
+        """Validate the template and return a list of issues (empty if valid)."""
+        issues: list[str] = []
+        if not self.template.strip():
+            issues.append("Template string is empty")
+        if not self.name.strip():
+            issues.append("Template name is empty")
+        return issues
+
+
+# Built-in templates for common evaluation formats
+BUILTIN_TEMPLATES: dict[str, PromptTemplate] = {
+    "gsm8k": PromptTemplate(
+        name="gsm8k",
+        template="Q: {question}\nA: Let's think step by step.",
+        description="GSM8K math reasoning format",
+    ),
+    "mmlu": PromptTemplate(
+        name="mmlu",
+        template=(
+            "The following is a multiple choice question about {subject}.\n\n"
+            "{question}\n\n"
+            "A. {choice_a}\nB. {choice_b}\nC. {choice_c}\nD. {choice_d}\n\n"
+            "Answer:"
+        ),
+        description="MMLU multiple-choice format",
+    ),
+    "humaneval": PromptTemplate(
+        name="humaneval",
+        template=(
+            "Complete the following Python function:\n\n{prompt}\n"
+        ),
+        description="HumanEval code generation format",
+    ),
+    "mt-bench": PromptTemplate(
+        name="mt-bench",
+        template=(
+            "[Instruction]\n{instruction}\n\n"
+            "[Response]"
+        ),
+        description="MT-Bench single-turn format",
+    ),
+    "simple": PromptTemplate(
+        name="simple",
+        template="{prompt}",
+        description="Pass-through template",
+    ),
+}
+
+
+def load_template_yaml(path: str | Path) -> PromptTemplate:
+    """Load a prompt template from a YAML file.
+
+    Expected format:
+        name: my-template
+        template: "Q: {question}\\nA:"
+        description: Optional description
+        variables: [question]  # optional, auto-detected if omitted
+
+    Args:
+        path: Path to the YAML template file.
+
+    Returns:
+        Loaded PromptTemplate.
+
+    Raises:
+        ValueError: If the file is missing required fields.
+        FileNotFoundError: If the file does not exist.
+    """
+    path = Path(path)
+    with path.open() as f:
+        data = yaml.safe_load(f)
+    return _parse_template_dict(data, str(path))
+
+
+def load_template_toml(path: str | Path) -> PromptTemplate:
+    """Load a prompt template from a TOML file.
+
+    Expected format:
+        [template]
+        name = "my-template"
+        template = "Q: {question}\\nA:"
+        description = "Optional description"
+        variables = ["question"]
+
+    Args:
+        path: Path to the TOML template file.
+
+    Returns:
+        Loaded PromptTemplate.
+
+    Raises:
+        ValueError: If the file is missing required fields.
+        FileNotFoundError: If the file does not exist.
+    """
+    path = Path(path)
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    # Support both top-level and [template] section
+    if "template" in data and isinstance(data["template"], dict):
+        return _parse_template_dict(data["template"], str(path))
+    return _parse_template_dict(data, str(path))
+
+
+def load_template(path: str | Path) -> PromptTemplate:
+    """Load a prompt template from a YAML or TOML file, auto-detecting format.
+
+    Args:
+        path: Path to the template file.
+
+    Returns:
+        Loaded PromptTemplate.
+
+    Raises:
+        ValueError: If the file format is unsupported or missing required fields.
+    """
+    path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix in (".yaml", ".yml"):
+        return load_template_yaml(path)
+    if suffix == ".toml":
+        return load_template_toml(path)
+    msg = f"Unsupported template format: {suffix} (use .yaml, .yml, or .toml)"
+    raise ValueError(msg)
+
+
+def get_builtin_template(name: str) -> PromptTemplate:
+    """Get a built-in template by name.
+
+    Args:
+        name: Template name (e.g., 'gsm8k', 'mmlu').
+
+    Returns:
+        The built-in PromptTemplate.
+
+    Raises:
+        KeyError: If no built-in template with that name exists.
+    """
+    if name not in BUILTIN_TEMPLATES:
+        available = ", ".join(sorted(BUILTIN_TEMPLATES))
+        msg = f"Unknown built-in template '{name}'. Available: {available}"
+        raise KeyError(msg)
+    return BUILTIN_TEMPLATES[name]
+
+
+def resolve_template(name_or_path: str) -> PromptTemplate:
+    """Resolve a template by built-in name or file path.
+
+    First checks built-in templates, then tries loading from file.
+
+    Args:
+        name_or_path: Built-in template name or path to template file.
+
+    Returns:
+        Resolved PromptTemplate.
+    """
+    if name_or_path in BUILTIN_TEMPLATES:
+        return BUILTIN_TEMPLATES[name_or_path]
+    return load_template(name_or_path)
+
+
+def _parse_template_dict(data: dict[str, Any], source: str) -> PromptTemplate:
+    """Parse a template from a dictionary."""
+    if not isinstance(data, dict):
+        msg = f"Template file {source}: expected a mapping, got {type(data).__name__}"
+        raise ValueError(msg)
+    if "template" not in data:
+        msg = f"Template file {source}: missing required 'template' field"
+        raise ValueError(msg)
+    name = data.get("name", Path(source).stem)
+    template_str = data["template"]
+    if not isinstance(template_str, str):
+        msg = f"Template file {source}: 'template' must be a string"
+        raise ValueError(msg)
+    description = data.get("description", "")
+    variables = data.get("variables", [])
+    return PromptTemplate(
+        name=name,
+        template=template_str,
+        description=description,
+        variables=variables if variables else [],
+    )

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,161 @@
+"""Tests for prompt template module."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_acc.templates import (
+    BUILTIN_TEMPLATES,
+    PromptTemplate,
+    get_builtin_template,
+    load_template,
+    load_template_toml,
+    load_template_yaml,
+    resolve_template,
+)
+
+
+class TestPromptTemplate:
+    """Test PromptTemplate dataclass."""
+
+    def test_render_simple(self) -> None:
+        t = PromptTemplate(name="test", template="Hello {name}!")
+        assert t.render({"name": "World"}) == "Hello World!"
+
+    def test_render_multiple_variables(self) -> None:
+        t = PromptTemplate(name="test", template="Q: {question}\nA: {answer}")
+        result = t.render({"question": "What?", "answer": "Yes"})
+        assert result == "Q: What?\nA: Yes"
+
+    def test_render_missing_variable(self) -> None:
+        t = PromptTemplate(name="test", template="Hello {name} from {place}!")
+        with pytest.raises(ValueError, match="missing required variables.*place"):
+            t.render({"name": "World"})
+
+    def test_auto_detect_variables(self) -> None:
+        t = PromptTemplate(name="test", template="{a} and {b} and {a}")
+        assert t.variables == ["a", "b"]
+
+    def test_explicit_variables(self) -> None:
+        t = PromptTemplate(name="test", template="{x}", variables=["x"])
+        assert t.variables == ["x"]
+
+    def test_validate_empty_template(self) -> None:
+        t = PromptTemplate(name="test", template="")
+        issues = t.validate()
+        assert any("empty" in i.lower() for i in issues)
+
+    def test_validate_empty_name(self) -> None:
+        t = PromptTemplate(name="", template="hello")
+        issues = t.validate()
+        assert any("name" in i.lower() for i in issues)
+
+    def test_validate_ok(self) -> None:
+        t = PromptTemplate(name="test", template="hello {x}")
+        assert t.validate() == []
+
+    def test_render_extra_variables_ignored(self) -> None:
+        t = PromptTemplate(name="test", template="Hi {name}")
+        result = t.render({"name": "Bob", "extra": "ignored"})
+        assert result == "Hi Bob"
+
+
+class TestBuiltinTemplates:
+    """Test built-in templates."""
+
+    def test_gsm8k(self) -> None:
+        t = get_builtin_template("gsm8k")
+        result = t.render({"question": "What is 2+2?"})
+        assert "What is 2+2?" in result
+        assert "step by step" in result
+
+    def test_mmlu(self) -> None:
+        t = get_builtin_template("mmlu")
+        result = t.render({
+            "subject": "math",
+            "question": "What is pi?",
+            "choice_a": "3.14",
+            "choice_b": "2.71",
+            "choice_c": "1.41",
+            "choice_d": "1.61",
+        })
+        assert "A. 3.14" in result
+        assert "math" in result
+
+    def test_simple(self) -> None:
+        t = get_builtin_template("simple")
+        assert t.render({"prompt": "hello"}) == "hello"
+
+    def test_unknown_builtin(self) -> None:
+        with pytest.raises(KeyError, match="Unknown built-in"):
+            get_builtin_template("nonexistent")
+
+    def test_all_builtins_valid(self) -> None:
+        for name, t in BUILTIN_TEMPLATES.items():
+            assert t.validate() == [], f"Built-in '{name}' has validation issues"
+
+
+class TestLoadTemplate:
+    """Test template file loading."""
+
+    def test_load_yaml(self, tmp_path) -> None:
+        f = tmp_path / "test.yaml"
+        f.write_text("name: my-template\ntemplate: 'Q: {question}'\n")
+        t = load_template_yaml(f)
+        assert t.name == "my-template"
+        assert t.render({"question": "hi"}) == "Q: hi"
+
+    def test_load_toml(self, tmp_path) -> None:
+        f = tmp_path / "test.toml"
+        f.write_text('[template]\nname = "my-template"\ntemplate = "Q: {question}"\n')
+        t = load_template_toml(f)
+        assert t.name == "my-template"
+        assert t.render({"question": "hi"}) == "Q: hi"
+
+    def test_load_toml_toplevel(self, tmp_path) -> None:
+        f = tmp_path / "test.toml"
+        f.write_text('name = "flat"\ntemplate = "Hello {name}"\n')
+        t = load_template_toml(f)
+        assert t.name == "flat"
+
+    def test_load_auto_yaml(self, tmp_path) -> None:
+        f = tmp_path / "test.yml"
+        f.write_text("name: auto\ntemplate: '{prompt}'\n")
+        t = load_template(f)
+        assert t.name == "auto"
+
+    def test_load_auto_toml(self, tmp_path) -> None:
+        f = tmp_path / "test.toml"
+        f.write_text('name = "auto"\ntemplate = "{prompt}"\n')
+        t = load_template(f)
+        assert t.name == "auto"
+
+    def test_load_unsupported_format(self, tmp_path) -> None:
+        f = tmp_path / "test.txt"
+        f.write_text("hello")
+        with pytest.raises(ValueError, match="Unsupported template format"):
+            load_template(f)
+
+    def test_load_missing_template_field(self, tmp_path) -> None:
+        f = tmp_path / "test.yaml"
+        f.write_text("name: broken\n")
+        with pytest.raises(ValueError, match="missing required 'template'"):
+            load_template_yaml(f)
+
+    def test_load_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_template_yaml("/nonexistent/path.yaml")
+
+
+class TestResolveTemplate:
+    """Test resolve_template function."""
+
+    def test_resolve_builtin(self) -> None:
+        t = resolve_template("gsm8k")
+        assert t.name == "gsm8k"
+
+    def test_resolve_file(self, tmp_path) -> None:
+        f = tmp_path / "custom.yaml"
+        f.write_text("name: custom\ntemplate: '{prompt}'\n")
+        t = resolve_template(str(f))
+        assert t.name == "custom"


### PR DESCRIPTION
## Summary
Add prompt template support for reusable, parameterized prompts in batch comparisons.

Closes #40

## Changes
- **`src/xpyd_acc/templates.py`**: New module with `PromptTemplate`, YAML/TOML loading, built-in templates
- **`src/xpyd_acc/cli.py`**: Add `--template` flag to `batch-compare` subcommand
- **`pyproject.toml`**: Add `pyyaml` dependency
- **`tests/test_templates.py`**: 24 tests covering all template features

## Details
- `PromptTemplate` dataclass with `render(variables)` and `validate()`
- Auto-detect `{variable}` placeholders from template string
- Built-in templates: gsm8k, mmlu, humaneval, mt-bench, simple
- Load from YAML or TOML files (auto-detect by extension)
- `resolve_template()`: try built-in name first, then file path
- Missing variables raise clear `ValueError` with details

## Testing
- All 205 tests pass
- ruff + isort clean