### PR TITLE
feat: Watch Mode — Continuous Divergence Monitoring

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -247,6 +247,32 @@ def main(argv: list[str] | None = None) -> None:
         help="Export aggregated report as JSON to this path",
     )
 
+    # watch
+    wp = sub.add_parser("watch", help="Continuous divergence monitoring")
+    wp.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    wp.add_argument("--target", required=True, help="Target endpoint URL")
+    wp.add_argument("--prompt", required=True, help="Prompt to compare")
+    wp.add_argument("--model", default=None, help="Model name")
+    wp.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
+    wp.add_argument("--api-key", default=None, help="API key for endpoints")
+    wp.add_argument(
+        "--interval", type=float, default=60.0,
+        help="Seconds between iterations (default: 60)",
+    )
+    wp.add_argument(
+        "--max-iterations", type=int, default=None,
+        help="Stop after N iterations (default: unlimited)",
+    )
+    wp.add_argument(
+        "--alert-threshold", type=int, default=None,
+        help="Exit code 1 after N consecutive failures",
+    )
+    wp.add_argument("--log", default=None, dest="log_path", help="JSON log file path")
+    wp.add_argument("--retries", type=int, default=None, help="Max retry attempts")
+    wp.add_argument("--retry-delay", type=float, default=None, help="Base retry delay (seconds)")
+    wp.add_argument("--skip-healthcheck", action="store_true", help="Skip pre-flight healthcheck")
+    _add_sampling_args(wp)
+
     sub.add_parser("profiles", help="List available named profiles")
 
     args = parser.parse_args(argv)
@@ -357,6 +383,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_regression(args)
     elif args.command == "aggregate":
         _run_aggregate(args)
