### PR TITLE
feat: M24 - Sampling Parameter Support (temperature, top_p, seed)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -163,3 +163,11 @@
 - Merge mode: `--rerun-merge` combines rerun results back into the original report
 - Useful for quick retesting after fixes without rerunning the full dataset
 - Exit code reflects rerun results (0 = all match, 1 = still divergent)
+
+## M24: Sampling Parameter Support
+- CLI flags: `--temperature`, `--top-p`, `--seed` for all comparison commands
+- Propagated to logprobs collection, batch comparison, streaming, and diagnose
+- TOML config support in `[defaults]` section
+- `temperature=0` + `seed` enables deterministic/reproducible comparisons
+- Environment variables: `XPYD_ACC_TEMPERATURE`, `XPYD_ACC_TOP_P`, `XPYD_ACC_SEED`
+- All flags default to None (server decides) to preserve backward compatibility

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -186,6 +186,7 @@ async def _collect_output(
     api_key: str = "no-key",
     retries: int = 3,
     retry_delay: float = 1.0,
+    sampling_params: Any | None = None,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list).
 
@@ -196,13 +197,15 @@ async def _collect_output(
 
     from xpyd_acc.retry import retry_async
 
-    payload = {
+    payload: dict[str, Any] = {
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": max_tokens,
         "logprobs": True,
         "top_logprobs": 5,
     }
+    if sampling_params is not None:
+        payload.update(sampling_params.to_payload())
     headers = {"Authorization": f"Bearer {api_key}"}
 
     async def _do_request() -> tuple[str, list[dict[str, Any]]]:
@@ -234,6 +237,7 @@ async def run_batch(
     retry_delay: float = 1.0,
     on_progress: Callable[[int, int], None] | None = None,
     match_config: Any | None = None,
+    sampling_params: Any | None = None,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report.
 
@@ -251,11 +255,13 @@ async def run_batch(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
+                sampling_params=sampling_params,
             )
             target_text, target_lp = await _collect_output(
                 target_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
+                sampling_params=sampling_params,
             )
 
         b_tokens = _tokenize(baseline_text)

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -16,6 +16,22 @@ def _get_version() -> str:
         return "unknown"
 
 
+def _add_sampling_args(parser: argparse.ArgumentParser) -> None:
+    """Add --temperature, --top-p, --seed flags to a subcommand parser."""
+    parser.add_argument(
+        "--temperature", type=float, default=None,
+        help="Sampling temperature (0 for greedy/deterministic)",
+    )
+    parser.add_argument(
+        "--top-p", type=float, default=None, dest="top_p",
+        help="Nucleus sampling top-p value",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=None,
+        help="Random seed for reproducible generation",
+    )
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(
         prog="xpyd-acc",
@@ -44,6 +60,7 @@ def main(argv: list[str] | None = None) -> None:
         "--retry-delay", type=float, default=None,
         help="Base retry delay in seconds (default: 1.0)",
     )
+    _add_sampling_args(lp)
 
     diag = sub.add_parser("diagnose", help="Run full diagnostic pipeline")
     diag.add_argument("--baseline", required=True, help="Baseline endpoint URL")
@@ -68,6 +85,7 @@ def main(argv: list[str] | None = None) -> None:
         help="KV cache cosine similarity threshold (default: 0.999)",
     )
     diag.add_argument("--json", action="store_true", help="Output report as JSON")
+    _add_sampling_args(diag)
 
     oc = sub.add_parser("compare-output", help="Compare text outputs from two endpoints")
     oc_input = oc.add_mutually_exclusive_group(required=True)
@@ -135,6 +153,7 @@ def main(argv: list[str] | None = None) -> None:
         "--rerun-merge", action="store_true", default=False,
         help="Merge rerun results back into the original report file",
     )
+    _add_sampling_args(bc)
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -168,6 +187,7 @@ def main(argv: list[str] | None = None) -> None:
         "--numeric-tolerance", type=float, default=None,
         help="Treat numbers within tolerance as equal",
     )
+    _add_sampling_args(cs)
 
     hc = sub.add_parser("healthcheck", help="Check endpoint health")
     hc.add_argument("url", nargs="+", help="Endpoint URL(s) to check")
@@ -232,6 +252,14 @@ def main(argv: list[str] | None = None) -> None:
     for key, env_val in _ENV_MAPPING.items():
         if env_val is not None and hasattr(args, key) and getattr(args, key) is None:
             setattr(args, key, env_val)
