### PR TITLE
feat: M25 - Named Profiles (Presets)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -19,6 +19,10 @@ def _get_version() -> str:
 def _add_sampling_args(parser: argparse.ArgumentParser) -> None:
     """Add --temperature, --top-p, --seed flags to a subcommand parser."""
     parser.add_argument(
+        "--profile", type=str, default=None,
+        help="Named profile/preset to activate (e.g., greedy, stochastic)",
+    )
+    parser.add_argument(
         "--temperature", type=float, default=None,
         help="Sampling temperature (0 for greedy/deterministic)",
     )
@@ -219,6 +223,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     kv.add_argument("--json", action="store_true", help="Output report as JSON")
 
+    sub.add_parser("profiles", help="List available named profiles")
+
     args = parser.parse_args(argv)
     if not args.command:
         parser.print_help()
@@ -238,6 +244,22 @@ def main(argv: list[str] | None = None) -> None:
         merged = merge_cli_args(config, args_dict, args.command)
         for key, val in merged.items():
             setattr(args, key, val)
+
+    # Apply named profile if --profile was specified
+    if hasattr(args, "profile") and args.profile is not None:
+        from xpyd_acc.profiles import apply_profile, parse_profiles, resolve_profile
+
+        user_profiles = parse_profiles(config.profiles_raw) if config is not None else None
+        try:
+            profile = resolve_profile(args.profile, user_profiles)
+        except KeyError as exc:
+            parser.error(str(exc))
+        apply_profile(vars(args), profile)
+
+    # Handle 'profiles' subcommand
+    if args.command == "profiles":
+        _run_profiles(config)
+        return
 
     # Apply environment variable defaults (priority: CLI > env > config > defaults)
     from xpyd_acc.env import get_env_defaults