+    elif args.command == "watch":
+        _run_watch(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -983,3 +1011,53 @@ def _run_aggregate(args: argparse.Namespace) -> None:
         Path(args.json_path).write_text(agg_report.to_json())
         print(f"\nAggregated report exported to {args.json_path}")
 
+
+
+def _run_watch(args: argparse.Namespace) -> None:
+    """Run continuous watch mode."""
+    from xpyd_acc.config import load_config
+    from xpyd_acc.env import apply_env_defaults
+    from xpyd_acc.profiles import apply_profile
+    from xpyd_acc.sampling import SamplingParams
+    from xpyd_acc.watch import run_watch
+
+    config = load_config(getattr(args, "config", None))
+    apply_env_defaults(args, config)
+    apply_profile(args, config)
+
+    sampling = SamplingParams.from_args(args)
+    model = args.model or config.get("defaults", {}).get("model", "default")
+    max_tokens = args.max_tokens or config.get("defaults", {}).get("max_tokens", 64)
+    api_key = args.api_key or config.get("defaults", {}).get("api_key")
+    defaults = config.get("defaults", {})
+    retries = args.retries if args.retries is not None else defaults.get("retries", 3)
+    retry_delay = (
+        args.retry_delay if args.retry_delay is not None
+        else defaults.get("retry_delay", 1.0)
+    )
+
+    if not getattr(args, "skip_healthcheck", False):
+        asyncio.run(_preflight_healthcheck(
+            [args.baseline, args.target],
+            api_key=api_key or "no-key",
+        ))
+
+    summary = asyncio.run(run_watch(
+        baseline_url=args.baseline,
+        target_url=args.target,
+        prompt=args.prompt,
+        model=model,
+        max_tokens=max_tokens,
+        api_key=api_key,
+        interval=args.interval,
+        max_iterations=args.max_iterations,
+        alert_threshold=args.alert_threshold,
+        log_path=args.log_path,
+        retries=retries,
+        retry_delay=retry_delay,
+        sampling_params=sampling,
+        no_live=False,
+    ))
+
+    if args.alert_threshold and summary.consecutive_failures_at_end >= args.alert_threshold:
+        sys.exit(1)

--- a/src/xpyd_acc/watch.py
+++ b/src/xpyd_acc/watch.py
@@ -1,0 +1,267 @@
+"""Watch mode: continuous divergence monitoring."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+
+from xpyd_acc.log import get_logger
+from xpyd_acc.logprobs import LogprobsCollector, LogprobsComparator
+from xpyd_acc.sampling import SamplingParams
+
+logger = get_logger("watch")
+
+
+@dataclass
+class WatchIteration:
+    """Result of a single watch iteration."""
+
+    iteration: int
+    timestamp: float
+    passed: bool
+    first_divergence_index: int | None
+    baseline_token: str | None
+    target_token: str | None
+    latency_seconds: float
+    error: str | None = None
+
+
+@dataclass
+class WatchSummary:
+    """Summary of a watch session."""
+
+    total_iterations: int
+    passed: int
+    failed: int
+    errors: int
+    pass_rate: float
+    avg_latency: float
+    consecutive_failures_at_end: int
+    iterations: list[WatchIteration] = field(default_factory=list)
+
+
+def _build_table(iterations: list[WatchIteration], summary_so_far: dict[str, Any]) -> Table:
+    """Build a rich table showing recent iterations and rolling stats."""
+    table = Table(title="xpyd-acc watch", show_header=True)
+    table.add_column("#", style="dim", width=6)
+    table.add_column("Status", width=8)
+    table.add_column("Divergence", width=14)
+    table.add_column("Latency", width=10)
+    table.add_column("Time", width=12)
+
+    for it in iterations[-10:]:
+        status = "[green]PASS[/green]" if it.passed else (
+            "[yellow]ERROR[/yellow]" if it.error else "[red]FAIL[/red]"
+        )
+        div = str(it.first_divergence_index) if it.first_divergence_index is not None else "-"
+        latency = f"{it.latency_seconds:.2f}s"
+        ts = time.strftime("%H:%M:%S", time.localtime(it.timestamp))
+        table.add_row(str(it.iteration), status, div, latency, ts)
+
+    total = summary_so_far.get("total", 0)
+    passed = summary_so_far.get("passed", 0)
+    rate = f"{passed / total * 100:.1f}%" if total > 0 else "-"
+    table.add_section()
+    table.add_row("", f"[bold]Pass rate: {rate}[/bold]", f"Total: {total}", "", "")
+
+    return table
+
+
+async def run_watch(
+    baseline_url: str,
+    target_url: str,
+    prompt: str,
+    model: str = "default",
+    max_tokens: int = 64,
+    api_key: str | None = None,
+    interval: float = 60.0,
+    max_iterations: int | None = None,
+    alert_threshold: int | None = None,
+    log_path: str | None = None,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+    sampling_params: SamplingParams | None = None,
+    no_live: bool = False,
+) -> WatchSummary:
+    """Run continuous watch loop.
+
+    Args:
+        baseline_url: Baseline endpoint URL.
+        target_url: Target endpoint URL.
+        prompt: Prompt to compare.
+        model: Model name.
+        max_tokens: Max tokens to generate.
+        api_key: API key for endpoints.
+        interval: Seconds between iterations.
+        max_iterations: Stop after N iterations (None = unlimited).
+        alert_threshold: Exit after N consecutive failures (None = disabled).
+        log_path: Path to write JSON log.
+        retries: HTTP retry count.
+        retry_delay: Base retry delay.
+        sampling_params: Sampling parameters.
+        no_live: Disable live display (for testing / non-TTY).
+
+    Returns:
+        WatchSummary with all iteration results.
+    """
+    console = Console()
+    iterations: list[WatchIteration] = []
+    passed_count = 0
+    failed_count = 0
+    error_count = 0
+    consecutive_failures = 0
+    total_latency = 0.0
+
+    key = api_key or "no-key"
+    baseline_collector = LogprobsCollector(base_url=baseline_url, api_key=key, model=model)
+    target_collector = LogprobsCollector(base_url=target_url, api_key=key, model=model)
+    comparator = LogprobsComparator()
+
+    log_file = None
+    if log_path:
+        log_file = Path(log_path).open("w")
+        log_file.write("[\n")
+
+    try:
+        iteration_num = 0
+        use_live = not no_live
+
+        context_mgr: Any
+        if use_live:
+            context_mgr = Live(console=console, refresh_per_second=2)
+        else:
+            from contextlib import nullcontext
+            context_mgr = nullcontext()
+
+        with context_mgr as live:
+            while True:
+                iteration_num += 1
+                start_time = time.time()
+                logger.info("Watch iteration %d starting", iteration_num)
+
+                try:
+                    baseline_result = await baseline_collector.collect(
+                        prompt=prompt,
+                        max_tokens=max_tokens,
+                        retries=retries,
+                        retry_delay=retry_delay,
+                        sampling_params=sampling_params,
+                    )
+                    target_result = await target_collector.collect(
+                        prompt=prompt,
+                        max_tokens=max_tokens,
+                        retries=retries,
+                        retry_delay=retry_delay,
+                        sampling_params=sampling_params,
+                    )
+
+                    report = comparator.compare(baseline_result, target_result)
+                    latency = time.time() - start_time
+
+                    if report.match:
+                        it = WatchIteration(
+                            iteration=iteration_num,
+                            timestamp=time.time(),
+                            passed=True,
+                            first_divergence_index=None,
+                            baseline_token=None,
+                            target_token=None,
+                            latency_seconds=latency,
+                        )
+                        passed_count += 1
+                        consecutive_failures = 0
+                    else:
+                        div = report.divergence
+                        it = WatchIteration(
+                            iteration=iteration_num,
+                            timestamp=time.time(),
+                            passed=False,
+                            first_divergence_index=div.token_index if div else None,
+                            baseline_token=div.expected_token if div else None,
+                            target_token=div.actual_token if div else None,
+                            latency_seconds=latency,
+                        )
+                        failed_count += 1
+                        consecutive_failures += 1
+
+                except Exception as e:
+                    latency = time.time() - start_time
+                    it = WatchIteration(
+                        iteration=iteration_num,
+                        timestamp=time.time(),
+                        passed=False,
+                        first_divergence_index=None,
+                        baseline_token=None,
+                        target_token=None,
+                        latency_seconds=latency,
+                        error=str(e),
+                    )
+                    error_count += 1
+                    consecutive_failures += 1
+                    logger.warning("Watch iteration %d error: %s", iteration_num, e)
+
+                iterations.append(it)
+                total_latency += it.latency_seconds
+
+                if log_file:
+                    if iteration_num > 1:
+                        log_file.write(",\n")
+                    json.dump(asdict(it), log_file)
+                    log_file.flush()
+
+                if use_live and live is not None:
+                    summary_so_far = {"total": iteration_num, "passed": passed_count}
+                    live.update(_build_table(iterations, summary_so_far))
+
+                if alert_threshold is not None and consecutive_failures >= alert_threshold:
+                    logger.warning(
+                        "Alert threshold reached: %d consecutive failures", consecutive_failures
+                    )
+                    break
+
+                if max_iterations is not None and iteration_num >= max_iterations:
+                    logger.info("Max iterations reached: %d", max_iterations)
+                    break
+
+                await asyncio.sleep(interval)
+
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        logger.info("Watch interrupted by user")
+    finally:
+        if log_file:
+            log_file.write("\n]\n")
+            log_file.close()
+
+    total = len(iterations)
+    avg_latency = total_latency / total if total > 0 else 0.0
+    pass_rate = passed_count / total if total > 0 else 0.0
+
+    summary = WatchSummary(
+        total_iterations=total,
+        passed=passed_count,
+        failed=failed_count,
+        errors=error_count,
+        pass_rate=pass_rate,
+        avg_latency=avg_latency,
+        consecutive_failures_at_end=consecutive_failures,
+        iterations=iterations,
+    )
+
+    console.print()
+    console.print("[bold]Watch Summary[/bold]")
+    console.print(f"  Total iterations: {total}")
+    console.print(f"  Passed: [green]{passed_count}[/green]")
+    console.print(f"  Failed: [red]{failed_count}[/red]")
+    console.print(f"  Errors: [yellow]{error_count}[/yellow]")
+    console.print(f"  Pass rate: {pass_rate * 100:.1f}%")
+    console.print(f"  Avg latency: {avg_latency:.2f}s")
+
+    return summary

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -1,0 +1,224 @@
+"""Tests for watch mode."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xpyd_acc.logprobs import ComparisonReport, DivergencePoint, LogprobsResult, TokenLogprob
+from xpyd_acc.watch import WatchIteration, _build_table, run_watch
+
+
+def _make_logprobs_result(tokens: list[str], endpoint: str = "http://test") -> LogprobsResult:
+    """Helper to create LogprobsResult."""
+    return LogprobsResult(
+        endpoint=endpoint,
+        model="test-model",
+        tokens=[TokenLogprob(index=i, token=t, logprob=-0.1) for i, t in enumerate(tokens)],
+    )
+
+
+def _matching_report() -> ComparisonReport:
+    baseline = _make_logprobs_result(["Hello", " world"], "http://baseline")
+    target = _make_logprobs_result(["Hello", " world"], "http://target")
+    return ComparisonReport(
+        baseline=baseline,
+        target=target,
+        divergence=None,
+        total_tokens_compared=2,
+        match=True,
+    )
+
+
+def _divergent_report() -> ComparisonReport:
+    baseline = _make_logprobs_result(["Hello", " world"], "http://baseline")
+    target = _make_logprobs_result(["Hello", " earth"], "http://target")
+    return ComparisonReport(
+        baseline=baseline,
+        target=target,
+        divergence=DivergencePoint(
+            token_index=1,
+            expected_token=" world",
+            actual_token=" earth",
+            expected_logprob=-0.1,
+            actual_logprob=-0.2,
+            prob_diff=0.1,
+        ),
+        total_tokens_compared=2,
+        match=False,
+    )
+
+
+class TestBuildTable:
+    """Tests for _build_table."""
+
+    def test_empty(self) -> None:
+        table = _build_table([], {"total": 0, "passed": 0})
+        assert table.title == "xpyd-acc watch"
+
+    def test_with_iterations(self) -> None:
+        iterations = [
+            WatchIteration(1, 1000.0, True, None, None, None, 0.5),
+            WatchIteration(2, 1060.0, False, 5, "a", "b", 0.8),
+        ]
+        table = _build_table(iterations, {"total": 2, "passed": 1})
+        assert table.row_count == 3  # 2 rows + 1 summary
+
+
+class TestRunWatch:
+    """Tests for run_watch."""
+
+    @pytest.mark.asyncio
+    async def test_max_iterations(self) -> None:
+        """Watch stops after max_iterations."""
+        with patch("xpyd_acc.watch.LogprobsCollector") as MockCollector, \
+             patch("xpyd_acc.watch.LogprobsComparator") as MockComparator:
+            mock_collector_instance = MagicMock()
+            mock_collector_instance.collect = AsyncMock(
+                return_value=_make_logprobs_result(["a", "b"])
+            )
+            MockCollector.return_value = mock_collector_instance
+
+            mock_comparator_instance = MagicMock()
+            mock_comparator_instance.compare.return_value = _matching_report()
+            MockComparator.return_value = mock_comparator_instance
+
+            summary = await run_watch(
+                baseline_url="http://baseline",
+                target_url="http://target",
+                prompt="test",
+                max_iterations=3,
+                interval=0.01,
+                no_live=True,
+            )
+
+            assert summary.total_iterations == 3
+            assert summary.passed == 3
+            assert summary.failed == 0
+            assert summary.pass_rate == 1.0
+
+    @pytest.mark.asyncio
+    async def test_alert_threshold(self) -> None:
+        """Watch exits after alert_threshold consecutive failures."""
+        with patch("xpyd_acc.watch.LogprobsCollector") as MockCollector, \
+             patch("xpyd_acc.watch.LogprobsComparator") as MockComparator:
+            mock_collector_instance = MagicMock()
+            mock_collector_instance.collect = AsyncMock(
+                return_value=_make_logprobs_result(["a", "b"])
+            )
+            MockCollector.return_value = mock_collector_instance
+
+            mock_comparator_instance = MagicMock()
+            mock_comparator_instance.compare.return_value = _divergent_report()
+            MockComparator.return_value = mock_comparator_instance
+
+            summary = await run_watch(
+                baseline_url="http://baseline",
+                target_url="http://target",
+                prompt="test",
+                max_iterations=10,
+                alert_threshold=2,
+                interval=0.01,
+                no_live=True,
+            )
+
+            assert summary.total_iterations == 2
+            assert summary.failed == 2
+            assert summary.consecutive_failures_at_end == 2
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self) -> None:
+        """Errors are captured without crashing the loop."""
+        with patch("xpyd_acc.watch.LogprobsCollector") as MockCollector, \
+             patch("xpyd_acc.watch.LogprobsComparator"):
+            mock_collector_instance = MagicMock()
+            mock_collector_instance.collect = AsyncMock(side_effect=ConnectionError("down"))
+            MockCollector.return_value = mock_collector_instance
+
+            summary = await run_watch(
+                baseline_url="http://baseline",
+                target_url="http://target",
+                prompt="test",
+                max_iterations=2,
+                interval=0.01,
+                no_live=True,
+            )
+
+            assert summary.total_iterations == 2
+            assert summary.errors == 2
+            assert all(it.error == "down" for it in summary.iterations)
+
+    @pytest.mark.asyncio
+    async def test_json_log(self) -> None:
+        """JSON log file is written correctly."""
+        with patch("xpyd_acc.watch.LogprobsCollector") as MockCollector, \
+             patch("xpyd_acc.watch.LogprobsComparator") as MockComparator:
+            mock_collector_instance = MagicMock()
+            mock_collector_instance.collect = AsyncMock(
+                return_value=_make_logprobs_result(["a"])
+            )
+            MockCollector.return_value = mock_collector_instance
+
+            mock_comparator_instance = MagicMock()
+            mock_comparator_instance.compare.return_value = _matching_report()
+            MockComparator.return_value = mock_comparator_instance
+
+            with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+                log_path = f.name
+
+            await run_watch(
+                baseline_url="http://baseline",
+                target_url="http://target",
+                prompt="test",
+                max_iterations=3,
+                interval=0.01,
+                log_path=log_path,
+                no_live=True,
+            )
+
+            log_data = json.loads(Path(log_path).read_text())
+            assert len(log_data) == 3
+            assert all(entry["passed"] for entry in log_data)
+            Path(log_path).unlink()
+
+    @pytest.mark.asyncio
+    async def test_mixed_results(self) -> None:
+        """Mix of pass and fail iterations."""
+        call_count = 0
+
+        with patch("xpyd_acc.watch.LogprobsCollector") as MockCollector, \
+             patch("xpyd_acc.watch.LogprobsComparator") as MockComparator:
+            mock_collector_instance = MagicMock()
+            mock_collector_instance.collect = AsyncMock(
+                return_value=_make_logprobs_result(["a", "b"])
+            )
+            MockCollector.return_value = mock_collector_instance
+
+            def compare_side_effect(*args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                if call_count % 2 == 0:
+                    return _divergent_report()
+                return _matching_report()
+
+            mock_comparator_instance = MagicMock()
+            mock_comparator_instance.compare.side_effect = compare_side_effect
+            MockComparator.return_value = mock_comparator_instance
+
+            summary = await run_watch(
+                baseline_url="http://baseline",
+                target_url="http://target",
+                prompt="test",
+                max_iterations=4,
+                interval=0.01,
+                no_live=True,
+            )
+
+            assert summary.total_iterations == 4
+            assert summary.passed == 2
+            assert summary.failed == 2
+            assert summary.pass_rate == 0.5


### PR DESCRIPTION
## Summary
Add `xpyd-acc watch` subcommand for continuous accuracy monitoring of PD disaggregated endpoints.

## Changes
- **`src/xpyd_acc/watch.py`**: Core watch loop with async iteration, Rich live display, JSON logging, alert threshold
- **`src/xpyd_acc/cli.py`**: New `watch` subparser with all flags (interval, max-iterations, alert-threshold, log, etc.)
- **`tests/test_watch.py`**: 7 tests covering max iterations, alert threshold, error handling, JSON log, mixed results

## Features
- `--interval <seconds>` — check frequency (default 60s)
- `--max-iterations <n>` — stop after N checks
- `--alert-threshold <n>` — exit code 1 after N consecutive failures
- `--log <path>` — JSON log of every iteration
- Rich live table with rolling pass rate
- Ctrl+C gracefully prints summary
- Full support for sampling params, profiles, retries, healthcheck

## Tests
All 369 tests pass (7 new + 362 existing).

Closes #65