### PR TITLE
feat: add Markdown report export for batch-compare (M19)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,3 +123,10 @@
 - Priority chain: CLI flags > env vars > config file > defaults
 - Avoids API keys in shell history
 - `env.py` module with `get_env_defaults()` and `apply_env_defaults()`
+
+## M19: Markdown Report Export
+- `batch-compare --markdown <path>` exports a Markdown report
+- `BatchReport.to_markdown()` method for programmatic use
+- Summary table, classification breakdown, divergence stats
+- Context length analysis table
+- Top divergent samples with details

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -63,6 +63,10 @@ class BatchReport:
     # Divergence by context length buckets
     divergence_by_context_length: dict[str, dict[str, int]] = field(default_factory=dict)
 
+    def to_markdown(self, *, max_divergent_samples: int = 10) -> str:
+        """Serialize the report to a Markdown string."""
+        return _to_markdown(self, max_divergent_samples=max_divergent_samples)
+
     def to_json(self) -> str:
         """Serialize the report to a JSON string."""
         data: dict[str, Any] = {
@@ -442,3 +446,108 @@ def format_report(report: BatchReport) -> str:
                 )
 
     return "\n".join(lines)
+
+
+def _to_markdown(report: BatchReport, *, max_divergent_samples: int = 10) -> str:
+    """Convert a BatchReport to a Markdown string.
+
+    Args:
+        report: The batch report to convert.
+        max_divergent_samples: Max number of divergent samples to include in detail section.
+    """
+    lines: list[str] = []
+    lines.append("# Batch Comparison Report")
+    lines.append("")
+
+    # Summary table
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Total samples | {report.total_samples} |")
+    lines.append(f"| Matches | {report.match_samples} |")
+    lines.append(f"| Divergent | {report.divergent_samples} |")
+    lines.append(f"| Divergence rate | {report.divergence_rate:.1%} |")
+    lines.append("")
+
+    if report.divergent_samples > 0:
+        # Classification
+        lines.append("## Classification")
+        lines.append("")
+        lines.append("| Category | Count |")
+        lines.append("|----------|-------|")
+        lines.append(f"| Likely bugs | {report.likely_bugs} |")
+        lines.append(f"| Likely uncertainty | {report.likely_uncertainty} |")
+        lines.append(f"| Unknown | {report.unknown_classification} |")
+        lines.append("")
+
+        # Divergence stats
+        if report.divergence_index_mean is not None:
+            lines.append("## Divergence Point Statistics")
+            lines.append("")
+            lines.append("| Stat | Value |")
+            lines.append("|------|-------|")
+            lines.append(f"| Mean token index | {report.divergence_index_mean:.1f} |")
+            lines.append(f"| Median token index | {report.divergence_index_median:.1f} |")
+            if report.logprob_gap_mean is not None:
+                lines.append(f"| Mean logprob gap | {report.logprob_gap_mean:.6f} |")
+                lines.append(f"| Median logprob gap | {report.logprob_gap_median:.6f} |")
+            lines.append("")
+
+        # Context length analysis
+        if report.divergence_by_context_length:
+            lines.append("## Divergence by Context Length")
+            lines.append("")
+            lines.append("| Bucket | Divergent | Total | Rate |")
+            lines.append("|--------|-----------|-------|------|")
+            for bucket in sorted(report.divergence_by_context_length.keys()):
+                stats = report.divergence_by_context_length[bucket]
+                rate = stats["divergent"] / stats["total"] if stats["total"] > 0 else 0
+                lines.append(
+                    f"| {bucket} | {stats['divergent']} | {stats['total']} | {rate:.1%} |"
+                )
+            lines.append("")
+
+        # Top divergent samples
+        divergent = [r for r in report.results if r.is_divergent()]
+        shown = divergent[:max_divergent_samples]
+        if shown:
+            lines.append(f"## Top Divergent Samples (showing {len(shown)}/{len(divergent)})")
+            lines.append("")
+            for r in shown:
+                lines.append(f"### Sample {r.sample_id}")
+                lines.append("")
+                lines.append(f"- **Classification:** {r.classification}")
+                lines.append(
+                    f"- **First divergence at token:** {r.first_divergence_index}"
+                )
+                if r.logprob_gap is not None:
+                    lines.append(f"- **Logprob gap:** {r.logprob_gap:.6f}")
+                prompt_preview = _truncate(r.prompt, 200)
+                lines.append(f"- **Prompt:** `{prompt_preview}`")
+                baseline_preview = _truncate(r.baseline_output, 200)
+                target_preview = _truncate(r.target_output, 200)
+                lines.append(f"- **Baseline:** `{baseline_preview}`")
+                lines.append(f"- **Target:** `{target_preview}`")
+                lines.append("")
+
+    return "\n".join(lines)
+
+
+def export_markdown(
+    report: BatchReport,
+    path: str | Path | None = None,
+    *,
+    max_divergent_samples: int = 10,
+) -> str:
+    """Export report as Markdown. Returns Markdown string. If path given, also writes to file.
+
+    Args:
+        report: The batch report to export.
+        path: Optional file path to write Markdown to.
+        max_divergent_samples: Max divergent samples to show in detail.
+    """
+    md = _to_markdown(report, max_divergent_samples=max_divergent_samples)
+    if path is not None:
+        Path(path).write_text(md)
+    return md

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -93,6 +93,7 @@ def main(argv: list[str] | None = None) -> None:
     )
     bc.add_argument("--csv", default=None, help="Path to export CSV results")
     bc.add_argument("--json", default=None, dest="json_path", help="Path to export JSON results")