+
+    # Apply numeric env defaults separately (typed)
+    if env.temperature is not None and hasattr(args, "temperature") and args.temperature is None:
+        args.temperature = env.temperature
+    if env.top_p is not None and hasattr(args, "top_p") and args.top_p is None:
+        args.top_p = env.top_p
+    if env.seed is not None and hasattr(args, "seed") and args.seed is None:
+        args.seed = env.seed
 
     # Apply hardcoded defaults for any remaining None values
     _FINAL_DEFAULTS: dict[str, object] = {
@@ -341,7 +369,9 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         load_dataset,
         run_batch,
     )
+    from xpyd_acc.sampling import SamplingParams
 
+    sampling = SamplingParams.from_args(args)
     samples = load_dataset(args.dataset)
 
     # Apply template if specified
@@ -420,6 +450,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             retry_delay=args.retry_delay,
             on_progress=on_progress if use_progress else None,
             match_config=effective_match,
+            sampling_params=sampling,
         )
     finally:
         if progress_ctx is not None:
@@ -456,6 +487,9 @@ async def _run_rerun(args: argparse.Namespace) -> None:
         run_batch,
     )
     from xpyd_acc.rerun import load_divergent_samples, merge_rerun_results
+    from xpyd_acc.sampling import SamplingParams
+
+    sampling = SamplingParams.from_args(args)
 
     plan = load_divergent_samples(args.rerun)
     print(
@@ -536,6 +570,7 @@ async def _run_rerun(args: argparse.Namespace) -> None:
             retry_delay=args.retry_delay,
             on_progress=on_progress if use_progress else None,
             match_config=effective_match,
+            sampling_params=sampling,
         )
     finally:
         if progress_ctx is not None:
@@ -597,7 +632,9 @@ def _run_compare_output(args: argparse.Namespace) -> None:
 async def _run_compare_logprobs(args: argparse.Namespace) -> None:
     """Run logprobs comparison between two endpoints."""
     from xpyd_acc.logprobs import LogprobsCollector, LogprobsComparator
+    from xpyd_acc.sampling import SamplingParams
 
+    sampling = SamplingParams.from_args(args)
     baseline_collector = LogprobsCollector(args.baseline, api_key=args.api_key, model=args.model)
     target_collector = LogprobsCollector(args.target, api_key=args.api_key, model=args.model)
 
@@ -605,12 +642,14 @@ async def _run_compare_logprobs(args: argparse.Namespace) -> None:
     baseline_result = await baseline_collector.collect(
         args.prompt, max_tokens=args.max_tokens,
         retries=args.retries, retry_delay=args.retry_delay,
+        sampling_params=sampling,
     )
 
     print(f"Collecting logprobs from target: {args.target}")
     target_result = await target_collector.collect(
         args.prompt, max_tokens=args.max_tokens,
         retries=args.retries, retry_delay=args.retry_delay,
+        sampling_params=sampling,
     )
 
     comparator = LogprobsComparator()
@@ -625,7 +664,9 @@ async def _run_compare_logprobs(args: argparse.Namespace) -> None:
 async def _run_diagnose(args: argparse.Namespace) -> None:
     """Run the full diagnostic pipeline."""
     from xpyd_acc.diagnose import DiagnosticPipeline, format_rich_report
+    from xpyd_acc.sampling import SamplingParams
 
+    sampling = SamplingParams.from_args(args)
     pipeline = DiagnosticPipeline(
         baseline_url=args.baseline,
         target_url=args.target,
@@ -637,6 +678,7 @@ async def _run_diagnose(args: argparse.Namespace) -> None:
         kv_target_path=args.kv_target,
         kv_max_abs_threshold=args.kv_max_abs_threshold,
         kv_cosine_threshold=args.kv_cosine_threshold,
+        sampling_params=sampling,
     )
 
     report = await pipeline.run()
@@ -654,6 +696,7 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
     """Run streaming comparison between two endpoints."""
     import time as time_mod
 
+    from xpyd_acc.sampling import SamplingParams
     from xpyd_acc.streaming import (
         StreamingCollector,
         StreamingComparator,
@@ -661,6 +704,7 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
         format_streaming_report,
     )
 