@@ -316,6 +338,28 @@ async def _preflight_healthcheck(
         print("\nAborting: unhealthy endpoint(s). Use --skip-healthcheck to bypass.")
         sys.exit(1)
     print()
+
+
+def _run_profiles(config: object) -> None:
+    """List all available named profiles."""
+    from xpyd_acc.profiles import list_profiles, parse_profiles
+
+    user_profiles = parse_profiles(config.profiles_raw) if config is not None else None
+    all_profiles = list_profiles(user_profiles)
+
+    if not all_profiles:
+        print("No profiles available.")
+        return
+
+    print("Available profiles:\n")
+    for name in sorted(all_profiles):
+        profile = all_profiles[name]
+        settings = profile.to_dict()
+        if settings:
+            parts = [f"{k}={v}" for k, v in settings.items()]
+            print(f"  {name}: {', '.join(parts)}")
+        else:
+            print(f"  {name}: (empty)")
 
 
 async def _run_healthcheck(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -81,6 +81,7 @@ class AppConfig:
     kv: KVConfig = field(default_factory=KVConfig)
     report: ReportConfig = field(default_factory=ReportConfig)
     matching: MatchingConfig = field(default_factory=MatchingConfig)
+    profiles_raw: dict[str, Any] = field(default_factory=dict)
 
 
 def _parse_section(data: dict[str, Any], cls: type) -> Any:
@@ -115,8 +116,12 @@ def load_config(path: str | Path) -> AppConfig:
     kv = _parse_section(raw.get("kv", {}), KVConfig)
     report = _parse_section(raw.get("report", {}), ReportConfig)
     matching = _parse_section(raw.get("matching", {}), MatchingConfig)
+    profiles_raw = raw.get("profiles", {})
 
-    return AppConfig(defaults=defaults, batch=batch, kv=kv, report=report, matching=matching)
+    return AppConfig(
+        defaults=defaults, batch=batch, kv=kv, report=report,
+        matching=matching, profiles_raw=profiles_raw,
+    )
 
 
 def discover_config() -> AppConfig | None:

--- a/src/xpyd_acc/profiles.py
+++ b/src/xpyd_acc/profiles.py
@@ -1,0 +1,134 @@
+"""Named profile (preset) support for xpyd-acc.
+
+Profiles are named configuration presets that can be activated via
+``--profile <name>`` to reduce repetitive CLI flags.
+
+Built-in profiles are always available.  User-defined profiles live in
+``[profiles.<name>]`` TOML sections and override built-ins of the same name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any
+
+
+@dataclass
+class ProfileConfig:
+    """A named configuration profile (preset).
+
+    All fields are optional — only non-None values override the defaults.
+    """
+
+    model: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    seed: int | None = None
+    max_tokens: int | None = None
+    retries: int | None = None
+    retry_delay: float | None = None
+    normalize_whitespace: bool | None = None
+    ignore_case: bool | None = None
+    numeric_tolerance: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return non-None fields as a dict."""
+        return {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if getattr(self, f.name) is not None
+        }
+
+
+# ---------------------------------------------------------------------------
+# Built-in profiles
+# ---------------------------------------------------------------------------
+
+BUILTIN_PROFILES: dict[str, ProfileConfig] = {
+    "greedy": ProfileConfig(temperature=0.0, seed=42),
+    "stochastic": ProfileConfig(temperature=0.7),
+}
+
+
+def parse_profiles(raw: dict[str, Any]) -> dict[str, ProfileConfig]:
+    """Parse ``[profiles.*]`` TOML tables into ProfileConfig instances.
+
+    Unknown keys inside a profile section are silently ignored.
+
+    Args:
+        raw: The top-level parsed TOML dict (or the ``profiles`` sub-dict).
+
+    Returns:
+        Mapping of profile name → ProfileConfig.
+    """
+    profiles_section = raw.get("profiles", raw) if "profiles" in raw else raw
+    valid_fields = {f.name for f in ProfileConfig.__dataclass_fields__.values()}
+    result: dict[str, ProfileConfig] = {}
+    for name, values in profiles_section.items():
+        if not isinstance(values, dict):
+            continue
+        filtered = {k: v for k, v in values.items() if k in valid_fields}
+        result[name] = ProfileConfig(**filtered)
+    return result
+
+
+def resolve_profile(
+    name: str,
+    user_profiles: dict[str, ProfileConfig] | None = None,
+) -> ProfileConfig:
+    """Look up a profile by name.
+
+    User-defined profiles take precedence over built-ins.
+
+    Args:
+        name: Profile name to look up.
+        user_profiles: Profiles parsed from user config file.
+
+    Returns:
+        The resolved ProfileConfig.
+
+    Raises:
+        KeyError: If the profile name is not found.
+    """
+    if user_profiles and name in user_profiles:
+        return user_profiles[name]
+    if name in BUILTIN_PROFILES:
+        return BUILTIN_PROFILES[name]
+    available = sorted(set((user_profiles or {}).keys()) | set(BUILTIN_PROFILES.keys()))
+    raise KeyError(
+        f"Unknown profile '{name}'. Available profiles: {', '.join(available)}"
+    )
+
+
+def apply_profile(args: dict[str, Any], profile: ProfileConfig) -> dict[str, Any]:
+    """Apply profile values to an args dict.
+
+    Profile values fill in where the current value is None (or False for bools).
+    CLI flags (non-None) always win.
+
+    Args:
+        args: Mutable argument dict.
+        profile: Profile to apply.
+
+    Returns:
+        The same args dict, mutated in place.
+    """
+    for key, val in profile.to_dict().items():
+        if key in args:
+            current = args[key]
+            if current is None or current is False:
+                args[key] = val
+    return args
+
+
+def list_profiles(
+    user_profiles: dict[str, ProfileConfig] | None = None,
+) -> dict[str, ProfileConfig]:
+    """Return all available profiles (built-in + user-defined).
+
+    User-defined profiles override built-ins of the same name.
+    """
+    merged = dict(BUILTIN_PROFILES)
+    if user_profiles:
+        merged.update(user_profiles)
+    return merged

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,192 @@
+"""Tests for named profile (preset) support."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_acc.profiles import (
+    BUILTIN_PROFILES,
+    ProfileConfig,
+    apply_profile,
+    list_profiles,
+    parse_profiles,
+    resolve_profile,
+)
+
+# ---------------------------------------------------------------------------
+# ProfileConfig
+# ---------------------------------------------------------------------------
+
+class TestProfileConfig:
+    def test_to_dict_all_none(self):
+        p = ProfileConfig()
+        assert p.to_dict() == {}
+
+    def test_to_dict_partial(self):
+        p = ProfileConfig(temperature=0.0, seed=42)
+        assert p.to_dict() == {"temperature": 0.0, "seed": 42}
+
+    def test_to_dict_full(self):
+        p = ProfileConfig(
+            model="gpt-4", temperature=0.5, top_p=0.9, seed=1,
+            max_tokens=128, retries=5, retry_delay=2.0,
+            normalize_whitespace=True, ignore_case=True, numeric_tolerance=0.01,
+        )
+        assert len(p.to_dict()) == 10
+
+
+# ---------------------------------------------------------------------------
+# Built-in profiles
+# ---------------------------------------------------------------------------
+
+class TestBuiltinProfiles:
+    def test_greedy_profile(self):
+        p = BUILTIN_PROFILES["greedy"]
+        assert p.temperature == 0.0
+        assert p.seed == 42
+
+    def test_stochastic_profile(self):
+        p = BUILTIN_PROFILES["stochastic"]
+        assert p.temperature == 0.7
+        assert p.seed is None
+
+
+# ---------------------------------------------------------------------------
+# parse_profiles
+# ---------------------------------------------------------------------------
+
+class TestParseProfiles:
+    def test_empty(self):
+        assert parse_profiles({}) == {}
+
+    def test_from_raw_toml(self):
+        raw = {
+            "profiles": {
+                "fast": {"max_tokens": 32, "temperature": 0.0},
+                "slow": {"max_tokens": 512, "retries": 10},
+            }
+        }
+        result = parse_profiles(raw)
+        assert "fast" in result
+        assert result["fast"].max_tokens == 32
+        assert result["fast"].temperature == 0.0
+        assert result["slow"].retries == 10
+
+    def test_unknown_keys_ignored(self):
+        raw = {
+            "profiles": {
+                "x": {"temperature": 0.5, "bogus_key": 999},
+            }
+        }
+        result = parse_profiles(raw)
+        assert result["x"].temperature == 0.5
+
+    def test_non_dict_values_skipped(self):
+        raw = {"profiles": {"name": "not-a-dict"}}
+        result = parse_profiles(raw)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_profile
+# ---------------------------------------------------------------------------
+
+class TestResolveProfile:
+    def test_builtin(self):
+        p = resolve_profile("greedy")
+        assert p.temperature == 0.0
+
+    def test_user_overrides_builtin(self):
+        user = {"greedy": ProfileConfig(temperature=0.0, seed=99)}
+        p = resolve_profile("greedy", user)
+        assert p.seed == 99
+
+    def test_user_only(self):
+        user = {"custom": ProfileConfig(model="llama")}
+        p = resolve_profile("custom", user)
+        assert p.model == "llama"
+
+    def test_unknown_raises(self):
+        with pytest.raises(KeyError, match="Unknown profile 'nope'"):
+            resolve_profile("nope")
+
+    def test_error_lists_available(self):
+        user = {"alpha": ProfileConfig()}
+        with pytest.raises(KeyError, match="alpha"):
+            resolve_profile("nope", user)
+
+
+# ---------------------------------------------------------------------------
+# apply_profile
+# ---------------------------------------------------------------------------
+
+class TestApplyProfile:
+    def test_fills_none_values(self):
+        args = {"temperature": None, "seed": None, "model": "gpt-4"}
+        profile = ProfileConfig(temperature=0.0, seed=42, model="llama")
+        apply_profile(args, profile)
+        assert args["temperature"] == 0.0
+        assert args["seed"] == 42
+        assert args["model"] == "gpt-4"  # CLI wins
+
+    def test_fills_false_bools(self):
+        args = {"normalize_whitespace": False, "ignore_case": False}
+        profile = ProfileConfig(normalize_whitespace=True, ignore_case=True)
+        apply_profile(args, profile)
+        assert args["normalize_whitespace"] is True
+        assert args["ignore_case"] is True
+
+    def test_no_effect_when_all_set(self):
+        args = {"temperature": 0.9, "seed": 1}
+        profile = ProfileConfig(temperature=0.0, seed=42)
+        apply_profile(args, profile)
+        assert args["temperature"] == 0.9
+        assert args["seed"] == 1
+
+    def test_missing_key_in_args_ignored(self):
+        args = {"model": None}
+        profile = ProfileConfig(temperature=0.5)
+        apply_profile(args, profile)
+        assert "temperature" not in args
+
+
+# ---------------------------------------------------------------------------
+# list_profiles
+# ---------------------------------------------------------------------------
+
+class TestListProfiles:
+    def test_builtins_only(self):
+        result = list_profiles()
+        assert "greedy" in result
+        assert "stochastic" in result
+
+    def test_user_added(self):
+        user = {"custom": ProfileConfig(model="x")}
+        result = list_profiles(user)
+        assert "custom" in result
+        assert "greedy" in result
+
+    def test_user_overrides(self):
+        user = {"greedy": ProfileConfig(temperature=0.0, seed=99)}
+        result = list_profiles(user)
+        assert result["greedy"].seed == 99
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+class TestCLIIntegration:
+    def test_profiles_subcommand(self):
+        """The 'profiles' subcommand should not error."""
+        from xpyd_acc.cli import main
+
+        # Just ensure it doesn't crash (no config file needed)
+        main(["profiles"])
+
+    def test_profile_flag_unknown(self):
+        """--profile with unknown name should error."""
+        from xpyd_acc.cli import main
+        with pytest.raises(SystemExit):
+            main(["compare-logprobs", "--baseline", "http://a", "--target", "http://b",
+                   "--prompt", "hi", "--profile", "nonexistent_xyz"])


### PR DESCRIPTION
## Summary
Add named profile (preset) support to reduce repetitive CLI flags for common testing scenarios.

Closes #57

## Changes
- **New module**: `src/xpyd_acc/profiles.py` — `ProfileConfig` dataclass, built-in profiles, parse/resolve/apply/list functions
- **CLI**: `--profile <name>` flag on all comparison subcommands (compare-logprobs, batch-compare, compare-streaming, diagnose)
- **CLI**: `xpyd-acc profiles` subcommand to list available profiles
- **Config**: `[profiles.<name>]` TOML sections parsed via `AppConfig.profiles_raw`
- **Built-in profiles**: `greedy` (temperature=0, seed=42), `stochastic` (temperature=0.7)
- **Priority chain**: CLI flags > profile > env vars > config defaults > hardcoded defaults
- **Tests**: 336 tests pass including 23 new in test_profiles.py
- **ROADMAP**: Added M25 milestone

## Backward Compatibility
No behavior change for existing users — `--profile` is optional.