### PR TITLE
feat: add logging & verbosity control (--verbose / --quiet)

### DIFF
--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -11,6 +11,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+from xpyd_acc.log import get_logger
+
+logger = get_logger("batch_compare")
+
 
 @dataclass
 class DatasetSample:
@@ -251,6 +255,7 @@ async def run_batch(
             Receives (completed_count, total_count).
         timeout: HTTP request timeout in seconds (default 120.0).
     """
+    logger.info("Starting batch comparison: %d samples, concurrency=%d", len(samples), concurrency)
     semaphore = asyncio.Semaphore(concurrency)
     results: list[SampleResult] = []
     completed = 0

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -45,6 +45,15 @@ def main(argv: list[str] | None = None) -> None:
         "-V", "--version", action="version",
         version=f"%(prog)s {_get_version()}",
     )
+    verbosity_group = parser.add_mutually_exclusive_group()
+    verbosity_group.add_argument(
+        "-v", "--verbose", action="count", default=0,
+        help="Increase verbosity (-v for INFO, -vv for DEBUG)",
+    )
+    verbosity_group.add_argument(
+        "-q", "--quiet", action="store_true", default=False,
+        help="Quiet mode (ERROR level only)",
+    )
     parser.add_argument(
         "--config", default=None,
         help="Path to TOML config file (auto-discovers xpyd-acc.toml in cwd if not set)",
@@ -241,6 +250,12 @@ def main(argv: list[str] | None = None) -> None:
     sub.add_parser("profiles", help="List available named profiles")
 
     args = parser.parse_args(argv)
+
+    # Setup logging from verbosity flags
+    from xpyd_acc.log import setup_logging
+    verbosity = -1 if args.quiet else args.verbose
+    setup_logging(verbosity)
+
     if not args.command:
         parser.print_help()
         return

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -19,6 +19,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from xpyd_acc.log import get_logger
+
+logger = get_logger("config")
+
 AUTO_CONFIG_NAME = "xpyd-acc.toml"
 
 
@@ -133,7 +137,9 @@ def discover_config() -> AppConfig | None:
     """
     candidate = Path.cwd() / AUTO_CONFIG_NAME
     if candidate.exists():
+        logger.info("Auto-discovered config: %s", candidate)
         return load_config(candidate)
+    logger.debug("No config file found in %s", Path.cwd())
     return None
 
 

--- a/src/xpyd_acc/healthcheck.py
+++ b/src/xpyd_acc/healthcheck.py
@@ -7,6 +7,10 @@ from dataclasses import dataclass
 
 import httpx
 
+from xpyd_acc.log import get_logger
+
+logger = get_logger("healthcheck")
+
 
 @dataclass
 class HealthCheckResult:
@@ -48,6 +52,7 @@ async def check_endpoint(
     base_url = url.rstrip("/")
     models_url = f"{base_url}/v1/models"
     headers = {"Authorization": f"Bearer {api_key}"}
+    logger.info("Checking endpoint health: %s", models_url)
 
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:

--- a/src/xpyd_acc/log.py
+++ b/src/xpyd_acc/log.py
@@ -1,0 +1,40 @@
+"""Logging configuration for xpyd-acc."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+_PACKAGE_LOGGER = "xpyd_acc"
+
+
+def setup_logging(verbosity: int = 0) -> None:
+    """Configure logging based on verbosity level.
+
+    Args:
+        verbosity: -1 = quiet (ERROR), 0 = default (WARNING),
+                   1 = verbose (INFO), 2+ = debug (DEBUG).
+    """
+    if verbosity <= -1:
+        level = logging.ERROR
+    elif verbosity == 0:
+        level = logging.WARNING
+    elif verbosity == 1:
+        level = logging.INFO
+    else:
+        level = logging.DEBUG
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        logging.Formatter("%(levelname)s %(name)s: %(message)s")
+    )
+
+    logger = logging.getLogger(_PACKAGE_LOGGER)
+    logger.handlers.clear()
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a child logger under the package namespace."""
+    return logging.getLogger(f"{_PACKAGE_LOGGER}.{name}")

--- a/src/xpyd_acc/retry.py
+++ b/src/xpyd_acc/retry.py
@@ -8,7 +8,11 @@ from typing import Any, Callable, TypeVar
 
 import httpx
 
+from xpyd_acc.log import get_logger
+
 T = TypeVar("T")
+
+logger = get_logger("retry")
 
 #: HTTP status codes that trigger a retry.
 RETRYABLE_STATUS_CODES = frozenset({429, 502, 503, 504})
@@ -64,9 +68,17 @@ async def retry_async(
                 raise
             last_error = exc
             delay = _compute_delay(exc.response, attempt, base_delay)
+            logger.info(
+                "Attempt %d/%d failed (HTTP %d), retrying in %.1fs",
+                attempt + 1, retries, exc.response.status_code, delay,
+            )
         except (httpx.ConnectError, httpx.TimeoutException) as exc:
             last_error = exc
             delay = _backoff(attempt, base_delay)
+            logger.info(
+                "Attempt %d/%d failed (%s), retrying in %.1fs",
+                attempt + 1, retries, type(exc).__name__, delay,
+            )
         else:
             break  # pragma: no cover – unreachable but keeps linter happy
 

--- a/src/xpyd_acc/streaming.py
+++ b/src/xpyd_acc/streaming.py
@@ -10,6 +10,10 @@ from typing import Any, AsyncIterator
 
 import httpx
 
+from xpyd_acc.log import get_logger
+
+logger = get_logger("streaming")
+
 
 @dataclass
 class StreamToken:
@@ -126,6 +130,7 @@ async def collect_stream(
     sampling_params: Any | None = None,
 ) -> list[StreamToken]:
     """Collect all tokens from a streaming endpoint into a list."""
+    logger.info("Collecting stream from %s", collector.url)
     tokens: list[StreamToken] = []
     async for token in collector.stream(
         prompt, max_tokens, timeout=timeout, sampling_params=sampling_params,

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,70 @@
+"""Tests for xpyd_acc.log module."""
+
+from __future__ import annotations
+
+import logging
+
+from xpyd_acc.log import get_logger, setup_logging
+
+
+class TestSetupLogging:
+    """Tests for setup_logging()."""
+
+    def test_default_level_is_warning(self) -> None:
+        setup_logging(0)
+        logger = logging.getLogger("xpyd_acc")
+        assert logger.level == logging.WARNING
+
+    def test_verbose_sets_info(self) -> None:
+        setup_logging(1)
+        logger = logging.getLogger("xpyd_acc")
+        assert logger.level == logging.INFO
+
+    def test_double_verbose_sets_debug(self) -> None:
+        setup_logging(2)
+        logger = logging.getLogger("xpyd_acc")
+        assert logger.level == logging.DEBUG
+
+    def test_quiet_sets_error(self) -> None:
+        setup_logging(-1)
+        logger = logging.getLogger("xpyd_acc")
+        assert logger.level == logging.ERROR
+
+    def test_get_logger_returns_child(self) -> None:
+        child = get_logger("test_child")
+        assert child.name == "xpyd_acc.test_child"
+
+    def test_handlers_not_duplicated(self) -> None:
+        setup_logging(0)
+        setup_logging(0)
+        logger = logging.getLogger("xpyd_acc")
+        assert len(logger.handlers) == 1
+
+
+class TestCLIVerbosity:
+    """Tests for --verbose / --quiet CLI integration."""
+
+    def test_verbose_flag_accepted(self) -> None:
+        from xpyd_acc.cli import main
+
+        # Just verify -v doesn't crash before subcommand check
+        # (will exit due to no subcommand, but should parse -v)
+        try:
+            main(["-v", "--version"])
+        except SystemExit:
+            pass  # --version causes SystemExit(0)
+
+    def test_quiet_flag_accepted(self) -> None:
+        from xpyd_acc.cli import main
+        try:
+            main(["-q", "--version"])
+        except SystemExit:
+            pass
+
+    def test_verbose_and_quiet_mutually_exclusive(self) -> None:
+        import pytest
+
+        from xpyd_acc.cli import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(["-v", "-q"])
+        assert exc_info.value.code != 0


### PR DESCRIPTION
## Summary
Add structured logging with verbosity control via CLI flags.

## Changes
- New `src/xpyd_acc/log.py` module: `setup_logging(verbosity)` and `get_logger(name)`
- `--verbose` / `-v` (INFO), `-vv` (DEBUG), `--quiet` / `-q` (ERROR only) — mutually exclusive
- Logging calls added to: retry, healthcheck, batch_compare, streaming, config
- 9 new tests covering log levels, CLI flags, mutual exclusivity

## Testing
All 362 tests pass. Lint clean (ruff + isort).

Closes #63