+    bc.add_argument("--markdown", default=None, help="Path to export Markdown report")
     bc.add_argument("--retries", type=int, default=None, help="Max retry attempts (default: 3)")
     bc.add_argument(
         "--retry-delay", type=float, default=None,
@@ -257,7 +258,13 @@ async def _run_healthcheck(args: argparse.Namespace) -> None:
 
 async def _run_batch_compare(args: argparse.Namespace) -> None:
     """Run batch dataset comparison."""
-    from xpyd_acc.batch_compare import export_csv, format_report, load_dataset, run_batch
+    from xpyd_acc.batch_compare import (
+        export_csv,
+        export_markdown,
+        format_report,
+        load_dataset,
+        run_batch,
+    )
 
     samples = load_dataset(args.dataset)
 
@@ -338,6 +345,10 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         from pathlib import Path
         Path(args.json_path).write_text(report.to_json())
         print(f"\nJSON exported to {args.json_path}")
+
+    if args.markdown:
+        export_markdown(report, args.markdown)
+        print(f"\nMarkdown exported to {args.markdown}")
 
     if report.divergent_samples > 0:
         sys.exit(1)

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -12,6 +12,7 @@ from xpyd_acc.batch_compare import (
     classify_divergence,
     compute_report,
     export_csv,
+    export_markdown,
     format_report,
     load_dataset,
 )
@@ -379,3 +380,126 @@ class TestOnProgressCallback:
             ))
 
         assert report.total_samples == 1
+
+
+class TestToMarkdown:
+    def _make_report(self, *, divergent: bool = True) -> BatchReport:
+        results = [
+            SampleResult(
+                sample_id="0",
+                prompt="What is 2+2?",
+                baseline_output="4",
+                target_output="4",
+                exact_match=True,
+                first_divergence_index=None,
+                baseline_logprob_at_divergence=None,
+                target_logprob_at_divergence=None,
+                logprob_gap=None,
+                classification="match",
+                context_length=10,
+            ),
+        ]
+        if divergent:
+            results.append(SampleResult(
+                sample_id="1",
+                prompt="Explain gravity",
+                baseline_output="Gravity is a force",
+                target_output="Gravity is energy",
+                exact_match=False,
+                first_divergence_index=3,
+                baseline_logprob_at_divergence=-0.5,
+                target_logprob_at_divergence=-1.2,
+                logprob_gap=0.5,
+                classification="likely_bug",
+                context_length=10,
+            ))
+        return compute_report(results)
+
+    def test_markdown_contains_summary(self) -> None:
+        report = self._make_report()
+        md = report.to_markdown()
+        assert "# Batch Comparison Report" in md
+        assert "| Total samples | 2 |" in md
+        assert "| Divergent | 1 |" in md
+
+    def test_markdown_contains_classification(self) -> None:
+        report = self._make_report()
+        md = report.to_markdown()
+        assert "## Classification" in md
+        assert "| Likely bugs | 1 |" in md
+
+    def test_markdown_contains_divergent_samples(self) -> None:
+        report = self._make_report()
+        md = report.to_markdown()
+        assert "### Sample 1" in md
+        assert "likely_bug" in md
+
+    def test_markdown_no_divergent_section_when_all_match(self) -> None:
+        report = self._make_report(divergent=False)
+        md = report.to_markdown()
+        assert "## Classification" not in md
+        assert "### Sample" not in md
+
+    def test_markdown_max_divergent_samples(self) -> None:
+        results = []
+        for i in range(20):
+            results.append(SampleResult(
+                sample_id=str(i),
+                prompt=f"prompt {i}",
+                baseline_output="a",
+                target_output="b",
+                exact_match=False,
+                first_divergence_index=0,
+                baseline_logprob_at_divergence=None,
+                target_logprob_at_divergence=None,
+                logprob_gap=None,
+                classification="unknown",
+                context_length=5,
+            ))
+        report = compute_report(results)
+        md = report.to_markdown(max_divergent_samples=5)
+        assert "showing 5/20" in md
+
+
+class TestExportMarkdown:
+    def test_export_to_file(self, tmp_path: Path) -> None:
+        results = [
+            SampleResult(
+                sample_id="0",
+                prompt="hi",
+                baseline_output="hello",
+                target_output="hello",
+                exact_match=True,
+                first_divergence_index=None,
+                baseline_logprob_at_divergence=None,
+                target_logprob_at_divergence=None,
+                logprob_gap=None,
+                classification="match",
+                context_length=1,
+            ),
+        ]
+        report = compute_report(results)
+        out = tmp_path / "report.md"
+        md = export_markdown(report, out)
+        assert out.read_text() == md
+        assert "# Batch Comparison Report" in md
+
+    def test_export_no_file(self) -> None:
+        results = [
+            SampleResult(
+                sample_id="0",
+                prompt="hi",
+                baseline_output="hello",
+                target_output="hello",
+                exact_match=True,
+                first_divergence_index=None,
+                baseline_logprob_at_divergence=None,
+                target_logprob_at_divergence=None,
+                logprob_gap=None,
+                classification="match",
+                context_length=1,
+            ),
+        ]
+        report = compute_report(results)
+        md = export_markdown(report)
+        assert "# Batch Comparison Report" in md


### PR DESCRIPTION
## Summary

Add Markdown report export capability for `batch-compare`.

### Changes
- `BatchReport.to_markdown()` method for programmatic Markdown generation
- `export_markdown(report, path)` function for file export
- `--markdown <path>` CLI flag on `batch-compare` subcommand
- M19 milestone added to ROADMAP.md
- Comprehensive unit tests for all new functionality

### Report includes
- Summary table (total, divergent, match rate)
- Classification breakdown (bugs vs uncertainty)
- Divergence point statistics
- Context length analysis table
- Top divergent samples with details

Closes #45