+    sampling = SamplingParams.from_args(args)
     baseline = StreamingCollector(args.baseline, api_key=args.api_key, model=args.model)
     target = StreamingCollector(args.target, api_key=args.api_key, model=args.model)
 
@@ -688,12 +732,14 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
         baseline_start = time_mod.monotonic()
         baseline_tokens = await collect_stream(
             baseline, args.prompt, max_tokens=args.max_tokens, timeout=args.timeout,
+            sampling_params=sampling,
         )
         baseline_elapsed = time_mod.monotonic() - baseline_start
 
         target_start = time_mod.monotonic()
         target_tokens = await collect_stream(
             target, args.prompt, max_tokens=args.max_tokens, timeout=args.timeout,
+            sampling_params=sampling,
         )
         target_elapsed = time_mod.monotonic() - target_start
 
@@ -733,6 +779,7 @@ async def _run_compare_streaming(args: argparse.Namespace) -> None:
             max_tokens=args.max_tokens,
             timeout=args.timeout,
             match_config=_eff_match2,
+            sampling_params=sampling,
         )
         print()
         print(format_streaming_report(report))

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -33,6 +33,9 @@ class DefaultsConfig:
     max_tokens: int = 64
     retries: int = 3
     retry_delay: float = 1.0
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
 
 
 @dataclass
@@ -152,6 +155,9 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
         "max_tokens": config.defaults.max_tokens,
         "retries": config.defaults.retries,
         "retry_delay": config.defaults.retry_delay,
+        "temperature": config.defaults.temperature,
+        "top_p": config.defaults.top_p,
+        "seed": config.defaults.seed,
     }
 
     for key, config_val in defaults_map.items():

--- a/src/xpyd_acc/diagnose.py
+++ b/src/xpyd_acc/diagnose.py
@@ -61,6 +61,7 @@ class DiagnosticPipeline:
         kv_target_path: str | None = None,
         kv_max_abs_threshold: float = 1e-3,
         kv_cosine_threshold: float = 0.999,
+        sampling_params: object | None = None,
     ) -> None:
         self.baseline_url = baseline_url
         self.target_url = target_url
@@ -72,6 +73,7 @@ class DiagnosticPipeline:
         self.kv_target_path = kv_target_path
         self.kv_max_abs_threshold = kv_max_abs_threshold
         self.kv_cosine_threshold = kv_cosine_threshold
+        self.sampling_params = sampling_params
 
     async def run(self) -> DiagnosticReport:
         """Execute all diagnostic steps and return the report."""
@@ -228,8 +230,12 @@ class DiagnosticPipeline:
             self.target_url, api_key=self.api_key, model=self.model,
         )
 
-        baseline_result = await baseline_collector.collect(self.prompt, max_tokens=max_tokens)
-        target_result = await target_collector.collect(self.prompt, max_tokens=max_tokens)
+        baseline_result = await baseline_collector.collect(
+            self.prompt, max_tokens=max_tokens, sampling_params=self.sampling_params,
+        )
+        target_result = await target_collector.collect(
+            self.prompt, max_tokens=max_tokens, sampling_params=self.sampling_params,
+        )
 
         comparator = LogprobsComparator()
         return comparator.compare(baseline_result, target_result)

--- a/src/xpyd_acc/env.py
+++ b/src/xpyd_acc/env.py
@@ -10,6 +10,9 @@ ENV_API_KEY = "XPYD_ACC_API_KEY"
 ENV_BASELINE_URL = "XPYD_ACC_BASELINE_URL"
 ENV_TARGET_URL = "XPYD_ACC_TARGET_URL"
 ENV_MODEL = "XPYD_ACC_MODEL"
+ENV_TEMPERATURE = "XPYD_ACC_TEMPERATURE"
+ENV_TOP_P = "XPYD_ACC_TOP_P"
+ENV_SEED = "XPYD_ACC_SEED"
 
 
 @dataclass
@@ -20,6 +23,9 @@ class EnvDefaults:
     baseline_url: str | None = None
     target_url: str | None = None
     model: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
 
 
 def get_env_defaults() -> EnvDefaults:
