### PR TITLE
feat: M26 - Multi-run aggregation for persistent vs flaky divergence detection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -180,3 +180,12 @@
 - `xpyd-acc profiles` subcommand to list available profiles
 - Built-in profiles: `greedy` (temperature=0, seed=42), `stochastic` (temperature=0.7)
 - Reduces repetitive CLI flags for common testing scenarios
+
+## M26: Multi-Run Aggregation
+- `xpyd-acc aggregate --reports r1.json r2.json ...` combines multiple batch run reports
+- Classify each sample: persistent divergence (diverges in all runs), flaky (some runs), stable match (all runs)
+- Per-sample consistency score: fraction of runs where the sample diverged
+- Summary: total persistent, flaky, stable counts and rates
+- Export aggregated report as JSON
+- Rich terminal output with per-sample status
+- Useful for distinguishing real bugs from non-deterministic behavior across multiple runs

--- a/src/xpyd_acc/aggregate.py
+++ b/src/xpyd_acc/aggregate.py
@@ -1,0 +1,209 @@
+"""Multi-run aggregation: combine multiple batch reports to find persistent vs flaky divergences."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from xpyd_acc.batch_compare import BatchReport
+
+
+@dataclass
+class AggregatedSample:
+    """Aggregated result for a single sample across multiple runs."""
+
+    sample_id: str
+    run_count: int
+    diverge_count: int
+    match_count: int
+    consistency_score: float  # diverge_count / run_count (0.0 = always match, 1.0 = always diverge)
+    classification: str  # "persistent", "flaky", "stable"
+    prompts: list[str] = field(default_factory=list)
+
+
+@dataclass
+class AggregatedReport:
+    """Report combining multiple batch comparison runs."""
+
+    total_runs: int
+    total_unique_samples: int
+    samples: list[AggregatedSample]
+    persistent_count: int = 0
+    flaky_count: int = 0
+    stable_count: int = 0
+    persistent_rate: float = 0.0
+    flaky_rate: float = 0.0
+    stable_rate: float = 0.0
+
+    def to_json(self) -> str:
+        """Serialize the aggregated report to JSON."""
+        data: dict[str, Any] = {
+            "total_runs": self.total_runs,
+            "total_unique_samples": self.total_unique_samples,
+            "persistent_count": self.persistent_count,
+            "flaky_count": self.flaky_count,
+            "stable_count": self.stable_count,
+            "persistent_rate": self.persistent_rate,
+            "flaky_rate": self.flaky_rate,
+            "stable_rate": self.stable_rate,
+            "samples": [
+                {
+                    "sample_id": s.sample_id,
+                    "run_count": s.run_count,
+                    "diverge_count": s.diverge_count,
+                    "match_count": s.match_count,
+                    "consistency_score": s.consistency_score,
+                    "classification": s.classification,
+                }
+                for s in self.samples
+            ],
+        }
+        return json.dumps(data, indent=2)
+
+
+def _classify_sample(diverge_count: int, run_count: int) -> str:
+    """Classify a sample based on how many runs it diverged in."""
+    if diverge_count == 0:
+        return "stable"
+    if diverge_count == run_count:
+        return "persistent"
+    return "flaky"
+
+
+def aggregate_reports(reports: list[BatchReport]) -> AggregatedReport:
+    """Aggregate multiple batch reports into a single aggregated report.
+
+    Each report is assumed to be a run of the same dataset. Samples are matched
+    by their sample_id.
+
+    Args:
+        reports: List of BatchReport objects from multiple runs.
+
+    Returns:
+        AggregatedReport with per-sample classification.
+
+    Raises:
+        ValueError: If no reports are provided.
+    """
+    if not reports:
+        msg = "At least one report is required"
+        raise ValueError(msg)
+
+    run_count = len(reports)
+
+    # Collect per-sample divergence counts
+    sample_diverge: dict[str, int] = {}
+    sample_appear: dict[str, int] = {}
+    sample_prompts: dict[str, list[str]] = {}
+
+    for report in reports:
+        for result in report.results:
+            sid = result.sample_id
+            sample_appear[sid] = sample_appear.get(sid, 0) + 1
+            if result.is_divergent():
+                sample_diverge[sid] = sample_diverge.get(sid, 0) + 1
+            if sid not in sample_prompts:
+                sample_prompts[sid] = []
+            if result.prompt not in sample_prompts[sid]:
+                sample_prompts[sid].append(result.prompt)
+
+    samples: list[AggregatedSample] = []
+    for sid in sorted(sample_appear.keys()):
+        appear = sample_appear[sid]
+        diverge = sample_diverge.get(sid, 0)
+        match = appear - diverge
+        score = diverge / appear if appear > 0 else 0.0
+        classification = _classify_sample(diverge, appear)
+        samples.append(AggregatedSample(
+            sample_id=sid,
+            run_count=appear,
+            diverge_count=diverge,
+            match_count=match,
+            consistency_score=score,
+            classification=classification,
+            prompts=sample_prompts.get(sid, []),
+        ))
+
+    persistent = sum(1 for s in samples if s.classification == "persistent")
+    flaky = sum(1 for s in samples if s.classification == "flaky")
+    stable = sum(1 for s in samples if s.classification == "stable")
+    total = len(samples)
+
+    return AggregatedReport(
+        total_runs=run_count,
+        total_unique_samples=total,
+        samples=samples,
+        persistent_count=persistent,
+        flaky_count=flaky,
+        stable_count=stable,
+        persistent_rate=persistent / total if total > 0 else 0.0,
+        flaky_rate=flaky / total if total > 0 else 0.0,
+        stable_rate=stable / total if total > 0 else 0.0,
+    )
+
+
+def format_aggregated_report(report: AggregatedReport) -> str:
+    """Format aggregated report as human-readable text."""
+    lines = [
+        "=== Multi-Run Aggregation Report ===",
+        f"Total runs: {report.total_runs}",
+        f"Unique samples: {report.total_unique_samples}",
+        "",
+        "--- Classification ---",
+        f"  Persistent (all diverge): {report.persistent_count} ({report.persistent_rate:.1%})",
+        f"  Flaky (some runs diverge):     {report.flaky_count} ({report.flaky_rate:.1%})",
+        f"  Stable (all runs match):       {report.stable_count} ({report.stable_rate:.1%})",
+    ]
+
+    persistent = [s for s in report.samples if s.classification == "persistent"]
+    flaky = [s for s in report.samples if s.classification == "flaky"]
+
+    if persistent:
+        lines.append("")
+        lines.append("--- Persistent Divergences ---")
+        for s in persistent:
+            lines.append(f"  Sample {s.sample_id}: {s.diverge_count}/{s.run_count} runs diverged")
+
+    if flaky:
+        lines.append("")
+        lines.append("--- Flaky Samples ---")
+        for s in flaky:
+            lines.append(
+                f"  Sample {s.sample_id}: {s.diverge_count}/{s.run_count} runs diverged "
+                f"(consistency: {s.consistency_score:.2f})"
+            )
+
+    return "\n".join(lines)
+
+
+def load_batch_report_from_json(path: str | Path) -> BatchReport:
+    """Load a BatchReport from a JSON file exported by batch-compare --json.
+
+    Args:
+        path: Path to the JSON report file.
+
+    Returns:
+        BatchReport reconstructed from JSON data.
+    """
+    from xpyd_acc.batch_compare import SampleResult, compute_report
+
+    data = json.loads(Path(path).read_text())
+    results = []
+    for r in data.get("results", []):
+        results.append(SampleResult(
+            sample_id=r["sample_id"],
+            prompt=r["prompt"],
+            baseline_output=r["baseline_output"],
+            target_output=r["target_output"],
+            exact_match=r["exact_match"],
+            first_divergence_index=r["first_divergence_index"],
+            baseline_logprob_at_divergence=r.get("baseline_logprob_at_divergence"),
+            target_logprob_at_divergence=r.get("target_logprob_at_divergence"),
+            logprob_gap=r.get("logprob_gap"),
+            classification=r.get("classification", "unknown"),
+            context_length=r.get("context_length", 0),
+        ))
+
+    return compute_report(results)

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -223,6 +223,17 @@ def main(argv: list[str] | None = None) -> None:
     )
     kv.add_argument("--json", action="store_true", help="Output report as JSON")
 
+    # aggregate
+    agg = sub.add_parser("aggregate", help="Aggregate multiple batch run reports")
+    agg.add_argument(
+        "--reports", nargs="+", required=True,
+        help="Paths to batch comparison JSON report files",
+    )
+    agg.add_argument(
+        "--json", default=None, dest="json_path",
+        help="Export aggregated report as JSON to this path",
+    )
+
     sub.add_parser("profiles", help="List available named profiles")
 
     args = parser.parse_args(argv)
@@ -322,6 +333,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_report(args)
     elif args.command == "regression":
         _run_regression(args)
+    elif args.command == "aggregate":
+        _run_aggregate(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -926,3 +939,23 @@ def _run_regression(args: argparse.Namespace) -> None:
         print(f"\nRegression report exported to {args.json_path}")
 
     sys.exit(1 if report.has_regressions else 0)
+
+
+def _run_aggregate(args: argparse.Namespace) -> None:
+    """Aggregate multiple batch run reports."""
+    from pathlib import Path
+
+    from xpyd_acc.aggregate import (
+        aggregate_reports,
+        format_aggregated_report,
+        load_batch_report_from_json,
+    )
+
+    reports = [load_batch_report_from_json(p) for p in args.reports]
+    agg_report = aggregate_reports(reports)
+    print(format_aggregated_report(agg_report))
+
+    if getattr(args, "json_path", None):
+        Path(args.json_path).write_text(agg_report.to_json())
+        print(f"\nAggregated report exported to {args.json_path}")
+

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -1,0 +1,207 @@
+"""Tests for multi-run aggregation."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.aggregate import (
+    aggregate_reports,
+    format_aggregated_report,
+    load_batch_report_from_json,
+)
+from xpyd_acc.batch_compare import BatchReport, SampleResult, compute_report
+
+
+def _make_result(
+    sample_id: str,
+    match: bool,
+    prompt: str = "test prompt",
+) -> SampleResult:
+    """Create a minimal SampleResult for testing."""
+    return SampleResult(
+        sample_id=sample_id,
+        prompt=prompt,
+        baseline_output="hello world",
+        target_output="hello world" if match else "hello mars",
+        exact_match=match,
+        first_divergence_index=None if match else 1,
+        baseline_logprob_at_divergence=None,
+        target_logprob_at_divergence=None,
+        logprob_gap=None if match else 0.5,
+        classification="match" if match else "likely_bug",
+        context_length=2,
+    )
+
+
+def _make_report(results: list[SampleResult]) -> BatchReport:
+    """Build a BatchReport from a list of SampleResults."""
+    return compute_report(results)
+
+
+class TestAggregateReports:
+    """Test aggregate_reports function."""
+
+    def test_all_stable(self) -> None:
+        """All samples match in all runs → all stable."""
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", True)])
+        r2 = _make_report([_make_result("s1", True), _make_result("s2", True)])
+
+        agg = aggregate_reports([r1, r2])
+        assert agg.total_runs == 2
+        assert agg.total_unique_samples == 2
+        assert agg.stable_count == 2
+        assert agg.persistent_count == 0
+        assert agg.flaky_count == 0
+        assert agg.stable_rate == 1.0
+
+    def test_all_persistent(self) -> None:
+        """All samples diverge in all runs → all persistent."""
+        r1 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+
+        agg = aggregate_reports([r1, r2])
+        assert agg.persistent_count == 2
+        assert agg.flaky_count == 0
+        assert agg.stable_count == 0
+        assert agg.persistent_rate == 1.0
+
+    def test_mixed_flaky(self) -> None:
+        """Sample diverges in some runs but not others → flaky."""
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", False)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+
+        agg = aggregate_reports([r1, r2])
+        samples_by_id = {s.sample_id: s for s in agg.samples}
+
+        assert samples_by_id["s1"].classification == "flaky"
+        assert samples_by_id["s1"].consistency_score == 0.5
+        assert samples_by_id["s2"].classification == "persistent"
+        assert samples_by_id["s2"].consistency_score == 1.0
+
+    def test_single_run(self) -> None:
+        """Single run edge case."""
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", False)])
+
+        agg = aggregate_reports([r1])
+        assert agg.total_runs == 1
+        samples_by_id = {s.sample_id: s for s in agg.samples}
+        assert samples_by_id["s1"].classification == "stable"
+        assert samples_by_id["s2"].classification == "persistent"
+
+    def test_empty_raises(self) -> None:
+        """No reports raises ValueError."""
+        with pytest.raises(ValueError, match="At least one report"):
+            aggregate_reports([])
+
+    def test_consistency_score(self) -> None:
+        """Consistency score = diverge_count / run_count."""
+        r1 = _make_report([_make_result("s1", False)])
+        r2 = _make_report([_make_result("s1", True)])
+        r3 = _make_report([_make_result("s1", False)])
+
+        agg = aggregate_reports([r1, r2, r3])
+        s = agg.samples[0]
+        assert s.diverge_count == 2
+        assert s.match_count == 1
+        assert abs(s.consistency_score - 2 / 3) < 1e-9
+
+    def test_json_export(self) -> None:
+        """to_json() produces valid JSON with expected fields."""
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", False)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+
+        agg = aggregate_reports([r1, r2])
+        data = json.loads(agg.to_json())
+
+        assert data["total_runs"] == 2
+        assert data["total_unique_samples"] == 2
+        assert len(data["samples"]) == 2
+        assert "consistency_score" in data["samples"][0]
+
+    def test_format_report(self) -> None:
+        """format_aggregated_report produces human-readable output."""
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", False)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+
+        agg = aggregate_reports([r1, r2])
+        text = format_aggregated_report(agg)
+
+        assert "Multi-Run Aggregation Report" in text
+        assert "Persistent" in text
+        assert "Flaky" in text
+
+
+class TestLoadBatchReportFromJson:
+    """Test loading BatchReport from JSON files."""
+
+    def test_round_trip(self) -> None:
+        """Save a report as JSON, load it back, verify results."""
+        original = _make_report([
+            _make_result("s1", True),
+            _make_result("s2", False),
+        ])
+        json_str = original.to_json()
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write(json_str)
+            path = f.name
+
+        loaded = load_batch_report_from_json(path)
+        Path(path).unlink()
+
+        assert loaded.total_samples == 2
+        assert len(loaded.results) == 2
+
+
+class TestCliAggregate:
+    """Test CLI aggregate subcommand integration."""
+
+    def test_aggregate_cli(self) -> None:
+        """CLI aggregate reads report files and prints output."""
+        from xpyd_acc.cli import main
+
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", False)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+
+        paths = []
+        for r in [r1, r2]:
+            f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+            f.write(r.to_json())
+            f.close()
+            paths.append(f.name)
+
+        try:
+            main(["aggregate", "--reports"] + paths)
+        finally:
+            for p in paths:
+                Path(p).unlink()
+
+    def test_aggregate_json_export(self, tmp_path: Path) -> None:
+        """CLI aggregate --json exports file."""
+        from xpyd_acc.cli import main
+
+        r1 = _make_report([_make_result("s1", True)])
+        r2 = _make_report([_make_result("s1", True)])
+
+        paths = []
+        for r in [r1, r2]:
+            f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+            f.write(r.to_json())
+            f.close()
+            paths.append(f.name)
+
+        out = tmp_path / "agg.json"
+        try:
+            main(["aggregate", "--reports"] + paths + ["--json", str(out)])
+        finally:
+            for p in paths:
+                Path(p).unlink()
+
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["total_runs"] == 2
+        assert data["stable_count"] == 1


### PR DESCRIPTION
## Summary

Add multi-run aggregation capability to combine multiple batch comparison reports and classify divergences as persistent, flaky, or stable.

Closes #59

## Changes

- New module `src/xpyd_acc/aggregate.py`:
  - `AggregatedSample` / `AggregatedReport` dataclasses
  - `aggregate_reports()` - combines multiple BatchReports, classifies each sample
  - `format_aggregated_report()` - human-readable terminal output
  - `load_batch_report_from_json()` - load BatchReport from JSON file
  - JSON export via `to_json()`

- CLI subcommand `xpyd-acc aggregate --reports r1.json r2.json [--json out.json]`

- Updated `ROADMAP.md` with M26 milestone

- 11 new tests in `tests/test_aggregate.py` covering:
  - All stable, all persistent, mixed/flaky scenarios
  - Single run edge case, empty input validation
  - Consistency score calculation
  - JSON export round-trip
  - CLI integration

## Classification Logic
- **Persistent**: diverges in ALL runs → likely real bug
- **Flaky**: diverges in SOME runs → likely non-deterministic
- **Stable**: matches in ALL runs → no issue
- **Consistency score**: diverge_count / run_count per sample

## Test Results
- All 347 tests pass
- Lint clean: `ruff check` + `isort --check`