### PR TITLE
feat: tolerance-based matching for batch comparison (M22)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -131,17 +131,27 @@
 - Context length analysis table
 - Top divergent samples with details
 
-## M20: Dry Run Mode for Batch Comparison
+## M20: Dry Run Mode for Batch Comparison ✅
 - `batch-compare --dry-run` validates everything without sending API requests
 - Checks: dataset loads correctly, template renders, endpoints reachable (via healthcheck)
 - Reports: number of samples, estimated tokens, resolved config values
 - Exits 0 if all validations pass, non-zero with actionable error messages
 - Useful for CI pipelines and pre-flight validation before long batch runs
 
-## M21: Regression Detection
+## M21: Regression Detection ✅
 - `xpyd-acc regression --baseline <old.json> --current <new.json>` compares two batch runs
 - Detects regressions (previously matched, now diverges), fixes, and persistent issues
 - Summary: regression count, fix count, net change, divergence rate comparison
 - Exit 0 if no regressions, exit 1 if regressions found (CI-friendly)
 - JSON export for regression reports
 - Rich terminal output with clear pass/fail indicators
+
+## M22: Tolerance-Based Matching for Batch Comparison
+- `--normalize-whitespace` flag: collapse/strip whitespace before comparison
+- `--ignore-case` flag: case-insensitive text matching
+- `--numeric-tolerance <float>` flag: treat numbers within tolerance as equal
+- New `MatchConfig` dataclass in `output_compare.py` for match settings
+- `normalized_match()` function applying configured tolerances
+- Integrated into `batch-compare` and `compare-streaming` commands
+- TOML config section `[matching]` for default tolerance settings
+- Tests for all tolerance modes and combinations

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -233,6 +233,7 @@ async def run_batch(
     retries: int = 3,
     retry_delay: float = 1.0,
     on_progress: Callable[[int, int], None] | None = None,
+    match_config: Any | None = None,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report.
 
@@ -259,7 +260,10 @@ async def run_batch(
 
         b_tokens = _tokenize(baseline_text)
         t_tokens = _tokenize(target_text)
-        exact = baseline_text == target_text
+
+        from xpyd_acc.output_compare import normalized_match
+
+        exact = normalized_match(baseline_text, target_text, match_config)
         div_idx = _find_first_divergence(b_tokens, t_tokens)
 
         b_lp_at_div: float | None = None

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -115,6 +115,18 @@ def main(argv: list[str] | None = None) -> None:
         "--dry-run", action="store_true", default=False,
         help="Validate setup without sending API requests",
     )
+    bc.add_argument(
+        "--normalize-whitespace", action="store_true", default=False,
+        help="Collapse and strip whitespace before comparison",
+    )
+    bc.add_argument(
+        "--ignore-case", action="store_true", default=False,
+        help="Case-insensitive text matching",
+    )
+    bc.add_argument(
+        "--numeric-tolerance", type=float, default=None,
+        help="Treat numbers within tolerance as equal",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -135,6 +147,18 @@ def main(argv: list[str] | None = None) -> None:
     cs.add_argument(
         "--timing", action="store_true", default=False,
         help="Enable token timing analysis (TTFT, inter-token latency)",
+    )
+    cs.add_argument(
+        "--normalize-whitespace", action="store_true", default=False,
+        help="Collapse and strip whitespace before comparison",
+    )
+    cs.add_argument(
+        "--ignore-case", action="store_true", default=False,
+        help="Case-insensitive text matching",
+    )
+    cs.add_argument(
+        "--numeric-tolerance", type=float, default=None,
+        help="Treat numbers within tolerance as equal",
     )
 
     hc = sub.add_parser("healthcheck", help="Check endpoint health")
@@ -356,6 +380,20 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         task_id = progress_ctx.add_task("Comparing samples", total=len(samples))
 
     try:
+        from xpyd_acc.output_compare import MatchConfig
+
+        match_config = MatchConfig(
+            normalize_whitespace=args.normalize_whitespace,
+            ignore_case=args.ignore_case,
+            numeric_tolerance=args.numeric_tolerance,
+        )
+        # Only pass config if any tolerance is enabled
+        effective_match = match_config if (
+            match_config.normalize_whitespace
+            or match_config.ignore_case
+            or match_config.numeric_tolerance is not None
+        ) else None
+
         report = await run_batch(
             samples,
             args.baseline,
@@ -368,6 +406,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             retries=args.retries,
             retry_delay=args.retry_delay,
             on_progress=on_progress if use_progress else None,
+            match_config=effective_match,
         )
     finally:
         if progress_ctx is not None:
@@ -497,6 +536,19 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
     print(f"Streaming from target:   {args.target}")
 
     if args.timing:
+        from xpyd_acc.output_compare import MatchConfig as _MC
+
+        _stream_match = _MC(
+            normalize_whitespace=args.normalize_whitespace,
+            ignore_case=args.ignore_case,
+            numeric_tolerance=args.numeric_tolerance,
+        )
+        _eff_match = _stream_match if (
+            _stream_match.normalize_whitespace
+            or _stream_match.ignore_case
+            or _stream_match.numeric_tolerance is not None
+        ) else None
+
         # Collect with timing info
         baseline_start = time_mod.monotonic()
         baseline_tokens = await collect_stream(
@@ -514,7 +566,9 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
         from xpyd_acc.timing import compare_timing, compute_timing_stats, format_timing_report
 
         stream_report = compare_token_lists(
-            baseline_tokens, target_tokens, elapsed=baseline_elapsed + target_elapsed,
+            baseline_tokens, target_tokens,
+            elapsed=baseline_elapsed + target_elapsed,
+            match_config=_eff_match,
         )
         print()
         print(format_streaming_report(stream_report))
@@ -525,11 +579,25 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
         print()
         print(format_timing_report(timing_report))
     else:
+        from xpyd_acc.output_compare import MatchConfig as _MC2
+
+        _stream_match2 = _MC2(
+            normalize_whitespace=args.normalize_whitespace,
+            ignore_case=args.ignore_case,
+            numeric_tolerance=args.numeric_tolerance,
+        )
+        _eff_match2 = _stream_match2 if (
+            _stream_match2.normalize_whitespace
+            or _stream_match2.ignore_case
+            or _stream_match2.numeric_tolerance is not None
+        ) else None
+
         comparator = StreamingComparator()
         report = await comparator.compare(
             baseline, target, args.prompt,
             max_tokens=args.max_tokens,
             timeout=args.timeout,
+            match_config=_eff_match2,
         )
         print()
         print(format_streaming_report(report))

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -61,6 +61,15 @@ class ReportConfig:
 
 
 @dataclass
+class MatchingConfig:
+    """Tolerance-based matching settings."""
+
+    normalize_whitespace: bool = False
+    ignore_case: bool = False
+    numeric_tolerance: float | None = None
+
+
+@dataclass
 class AppConfig:
     """Top-level application configuration."""
 
@@ -68,6 +77,7 @@ class AppConfig:
     batch: BatchConfig = field(default_factory=BatchConfig)
     kv: KVConfig = field(default_factory=KVConfig)
     report: ReportConfig = field(default_factory=ReportConfig)
+    matching: MatchingConfig = field(default_factory=MatchingConfig)
 
 
 def _parse_section(data: dict[str, Any], cls: type) -> Any:
@@ -101,8 +111,9 @@ def load_config(path: str | Path) -> AppConfig:
     batch = _parse_section(raw.get("batch", {}), BatchConfig)
     kv = _parse_section(raw.get("kv", {}), KVConfig)
     report = _parse_section(raw.get("report", {}), ReportConfig)
+    matching = _parse_section(raw.get("matching", {}), MatchingConfig)
 
-    return AppConfig(defaults=defaults, batch=batch, kv=kv, report=report)
+    return AppConfig(defaults=defaults, batch=batch, kv=kv, report=report, matching=matching)
 
 
 def discover_config() -> AppConfig | None:
@@ -178,5 +189,17 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
     elif command == "report":
         if "output" in merged and merged["output"] is None:
             merged["output"] = config.report.output
+
+    # Apply matching config for commands that support tolerance
+    if command in ("batch-compare", "compare-streaming"):
+        matching_map: dict[str, Any] = {
+            "normalize_whitespace": config.matching.normalize_whitespace,
+            "ignore_case": config.matching.ignore_case,
+            "numeric_tolerance": config.matching.numeric_tolerance,
+        }
+        for key, config_val in matching_map.items():
+            if key in merged and (merged[key] is None or merged[key] is False):
+                if config_val is not None and config_val is not False:
+                    merged[key] = config_val
 
     return merged

--- a/src/xpyd_acc/output_compare.py
+++ b/src/xpyd_acc/output_compare.py
@@ -2,7 +2,68 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+
+_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?")
+
+
+@dataclass
+class MatchConfig:
+    """Configuration for tolerance-based matching."""
+
+    normalize_whitespace: bool = False
+    ignore_case: bool = False
+    numeric_tolerance: float | None = None
+
+
+def _normalize_text(text: str, config: MatchConfig) -> str:
+    """Apply whitespace and case normalization to *text*."""
+    result = text
+    if config.normalize_whitespace:
+        result = " ".join(result.split())
+    if config.ignore_case:
+        result = result.lower()
+    return result
+
+
+def _numbers_close(a_str: str, b_str: str, tolerance: float) -> bool:
+    """Return True if two number strings are within *tolerance*."""
+    try:
+        return abs(float(a_str) - float(b_str)) <= tolerance
+    except ValueError:
+        return False
+
+
+def normalized_match(text1: str, text2: str, config: MatchConfig | None = None) -> bool:
+    """Check whether *text1* and *text2* match under the given tolerances.
+
+    With default (None) config, this is strict exact match.
+    """
+    if config is None:
+        return text1 == text2
+
+    a = _normalize_text(text1, config)
+    b = _normalize_text(text2, config)
+
+    if config.numeric_tolerance is None:
+        return a == b
+
+    # Replace numbers with placeholders, compare non-numeric parts,
+    # then compare each number pair with tolerance.
+    nums_a = _NUMBER_RE.findall(a)
+    nums_b = _NUMBER_RE.findall(b)
+    skeleton_a = _NUMBER_RE.sub("\x00", a)
+    skeleton_b = _NUMBER_RE.sub("\x00", b)
+
+    if skeleton_a != skeleton_b:
+        return False
+    if len(nums_a) != len(nums_b):
+        return False
+    return all(
+        _numbers_close(na, nb, config.numeric_tolerance)
+        for na, nb in zip(nums_a, nums_b)
+    )
 
 
 @dataclass

--- a/src/xpyd_acc/streaming.py
+++ b/src/xpyd_acc/streaming.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import time
 from dataclasses import dataclass
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 import httpx
 
@@ -140,6 +140,7 @@ class StreamingComparator:
         *,
         timeout: float = 60.0,
         on_token: None = None,
+        match_config: Any | None = None,
     ) -> StreamingComparisonReport:
         """Run both streams in parallel and compare tokens as they arrive.
 
@@ -163,22 +164,25 @@ class StreamingComparator:
         )
 
         elapsed = time.monotonic() - start
-        return compare_token_lists(baseline_tokens, target_tokens, elapsed)
+        return compare_token_lists(baseline_tokens, target_tokens, elapsed, match_config)
 
 
 def compare_token_lists(
     baseline_tokens: list[StreamToken],
     target_tokens: list[StreamToken],
     elapsed: float = 0.0,
+    match_config: Any | None = None,
 ) -> StreamingComparisonReport:
     """Compare two lists of StreamTokens and find first divergence."""
+    from xpyd_acc.output_compare import normalized_match
+
     min_len = min(len(baseline_tokens), len(target_tokens))
     divergence: StreamingDivergence | None = None
 
     for i in range(min_len):
         bt = baseline_tokens[i]
         tt = target_tokens[i]
-        if bt.token != tt.token:
+        if not normalized_match(bt.token, tt.token, match_config):
             divergence = StreamingDivergence(
                 token_index=i,
                 expected_token=bt.token,

--- a/tests/test_tolerance.py
+++ b/tests/test_tolerance.py
@@ -1,0 +1,210 @@
+"""Tests for tolerance-based matching (M22)."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_acc.output_compare import MatchConfig, normalized_match
+
+
+class TestMatchConfigDefaults:
+    """MatchConfig should default to strict matching."""
+
+    def test_default_config(self) -> None:
+        cfg = MatchConfig()
+        assert cfg.normalize_whitespace is False
+        assert cfg.ignore_case is False
+        assert cfg.numeric_tolerance is None
+
+    def test_none_config_strict(self) -> None:
+        assert normalized_match("hello", "hello", None) is True
+        assert normalized_match("hello", "Hello", None) is False
+
+
+class TestNormalizeWhitespace:
+    """Test whitespace normalization."""
+
+    def test_trailing_whitespace(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("hello ", "hello", cfg) is True
+
+    def test_leading_whitespace(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("  hello", "hello", cfg) is True
+
+    def test_multiple_spaces(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("hello   world", "hello world", cfg) is True
+
+    def test_tabs_and_newlines(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("hello\t\nworld", "hello world", cfg) is True
+
+    def test_different_content_still_fails(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("hello world", "hello earth", cfg) is False
+
+    def test_disabled_whitespace(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=False)
+        assert normalized_match("hello ", "hello", cfg) is False
+
+
+class TestIgnoreCase:
+    """Test case-insensitive matching."""
+
+    def test_case_match(self) -> None:
+        cfg = MatchConfig(ignore_case=True)
+        assert normalized_match("Hello World", "hello world", cfg) is True
+
+    def test_mixed_case(self) -> None:
+        cfg = MatchConfig(ignore_case=True)
+        assert normalized_match("ABC", "abc", cfg) is True
+
+    def test_different_content(self) -> None:
+        cfg = MatchConfig(ignore_case=True)
+        assert normalized_match("abc", "xyz", cfg) is False
+
+    def test_disabled_case(self) -> None:
+        cfg = MatchConfig(ignore_case=False)
+        assert normalized_match("Hello", "hello", cfg) is False
+
+
+class TestNumericTolerance:
+    """Test numeric tolerance matching."""
+
+    def test_exact_numbers(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.01)
+        assert normalized_match("result: 3.14", "result: 3.14", cfg) is True
+
+    def test_within_tolerance(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.01)
+        assert normalized_match("result: 3.14", "result: 3.145", cfg) is True
+
+    def test_outside_tolerance(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.001)
+        assert normalized_match("result: 3.14", "result: 3.20", cfg) is False
+
+    def test_multiple_numbers(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.1)
+        assert normalized_match("x=1.0, y=2.0", "x=1.05, y=2.08", cfg) is True
+
+    def test_different_text_between_numbers(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.1)
+        assert normalized_match("x=1.0 foo", "x=1.0 bar", cfg) is False
+
+    def test_different_number_count(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.1)
+        assert normalized_match("1.0 2.0", "1.0", cfg) is False
+
+    def test_negative_numbers(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.01)
+        assert normalized_match("value: -3.14", "value: -3.145", cfg) is True
+
+    def test_scientific_notation(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.01)
+        assert normalized_match("val: 1e-3", "val: 0.001", cfg) is True
+
+    def test_integers(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.5)
+        assert normalized_match("count: 10", "count: 10", cfg) is True
+
+
+class TestCombinedTolerances:
+    """Test combinations of tolerance modes."""
+
+    def test_whitespace_and_case(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True, ignore_case=True)
+        assert normalized_match("  Hello  World  ", "hello world", cfg) is True
+
+    def test_whitespace_and_numeric(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True, numeric_tolerance=0.01)
+        assert normalized_match("result:  3.14", "result: 3.145", cfg) is True
+
+    def test_case_and_numeric(self) -> None:
+        cfg = MatchConfig(ignore_case=True, numeric_tolerance=0.01)
+        assert normalized_match("Result: 3.14", "result: 3.145", cfg) is True
+
+    def test_all_three(self) -> None:
+        cfg = MatchConfig(
+            normalize_whitespace=True, ignore_case=True, numeric_tolerance=0.01,
+        )
+        assert normalized_match(
+            "  Result:  3.14  ", "result: 3.145", cfg,
+        ) is True
+
+    def test_all_three_fail(self) -> None:
+        cfg = MatchConfig(
+            normalize_whitespace=True, ignore_case=True, numeric_tolerance=0.001,
+        )
+        assert normalized_match(
+            "Result: 3.14", "result: 3.20", cfg,
+        ) is False
+
+
+class TestConfigToml:
+    """Test TOML [matching] section parsing."""
+
+    def test_matching_section(self, tmp_path: pytest.TempPathFactory) -> None:
+        from xpyd_acc.config import load_config
+
+        toml_file = tmp_path / "test.toml"  # type: ignore[operator]
+        toml_file.write_text(
+            "[matching]\n"
+            "normalize_whitespace = true\n"
+            "ignore_case = true\n"
+            "numeric_tolerance = 0.01\n"
+        )
+        cfg = load_config(str(toml_file))
+        assert cfg.matching.normalize_whitespace is True
+        assert cfg.matching.ignore_case is True
+        assert cfg.matching.numeric_tolerance == 0.01
+
+    def test_empty_matching(self, tmp_path: pytest.TempPathFactory) -> None:
+        from xpyd_acc.config import load_config
+
+        toml_file = tmp_path / "test.toml"  # type: ignore[operator]
+        toml_file.write_text("[defaults]\nmodel = 'test'\n")
+        cfg = load_config(str(toml_file))
+        assert cfg.matching.normalize_whitespace is False
+        assert cfg.matching.ignore_case is False
+        assert cfg.matching.numeric_tolerance is None
+
+    def test_merge_cli_args(self) -> None:
+        from xpyd_acc.config import AppConfig, MatchingConfig, merge_cli_args
+
+        config = AppConfig(
+            matching=MatchingConfig(
+                normalize_whitespace=True,
+                ignore_case=True,
+                numeric_tolerance=0.05,
+            ),
+        )
+        args = {
+            "normalize_whitespace": False,
+            "ignore_case": False,
+            "numeric_tolerance": None,
+        }
+        merged = merge_cli_args(config, args, "batch-compare")
+        assert merged["normalize_whitespace"] is True
+        assert merged["ignore_case"] is True
+        assert merged["numeric_tolerance"] == 0.05
+
+
+class TestEdgeCases:
+    """Edge cases for tolerance matching."""
+
+    def test_empty_strings(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("", "", cfg) is True
+
+    def test_whitespace_only(self) -> None:
+        cfg = MatchConfig(normalize_whitespace=True)
+        assert normalized_match("   ", "", cfg) is True
+
+    def test_no_numbers_with_tolerance(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.1)
+        assert normalized_match("hello", "hello", cfg) is True
+
+    def test_no_numbers_different(self) -> None:
+        cfg = MatchConfig(numeric_tolerance=0.1)
+        assert normalized_match("hello", "world", cfg) is False


### PR DESCRIPTION
## Summary

Add configurable tolerance modes for output matching in batch comparisons, reducing false divergence reports caused by trivial differences.

## Changes

- **`MatchConfig` dataclass** in `output_compare.py` with three tolerance options:
  - `normalize_whitespace`: collapse/strip whitespace before comparison
  - `ignore_case`: case-insensitive text matching  
  - `numeric_tolerance`: treat numbers within tolerance as equal
- **`normalized_match()` function** applying configured tolerances with numeric-aware comparison
- **CLI flags** `--normalize-whitespace`, `--ignore-case`, `--numeric-tolerance` on both `batch-compare` and `compare-streaming`
- **TOML `[matching]` section** in config with merge support (CLI flags override config)
- **Comprehensive tests** (28 test cases) covering each mode, combinations, edge cases, and config
- Updated ROADMAP: marked M20/M21 ✅, added M22

## Testing

All 288 tests pass. Lint clean (ruff + isort).

Closes #51