### PR TITLE
feat: configurable HTTP timeout for batch-compare

### DIFF
--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -187,11 +187,15 @@ async def _collect_output(
     retries: int = 3,
     retry_delay: float = 1.0,
     sampling_params: Any | None = None,
+    timeout: float = 120.0,
 ) -> tuple[str, list[dict[str, Any]]]:
     """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list).
 
     Returns a tuple of (generated_text, logprobs_per_token).
     Each logprob entry has: {"token": str, "logprob": float, "top_logprobs": [...]}.
+
+    Args:
+        timeout: HTTP request timeout in seconds (default 120.0).
     """
     import httpx
 
@@ -209,7 +213,7 @@ async def _collect_output(
     headers = {"Authorization": f"Bearer {api_key}"}
 
     async def _do_request() -> tuple[str, list[dict[str, Any]]]:
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(
                 f"{url}/v1/chat/completions", json=payload, headers=headers,
             )
@@ -238,12 +242,14 @@ async def run_batch(
     on_progress: Callable[[int, int], None] | None = None,
     match_config: Any | None = None,
     sampling_params: Any | None = None,
+    timeout: float = 120.0,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report.
 
     Args:
         on_progress: Optional callback called after each sample completes.
             Receives (completed_count, total_count).
+        timeout: HTTP request timeout in seconds (default 120.0).
     """
     semaphore = asyncio.Semaphore(concurrency)
     results: list[SampleResult] = []
@@ -255,13 +261,13 @@ async def run_batch(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
-                sampling_params=sampling_params,
+                sampling_params=sampling_params, timeout=timeout,
             )
             target_text, target_lp = await _collect_output(
                 target_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
-                sampling_params=sampling_params,
+                sampling_params=sampling_params, timeout=timeout,
             )
 
         b_tokens = _tokenize(baseline_text)

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -157,6 +157,10 @@ def main(argv: list[str] | None = None) -> None:
         "--rerun-merge", action="store_true", default=False,
         help="Merge rerun results back into the original report file",
     )
+    bc.add_argument(
+        "--timeout", type=float, default=None,
+        help="HTTP request timeout in seconds (default: 120.0)",
+    )
     _add_sampling_args(bc)
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
@@ -293,6 +297,8 @@ def main(argv: list[str] | None = None) -> None:
         args.top_p = env.top_p
     if env.seed is not None and hasattr(args, "seed") and args.seed is None:
         args.seed = env.seed
+    if env.timeout is not None and hasattr(args, "timeout") and args.timeout is None:
+        args.timeout = env.timeout
 
     # Apply hardcoded defaults for any remaining None values
     _FINAL_DEFAULTS: dict[str, object] = {
@@ -308,6 +314,7 @@ def main(argv: list[str] | None = None) -> None:
         "cosine_threshold": 0.999,
         "kv_max_abs_threshold": 1e-3,
         "kv_cosine_threshold": 0.999,
+        "timeout": 120.0,
     }
     for key, default in _FINAL_DEFAULTS.items():
         if hasattr(args, key) and getattr(args, key) is None:
@@ -508,6 +515,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             on_progress=on_progress if use_progress else None,
             match_config=effective_match,
             sampling_params=sampling,
+            timeout=args.timeout,
         )
     finally:
         if progress_ctx is not None:
@@ -628,6 +636,7 @@ async def _run_rerun(args: argparse.Namespace) -> None:
             on_progress=on_progress if use_progress else None,
             match_config=effective_match,
             sampling_params=sampling,
+            timeout=args.timeout,
         )
     finally:
         if progress_ctx is not None:

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -36,6 +36,7 @@ class DefaultsConfig:
     temperature: float | None = None
     top_p: float | None = None
     seed: int | None = None
+    timeout: float = 120.0
 
 
 @dataclass
@@ -163,6 +164,7 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
         "temperature": config.defaults.temperature,
         "top_p": config.defaults.top_p,
         "seed": config.defaults.seed,
+        "timeout": config.defaults.timeout,
     }
 
     for key, config_val in defaults_map.items():

--- a/src/xpyd_acc/env.py
+++ b/src/xpyd_acc/env.py
@@ -13,6 +13,7 @@ ENV_MODEL = "XPYD_ACC_MODEL"
 ENV_TEMPERATURE = "XPYD_ACC_TEMPERATURE"
 ENV_TOP_P = "XPYD_ACC_TOP_P"
 ENV_SEED = "XPYD_ACC_SEED"
+ENV_TIMEOUT = "XPYD_ACC_TIMEOUT"
 
 
 @dataclass
@@ -26,6 +27,7 @@ class EnvDefaults:
     temperature: float | None = None
     top_p: float | None = None
     seed: int | None = None
+    timeout: float | None = None
 
 
 def get_env_defaults() -> EnvDefaults:
@@ -37,6 +39,7 @@ def get_env_defaults() -> EnvDefaults:
     temp_str = os.environ.get(ENV_TEMPERATURE) or None
     top_p_str = os.environ.get(ENV_TOP_P) or None
     seed_str = os.environ.get(ENV_SEED) or None
+    timeout_str = os.environ.get(ENV_TIMEOUT) or None
 
     return EnvDefaults(
         api_key=os.environ.get(ENV_API_KEY) or None,
@@ -46,6 +49,7 @@ def get_env_defaults() -> EnvDefaults:
         temperature=float(temp_str) if temp_str is not None else None,
         top_p=float(top_p_str) if top_p_str is not None else None,
         seed=int(seed_str) if seed_str is not None else None,
+        timeout=float(timeout_str) if timeout_str is not None else None,
     )
 
 

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -503,3 +503,27 @@ class TestExportMarkdown:
         report = compute_report(results)
         md = export_markdown(report)
         assert "# Batch Comparison Report" in md
+
+
+class TestCollectOutputTimeout:
+    """Test that _collect_output accepts timeout parameter."""
+
+    def test_timeout_parameter_signature(self) -> None:
+        """Verify _collect_output has timeout in its signature."""
+        import inspect
+
+        from xpyd_acc.batch_compare import _collect_output
+
+        sig = inspect.signature(_collect_output)
+        assert "timeout" in sig.parameters
+        assert sig.parameters["timeout"].default == 120.0
+
+    def test_run_batch_timeout_parameter(self) -> None:
+        """Verify run_batch has timeout in its signature."""
+        import inspect
+
+        from xpyd_acc.batch_compare import run_batch
+
+        sig = inspect.signature(run_batch)
+        assert "timeout" in sig.parameters
+        assert sig.parameters["timeout"].default == 120.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,3 +169,11 @@ class TestMergeCliArgs:
         merged = merge_cli_args(config, args, "compare-logprobs")
         assert merged["baseline"] == "http://x:8000"
         assert merged["model"] == "m"
+
+    def test_timeout_default(self) -> None:
+        config = AppConfig()
+        assert config.defaults.timeout == 120.0
+
+    def test_timeout_from_config(self) -> None:
+        config = AppConfig(defaults=DefaultsConfig(timeout=30.0))
+        assert config.defaults.timeout == 30.0

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -10,6 +10,7 @@ from xpyd_acc.env import (
     ENV_BASELINE_URL,
     ENV_MODEL,
     ENV_TARGET_URL,
+    ENV_TIMEOUT,
     apply_env_defaults,
     get_env_defaults,
 )
@@ -100,3 +101,16 @@ class TestCliEnvIntegration:
             assert defaults.baseline_url == "http://env-baseline:8000"
             assert defaults.target_url == "http://env-target:8000"
             assert defaults.model == "env-model"
+
+    def test_timeout_env_var(self) -> None:
+        """Verify XPYD_ACC_TIMEOUT env var is read correctly."""
+        env = {ENV_TIMEOUT: "30.0"}
+        with patch.dict(os.environ, env, clear=True):
+            defaults = get_env_defaults()
+        assert defaults.timeout == 30.0
+
+    def test_timeout_env_var_not_set(self) -> None:
+        """Verify timeout is None when env var not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            defaults = get_env_defaults()
+        assert defaults.timeout is None


### PR DESCRIPTION
## Summary

Add configurable HTTP timeout for `batch-compare` and related commands. The timeout was previously hardcoded at 120s in `_collect_output()`.

## Changes

- `_collect_output()` accepts `timeout` parameter (default 120.0s)
- `run_batch()` accepts and forwards `timeout`
- `--timeout` CLI flag for `batch-compare`
- `XPYD_ACC_TIMEOUT` environment variable support
- `[defaults] timeout = 30.0` TOML config support
- Priority chain: CLI > env > config > default (120.0s)
- Tests for env, config, and function signatures

Closes #61