@@ -28,11 +34,18 @@ def get_env_defaults() -> EnvDefaults:
     Returns an EnvDefaults with non-None values only for variables that are set
     and non-empty in the environment.
     """
+    temp_str = os.environ.get(ENV_TEMPERATURE) or None
+    top_p_str = os.environ.get(ENV_TOP_P) or None
+    seed_str = os.environ.get(ENV_SEED) or None
+
     return EnvDefaults(
         api_key=os.environ.get(ENV_API_KEY) or None,
         baseline_url=os.environ.get(ENV_BASELINE_URL) or None,
         target_url=os.environ.get(ENV_TARGET_URL) or None,
         model=os.environ.get(ENV_MODEL) or None,
+        temperature=float(temp_str) if temp_str is not None else None,
+        top_p=float(top_p_str) if top_p_str is not None else None,
+        seed=int(seed_str) if seed_str is not None else None,
     )
 
 

--- a/src/xpyd_acc/logprobs.py
+++ b/src/xpyd_acc/logprobs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 import httpx
 
@@ -64,19 +65,22 @@ class LogprobsCollector:
         timeout: float = 30.0,
         retries: int = 3,
         retry_delay: float = 1.0,
+        sampling_params: Any | None = None,
     ) -> LogprobsResult:
         """Send prompt and collect logprobs from the completions endpoint."""
         from xpyd_acc.retry import retry_async
 
         url = f"{self.base_url}/v1/chat/completions"
         headers = {"Authorization": f"Bearer {self.api_key}"}
-        payload = {
+        payload: dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": max_tokens,
             "logprobs": True,
             "top_logprobs": 1,
         }
+        if sampling_params is not None:
+            payload.update(sampling_params.to_payload())
 
         async def _do_request() -> dict:
             async with httpx.AsyncClient(timeout=timeout) as client:

--- a/src/xpyd_acc/sampling.py
+++ b/src/xpyd_acc/sampling.py
@@ -1,0 +1,35 @@
+"""Sampling parameter utilities for reproducible LLM comparisons."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class SamplingParams:
+    """Sampling parameters for LLM requests."""
+
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return non-None params as a dict suitable for API payloads."""
+        d: dict[str, Any] = {}
+        if self.temperature is not None:
+            d["temperature"] = self.temperature
+        if self.top_p is not None:
+            d["top_p"] = self.top_p
+        if self.seed is not None:
+            d["seed"] = self.seed
+        return d
+
+    @classmethod
+    def from_args(cls, args: Any) -> SamplingParams:
+        """Create from an argparse Namespace (attributes may be absent)."""
+        return cls(
+            temperature=getattr(args, "temperature", None),
+            top_p=getattr(args, "top_p", None),
+            seed=getattr(args, "seed", None),
+        )

--- a/src/xpyd_acc/streaming.py
+++ b/src/xpyd_acc/streaming.py
@@ -64,6 +64,7 @@ class StreamingCollector:
         max_tokens: int = 64,
         *,
         timeout: float = 60.0,
+        sampling_params: Any | None = None,
     ) -> AsyncIterator[StreamToken]:
         """Send prompt and yield tokens as they arrive via SSE.
 
@@ -72,12 +73,14 @@ class StreamingCollector:
         """
         url = f"{self.base_url}/v1/chat/completions"
         headers = {"Authorization": f"Bearer {self.api_key}"}
-        payload = {
+        payload: dict[str, Any] = {
             "model": self.model,
             "messages": [{"role": "user", "content": prompt}],
             "max_tokens": max_tokens,
             "stream": True,
         }
+        if sampling_params is not None:
+            payload.update(sampling_params.to_payload())
 
         index = 0
         async with httpx.AsyncClient(timeout=timeout) as client:
@@ -120,10 +123,13 @@ async def collect_stream(
     max_tokens: int = 64,
     *,
     timeout: float = 60.0,
+    sampling_params: Any | None = None,
 ) -> list[StreamToken]:
     """Collect all tokens from a streaming endpoint into a list."""
     tokens: list[StreamToken] = []
-    async for token in collector.stream(prompt, max_tokens, timeout=timeout):
+    async for token in collector.stream(
+        prompt, max_tokens, timeout=timeout, sampling_params=sampling_params,
+    ):
         tokens.append(token)
     return tokens
 
@@ -141,6 +147,7 @@ class StreamingComparator:
         timeout: float = 60.0,
         on_token: None = None,
         match_config: Any | None = None,
+        sampling_params: Any | None = None,
     ) -> StreamingComparisonReport:
         """Run both streams in parallel and compare tokens as they arrive.
 
