### PR TITLE
feat: selective sample rerun for batch comparison (M23)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -127,6 +127,14 @@ def main(argv: list[str] | None = None) -> None:
         "--numeric-tolerance", type=float, default=None,
         help="Treat numbers within tolerance as equal",
     )
+    bc.add_argument(
+        "--rerun", default=None, metavar="REPORT_JSON",
+        help="Rerun only divergent samples from a previous JSON report",
+    )
+    bc.add_argument(
+        "--rerun-merge", action="store_true", default=False,
+        help="Merge rerun results back into the original report file",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -296,6 +304,11 @@ async def _run_healthcheck(args: argparse.Namespace) -> None:
 
 async def _run_batch_compare(args: argparse.Namespace) -> None:
     """Run batch dataset comparison."""
+    # Handle rerun mode
+    if getattr(args, "rerun", None):
+        await _run_rerun(args)
+        return
+
     # Handle dry run mode
     if getattr(args, "dry_run", False):
         from xpyd_acc.dry_run import format_dry_run, run_dry_run
@@ -421,6 +434,128 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
 
     if args.json_path:
         from pathlib import Path
+        Path(args.json_path).write_text(report.to_json())
+        print(f"\nJSON exported to {args.json_path}")
+
+    if args.markdown:
+        export_markdown(report, args.markdown)
+        print(f"\nMarkdown exported to {args.markdown}")
+
+    if report.divergent_samples > 0:
+        sys.exit(1)
+
+
+async def _run_rerun(args: argparse.Namespace) -> None:
+    """Run selective sample rerun from a previous report."""
+    from pathlib import Path
+
+    from xpyd_acc.batch_compare import (
+        export_csv,
+        export_markdown,
+        format_report,
+        run_batch,
+    )
+    from xpyd_acc.rerun import load_divergent_samples, merge_rerun_results
+
+    plan = load_divergent_samples(args.rerun)
+    print(
+        f"Rerun: {plan.divergent_count} divergent samples "
+        f"out of {plan.total_in_report} total"
+    )
+
+    if not args.skip_healthcheck:
+        await _preflight_healthcheck([args.baseline, args.target], api_key=args.api_key)
+
+    # Apply template if specified
+    if args.template:
+        from xpyd_acc.templates import resolve_template
+
+        template = resolve_template(args.template)
+        print(f"Using template: {template.name}")
+        for sample in plan.divergent_samples:
+            variables = {"prompt": sample.prompt, **sample.metadata}
+            sample.prompt = template.render(variables)
+
+    # Set up Rich progress bar unless disabled or non-TTY
+    use_progress = not args.no_progress and sys.stderr.isatty()
+    progress_ctx = None
+    task_id = None
+
+    if use_progress:
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            TextColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+        )
+
+        progress_ctx = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("•"),
+            TimeElapsedColumn(),
+            TextColumn("•"),
+            TimeRemainingColumn(),
+        )
+
+    def on_progress(completed: int, total: int) -> None:
+        if progress_ctx is not None and task_id is not None:
+            progress_ctx.update(task_id, completed=completed)
+
+    if progress_ctx is not None:
+        progress_ctx.start()
+        task_id = progress_ctx.add_task("Rerunning samples", total=len(plan.divergent_samples))
+
+    try:
+        from xpyd_acc.output_compare import MatchConfig
+
+        match_config = MatchConfig(
+            normalize_whitespace=args.normalize_whitespace,
+            ignore_case=args.ignore_case,
+            numeric_tolerance=args.numeric_tolerance,
+        )
+        effective_match = match_config if (
+            match_config.normalize_whitespace
+            or match_config.ignore_case
+            or match_config.numeric_tolerance is not None
+        ) else None
+
+        report = await run_batch(
+            plan.divergent_samples,
+            args.baseline,
+            args.target,
+            model=args.model,
+            max_tokens=args.max_tokens,
+            api_key=args.api_key,
+            logprob_gap_threshold=args.logprob_gap_threshold,
+            concurrency=args.concurrency,
+            retries=args.retries,
+            retry_delay=args.retry_delay,
+            on_progress=on_progress if use_progress else None,
+            match_config=effective_match,
+        )
+    finally:
+        if progress_ctx is not None:
+            progress_ctx.stop()
+
+    # Handle merge mode
+    if args.rerun_merge:
+        report = merge_rerun_results(args.rerun, report)
+        # Overwrite the original report
+        Path(args.rerun).write_text(report.to_json())
+        print(f"\nMerged results written back to {args.rerun}")
+
+    print()
+    print(format_report(report))
+
+    if args.csv:
+        export_csv(report, args.csv)
+        print(f"\nCSV exported to {args.csv}")
+
+    if args.json_path:
         Path(args.json_path).write_text(report.to_json())
         print(f"\nJSON exported to {args.json_path}")
 