@@ -159,8 +166,10 @@ class StreamingComparator:
 
         # Collect both streams concurrently
         baseline_tokens, target_tokens = await asyncio.gather(
-            collect_stream(baseline, prompt, max_tokens, timeout=timeout),
-            collect_stream(target, prompt, max_tokens, timeout=timeout),
+            collect_stream(baseline, prompt, max_tokens, timeout=timeout,
+                           sampling_params=sampling_params),
+            collect_stream(target, prompt, max_tokens, timeout=timeout,
+                           sampling_params=sampling_params),
         )
 
         elapsed = time.monotonic() - start

--- a/tests/test_diagnose.py
+++ b/tests/test_diagnose.py
@@ -36,7 +36,7 @@ def _mock_collect_factory(tokens_a: list[tuple[str, float]], tokens_b: list[tupl
     """Return a side_effect function that returns different results per endpoint."""
     call_count = 0
 
-    async def _collect(prompt, max_tokens=64):
+    async def _collect(prompt, max_tokens=64, **kwargs):
         nonlocal call_count
         call_count += 1
         if call_count % 2 == 1:  # odd calls = baseline

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,219 @@
+"""Tests for M24: Sampling Parameter Support."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xpyd_acc.sampling import SamplingParams
+
+
+class TestSamplingParams:
+    """Tests for SamplingParams dataclass."""
+
+    def test_defaults_are_none(self) -> None:
+        sp = SamplingParams()
+        assert sp.temperature is None
+        assert sp.top_p is None
+        assert sp.seed is None
+
+    def test_to_payload_empty(self) -> None:
+        sp = SamplingParams()
+        assert sp.to_payload() == {}
+
+    def test_to_payload_all_set(self) -> None:
+        sp = SamplingParams(temperature=0.0, top_p=0.9, seed=42)
+        payload = sp.to_payload()
+        assert payload == {"temperature": 0.0, "top_p": 0.9, "seed": 42}
+
+    def test_to_payload_partial(self) -> None:
+        sp = SamplingParams(temperature=0.5)
+        assert sp.to_payload() == {"temperature": 0.5}
+
+    def test_from_args(self) -> None:
+        args = MagicMock()
+        args.temperature = 0.7
+        args.top_p = 0.95
+        args.seed = 123
+        sp = SamplingParams.from_args(args)
+        assert sp.temperature == 0.7
+        assert sp.top_p == 0.95
+        assert sp.seed == 123
+
+    def test_from_args_missing_attrs(self) -> None:
+        """from_args handles missing attributes gracefully."""
+        args = MagicMock(spec=[])  # empty spec = no attributes
+        sp = SamplingParams.from_args(args)
+        assert sp.temperature is None
+        assert sp.top_p is None
+        assert sp.seed is None
+
+
+class TestLogprobsSamplingParams:
+    """Test that LogprobsCollector passes sampling params to payload."""
+
+    @pytest.mark.asyncio
+    async def test_collect_includes_sampling_params(self) -> None:
+        from xpyd_acc.logprobs import LogprobsCollector
+
+        collector = LogprobsCollector("http://localhost:8000", model="test")
+        sampling = SamplingParams(temperature=0.0, seed=42)
+
+        captured_payload: dict = {}
+
+        async def mock_post(url, json=None, headers=None):
+            captured_payload.update(json)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "model": "test",
+                "choices": [
+                    {
+                        "message": {"content": "hello"},
+                        "logprobs": {"content": []},
+                    }
+                ],
+            }
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await collector.collect("test", sampling_params=sampling, retries=0)
+
+        assert captured_payload["temperature"] == 0.0
+        assert captured_payload["seed"] == 42
+        assert "top_p" not in captured_payload
+
+    @pytest.mark.asyncio
+    async def test_collect_no_sampling_params(self) -> None:
+        from xpyd_acc.logprobs import LogprobsCollector
+
+        collector = LogprobsCollector("http://localhost:8000", model="test")
+        captured_payload: dict = {}
+
+        async def mock_post(url, json=None, headers=None):
+            captured_payload.update(json)
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "model": "test",
+                "choices": [
+                    {
+                        "message": {"content": "hello"},
+                        "logprobs": {"content": []},
+                    }
+                ],
+            }
+            return resp
+
+        mock_client = AsyncMock()
+        mock_client.post = mock_post
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            await collector.collect("test", retries=0)
+
+        assert "temperature" not in captured_payload
+        assert "seed" not in captured_payload
+
+
+class TestConfigSamplingParams:
+    """Test TOML config support for sampling params."""
+
+    def test_defaults_config_has_sampling_fields(self) -> None:
+        from xpyd_acc.config import DefaultsConfig
+
+        cfg = DefaultsConfig()
+        assert cfg.temperature is None
+        assert cfg.top_p is None
+        assert cfg.seed is None
+
+    def test_load_config_with_sampling(self, tmp_path) -> None:
+        from xpyd_acc.config import load_config
+
+        toml_content = """
+[defaults]
+temperature = 0.0
+top_p = 0.95
+seed = 42
+"""
+        cfg_file = tmp_path / "xpyd-acc.toml"
+        cfg_file.write_text(toml_content)
+        config = load_config(cfg_file)
+        assert config.defaults.temperature == 0.0
+        assert config.defaults.top_p == 0.95
+        assert config.defaults.seed == 42
+
+    def test_merge_cli_args_sampling(self) -> None:
+        from xpyd_acc.config import AppConfig, DefaultsConfig, merge_cli_args
+
+        config = AppConfig(
+            defaults=DefaultsConfig(temperature=0.5, top_p=0.9, seed=100),
+        )
+        args = {
+            "temperature": None,
+            "top_p": 0.8,  # CLI override
+            "seed": None,
+            "command": "compare-logprobs",
+        }
+        merged = merge_cli_args(config, args, "compare-logprobs")
+        assert merged["temperature"] == 0.5  # from config
+        assert merged["top_p"] == 0.8  # CLI wins
+        assert merged["seed"] == 100  # from config
+
+
+class TestEnvSamplingParams:
+    """Test environment variable support for sampling params."""
+
+    def test_env_defaults_sampling(self) -> None:
+        from xpyd_acc.env import get_env_defaults
+
+        with patch.dict(os.environ, {
+            "XPYD_ACC_TEMPERATURE": "0.3",
+            "XPYD_ACC_TOP_P": "0.85",
+            "XPYD_ACC_SEED": "99",
+        }):
+            env = get_env_defaults()
+            assert env.temperature == 0.3
+            assert env.top_p == 0.85
+            assert env.seed == 99
+
+    def test_env_defaults_no_sampling(self) -> None:
+        from xpyd_acc.env import get_env_defaults
+
+        with patch.dict(os.environ, {}, clear=True):
+            env = get_env_defaults()
+            assert env.temperature is None
+            assert env.top_p is None
+            assert env.seed is None
+
+
+class TestCLISamplingArgs:
+    """Test CLI argument parsing for sampling params."""
+
+    def test_compare_logprobs_sampling_args(self) -> None:
+        # Just verify parsing doesn't fail
+        from unittest.mock import patch as _patch
+
+        from xpyd_acc.cli import main
+
+        with _patch("xpyd_acc.cli.asyncio") as mock_asyncio:
+            mock_asyncio.run = MagicMock()
+            main([
+                "compare-logprobs",
+                "--baseline", "http://a",
+                "--target", "http://b",
+                "--prompt", "test",
+                "--temperature", "0",
+                "--top-p", "0.9",
+                "--seed", "42",
+            ])
+            # If we get here, parsing succeeded
+            assert mock_asyncio.run.called


### PR DESCRIPTION
## Summary
Add sampling parameter support (`--temperature`, `--top-p`, `--seed`) across all comparison commands for reproducible accuracy testing.

Closes #55

## Changes
- **New module**: `src/xpyd_acc/sampling.py` — `SamplingParams` dataclass with `to_payload()` and `from_args()`
- **CLI**: Added `--temperature`, `--top-p`, `--seed` to `compare-logprobs`, `batch-compare`, `compare-streaming`, `diagnose`
- **Config**: `temperature`, `top_p`, `seed` in `DefaultsConfig` + merge support
- **Env vars**: `XPYD_ACC_TEMPERATURE`, `XPYD_ACC_TOP_P`, `XPYD_ACC_SEED`
- **Propagation**: All modules (logprobs, batch_compare, streaming, diagnose) accept and inject sampling params into API payloads
- **Tests**: 313 tests pass including new test_sampling.py (SamplingParams, payload injection, config, env, CLI)
- **ROADMAP**: Added M24 milestone

## Backward Compatibility
All params default to `None` — no behavior change for existing users.