--- a/src/xpyd_acc/rerun.py
+++ b/src/xpyd_acc/rerun.py
@@ -1,0 +1,134 @@
+"""Selective sample rerun: rerun only divergent samples from a previous batch report."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from xpyd_acc.batch_compare import BatchReport, DatasetSample, SampleResult, compute_report
+
+
+@dataclass
+class RerunPlan:
+    """Plan for which samples to rerun."""
+
+    divergent_samples: list[DatasetSample]
+    total_in_report: int
+    divergent_count: int
+
+
+def load_divergent_samples(report_path: str | Path) -> RerunPlan:
+    """Load a previous JSON report and extract divergent samples for rerun.
+
+    Args:
+        report_path: Path to a batch comparison JSON report.
+
+    Returns:
+        RerunPlan with the divergent samples as DatasetSample objects.
+
+    Raises:
+        FileNotFoundError: If the report file does not exist.
+        json.JSONDecodeError: If the file is not valid JSON.
+        ValueError: If the report is missing required fields or has no divergent samples.
+    """
+    path = Path(report_path)
+    if not path.exists():
+        msg = f"Report file not found: {path}"
+        raise FileNotFoundError(msg)
+
+    text = path.read_text()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        msg = f"Invalid JSON in report file: {path}"
+        raise json.JSONDecodeError(msg, exc.doc, exc.pos) from exc
+
+    if not isinstance(data, dict) or "results" not in data:
+        msg = "Report JSON must contain a 'results' array"
+        raise ValueError(msg)
+
+    results = data["results"]
+    if not isinstance(results, list):
+        msg = "Report 'results' must be a list"
+        raise ValueError(msg)
+
+    divergent: list[DatasetSample] = []
+    for r in results:
+        if not r.get("exact_match", True):
+            divergent.append(
+                DatasetSample(
+                    id=r.get("sample_id", "unknown"),
+                    prompt=r.get("prompt", ""),
+                    metadata=r.get("metadata", {}),
+                )
+            )
+
+    if not divergent:
+        msg = "No divergent samples found in report — nothing to rerun"
+        raise ValueError(msg)
+
+    return RerunPlan(
+        divergent_samples=divergent,
+        total_in_report=data.get("total_samples", len(results)),
+        divergent_count=len(divergent),
+    )
+
+
+def merge_rerun_results(
+    original_path: str | Path,
+    rerun_report: BatchReport,
+) -> BatchReport:
+    """Merge rerun results back into the original report.
+
+    Replaces original results for rerun sample IDs with the new results,
+    then recomputes report statistics.
+
+    Args:
+        original_path: Path to the original JSON report.
+        rerun_report: The report from the rerun.
+
+    Returns:
+        A new BatchReport combining original + rerun results.
+    """
+    path = Path(original_path)
+    data = json.loads(path.read_text())
+
+    # Build lookup of rerun results by sample_id
+    rerun_by_id: dict[str, SampleResult] = {
+        r.sample_id: r for r in rerun_report.results
+    }
+
+    # Rebuild results: replace rerun samples, keep others
+    original_results = _parse_sample_results(data["results"])
+    merged: list[SampleResult] = []
+    for r in original_results:
+        if r.sample_id in rerun_by_id:
+            merged.append(rerun_by_id[r.sample_id])
+        else:
+            merged.append(r)
+
+    return compute_report(merged)
+
+
+def _parse_sample_results(results_data: list[dict[str, Any]]) -> list[SampleResult]:
+    """Parse raw JSON result dicts into SampleResult objects."""
+    parsed: list[SampleResult] = []
+    for r in results_data:
+        parsed.append(
+            SampleResult(
+                sample_id=r["sample_id"],
+                prompt=r["prompt"],
+                baseline_output=r["baseline_output"],
+                target_output=r["target_output"],
+                exact_match=r["exact_match"],
+                first_divergence_index=r.get("first_divergence_index"),
+                baseline_logprob_at_divergence=r.get("baseline_logprob_at_divergence"),
+                target_logprob_at_divergence=r.get("target_logprob_at_divergence"),
+                logprob_gap=r.get("logprob_gap"),
+                classification=r.get("classification", "unknown"),
+                context_length=r.get("context_length", 0),
+            )
+        )
+    return parsed

--- a/tests/test_rerun.py
+++ b/tests/test_rerun.py
@@ -1,0 +1,204 @@
+"""Tests for selective sample rerun (M23)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.rerun import (
+    RerunPlan,
+    _parse_sample_results,
+    load_divergent_samples,
+    merge_rerun_results,
+)
+
+
+def _make_report_json(results: list[dict], total: int | None = None) -> str:
+    """Helper to create a report JSON string."""
+    if total is None:
+        total = len(results)
+    data = {
+        "total_samples": total,
+        "divergent_samples": sum(1 for r in results if not r.get("exact_match", True)),
+        "match_samples": sum(1 for r in results if r.get("exact_match", True)),
+        "divergence_rate": 0.0,
+        "divergence_index_mean": None,
+        "divergence_index_median": None,
+        "logprob_gap_mean": None,
+        "logprob_gap_median": None,
+        "likely_bugs": 0,
+        "likely_uncertainty": 0,
+        "unknown_classification": 0,
+        "divergence_by_context_length": {},
+        "results": results,
+    }
+    return json.dumps(data)
+
+
+def _sample_result(sample_id: str, match: bool, prompt: str = "test") -> dict:
+    """Create a sample result dict."""
+    return {
+        "sample_id": sample_id,
+        "prompt": prompt,
+        "baseline_output": "hello",
+        "target_output": "hello" if match else "world",
+        "exact_match": match,
+        "first_divergence_index": None if match else 0,
+        "baseline_logprob_at_divergence": None,
+        "target_logprob_at_divergence": None,
+        "logprob_gap": None,
+        "classification": "match" if match else "likely_bug",
+        "context_length": 5,
+    }
+
+
+class TestLoadDivergentSamples:
+    """Tests for load_divergent_samples."""
+
+    def test_basic_load(self, tmp_path: Path) -> None:
+        results = [
+            _sample_result("s1", match=True),
+            _sample_result("s2", match=False),
+            _sample_result("s3", match=False, prompt="other"),
+        ]
+        report = tmp_path / "report.json"
+        report.write_text(_make_report_json(results))
+
+        plan = load_divergent_samples(report)
+        assert isinstance(plan, RerunPlan)
+        assert plan.divergent_count == 2
+        assert plan.total_in_report == 3
+        assert len(plan.divergent_samples) == 2
+        ids = {s.id for s in plan.divergent_samples}
+        assert ids == {"s2", "s3"}
+
+    def test_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError, match="not found"):
+            load_divergent_samples("/nonexistent/report.json")
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        report = tmp_path / "bad.json"
+        report.write_text("not json at all")
+        with pytest.raises(json.JSONDecodeError):
+            load_divergent_samples(report)
+
+    def test_missing_results_key(self, tmp_path: Path) -> None:
+        report = tmp_path / "report.json"
+        report.write_text(json.dumps({"total_samples": 5}))
+        with pytest.raises(ValueError, match="results"):
+            load_divergent_samples(report)
+
+    def test_no_divergent_samples(self, tmp_path: Path) -> None:
+        results = [_sample_result("s1", match=True), _sample_result("s2", match=True)]
+        report = tmp_path / "report.json"
+        report.write_text(_make_report_json(results))
+        with pytest.raises(ValueError, match="No divergent"):
+            load_divergent_samples(report)
+
+    def test_all_divergent(self, tmp_path: Path) -> None:
+        results = [_sample_result("s1", match=False), _sample_result("s2", match=False)]
+        report = tmp_path / "report.json"
+        report.write_text(_make_report_json(results))
+        plan = load_divergent_samples(report)
+        assert plan.divergent_count == 2
+        assert plan.total_in_report == 2
+
+    def test_preserves_prompt(self, tmp_path: Path) -> None:
+        results = [_sample_result("s1", match=False, prompt="my special prompt")]
+        report = tmp_path / "report.json"
+        report.write_text(_make_report_json(results))
+        plan = load_divergent_samples(report)
+        assert plan.divergent_samples[0].prompt == "my special prompt"
+
+
+class TestMergeRerunResults:
+    """Tests for merge_rerun_results."""
+
+    def test_basic_merge(self, tmp_path: Path) -> None:
+        # Original: s1 match, s2 diverges, s3 match
+        original_results = [
+            _sample_result("s1", match=True),
+            _sample_result("s2", match=False),
+            _sample_result("s3", match=True),
+        ]
+        report_path = tmp_path / "report.json"
+        report_path.write_text(_make_report_json(original_results))
+
+        # Rerun: s2 now matches
+        from xpyd_acc.batch_compare import SampleResult, compute_report
+
+        rerun_result = SampleResult(
+            sample_id="s2",
+            prompt="test",
+            baseline_output="hello",
+            target_output="hello",
+            exact_match=True,
+            first_divergence_index=None,
+            baseline_logprob_at_divergence=None,
+            target_logprob_at_divergence=None,
+            logprob_gap=None,
+            classification="match",
+            context_length=5,
+        )
+        rerun_report = compute_report([rerun_result])
+
+        merged = merge_rerun_results(report_path, rerun_report)
+        assert merged.total_samples == 3
+        assert merged.match_samples == 3
+        assert merged.divergent_samples == 0
+
+    def test_merge_still_divergent(self, tmp_path: Path) -> None:
+        original_results = [
+            _sample_result("s1", match=True),
+            _sample_result("s2", match=False),
+        ]
+        report_path = tmp_path / "report.json"
+        report_path.write_text(_make_report_json(original_results))
+
+        from xpyd_acc.batch_compare import SampleResult, compute_report
+
+        rerun_result = SampleResult(
+            sample_id="s2",
+            prompt="test",
+            baseline_output="hello",
+            target_output="different",
+            exact_match=False,
+            first_divergence_index=0,
+            baseline_logprob_at_divergence=None,
+            target_logprob_at_divergence=None,
+            logprob_gap=None,
+            classification="likely_bug",
+            context_length=5,
+        )
+        rerun_report = compute_report([rerun_result])
+
+        merged = merge_rerun_results(report_path, rerun_report)
+        assert merged.total_samples == 2
+        assert merged.divergent_samples == 1
+
+
+class TestParseSampleResults:
+    """Tests for _parse_sample_results."""
+
+    def test_parses_correctly(self) -> None:
+        data = [_sample_result("s1", match=True), _sample_result("s2", match=False)]
+        parsed = _parse_sample_results(data)
+        assert len(parsed) == 2
+        assert parsed[0].sample_id == "s1"
+        assert parsed[0].exact_match is True
+        assert parsed[1].sample_id == "s2"
+        assert parsed[1].exact_match is False
+
+    def test_handles_missing_optional_fields(self) -> None:
+        data = [{
+            "sample_id": "s1",
+            "prompt": "test",
+            "baseline_output": "a",
+            "target_output": "b",
+            "exact_match": False,
+        }]
+        parsed = _parse_sample_results(data)
+        assert parsed[0].classification == "unknown"
+        assert parsed[0].context_length == 0


### PR DESCRIPTION
## Summary

Add `--rerun` flag to `batch-compare` that reruns only divergent samples from a previous JSON report, saving time and API calls when retesting after fixes.

## Changes

- **`rerun.py` module** with:
  - `load_divergent_samples()`: parse previous report, extract divergent samples
  - `merge_rerun_results()`: merge rerun results back into original report
  - `RerunPlan` dataclass for rerun planning
- **CLI flags** on `batch-compare`:
  - `--rerun <report.json>`: rerun only divergent samples
  - `--rerun-merge`: merge results back into original report file
- **11 test cases** covering: basic load, file not found, invalid JSON, missing fields, no divergent samples, all divergent, prompt preservation, merge (fix + still divergent), parse with missing optional fields

## Testing

All 299 tests pass. Lint clean (ruff + isort).

Closes #53