### PR TITLE
feat: snapshot baseline capture & replay (M30)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -215,3 +215,11 @@
 - JSON log file via `--log <path>` for post-hoc analysis
 - Ctrl+C gracefully stops and prints summary
 - Useful for monitoring PD accuracy during long-running deployments
+
+## M30: Snapshot Baseline Capture & Replay ⬜
+- `xpyd-acc snapshot capture --baseline <url> --dataset <path> --output <snap.json>` — capture baseline once
+- `batch-compare --snapshot <snap.json> --target <url>` — replay without baseline endpoint
+- Snapshot stores: timestamp, endpoint URL, model, per-sample outputs + logprobs
+- Dataset/snapshot validation (mismatched sample IDs raise clear error)
+- Progress bars, template support, all export formats (CSV, JSON, Markdown)
+- Eliminates redundant baseline API calls for repeated comparisons

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -108,8 +108,12 @@ def main(argv: list[str] | None = None) -> None:
     oc.add_argument("--target-file", help="Path to file with target output")
 
     bc = sub.add_parser("batch-compare", help="Run batch dataset comparison")
-    bc.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    bc.add_argument("--baseline", default=None, help="Baseline endpoint URL")
     bc.add_argument("--target", required=True, help="Target endpoint URL")
+    bc.add_argument(
+        "--snapshot", default=None, metavar="SNAPSHOT_JSON",
+        help="Use saved snapshot as baseline (mutually exclusive with --baseline)",
+    )
     bc.add_argument("--dataset", required=True, help="Path to JSONL dataset file")
     bc.add_argument("--model", default=None, help="Model name (default: default)")
     bc.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
@@ -275,6 +279,38 @@ def main(argv: list[str] | None = None) -> None:
 
     sub.add_parser("profiles", help="List available named profiles")
 
+    # snapshot capture
+    sc = sub.add_parser("snapshot", help="Capture baseline outputs as a snapshot")
+    sc.add_argument("action", choices=["capture"], help="Snapshot action")
+    sc.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    sc.add_argument("--dataset", required=True, help="Path to JSONL dataset file")
+    sc.add_argument("--output", required=True, help="Output snapshot JSON path")
+    sc.add_argument("--model", default=None, help="Model name (default: default)")
+    sc.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
+    sc.add_argument("--api-key", default=None, help="API key for endpoint")
+    sc.add_argument(
+        "--concurrency", type=int, default=None,
+        help="Max concurrent requests (default: 5)",
+    )
+    sc.add_argument("--retries", type=int, default=None, help="Max retry attempts (default: 3)")
+    sc.add_argument(
+        "--retry-delay", type=float, default=None,
+        help="Base retry delay in seconds (default: 1.0)",
+    )
+    sc.add_argument(
+        "--timeout", type=float, default=None,
+        help="HTTP request timeout in seconds (default: 120.0)",
+    )
+    sc.add_argument(
+        "--template", default=None,
+        help="Prompt template: built-in name or path to YAML/TOML file",
+    )
+    sc.add_argument(
+        "--no-progress", action="store_true", default=False,
+        help="Disable progress bar",
+    )
+    _add_sampling_args(sc)
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -385,6 +421,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_aggregate(args)
     elif args.command == "watch":
         _run_watch(args)
+    elif args.command == "snapshot":
+        asyncio.run(_run_snapshot(args))
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -439,6 +477,21 @@ async def _run_healthcheck(args: argparse.Namespace) -> None:
 
 async def _run_batch_compare(args: argparse.Namespace) -> None:
     """Run batch dataset comparison."""
+    # Validate --baseline vs --snapshot
+    snapshot_path = getattr(args, "snapshot", None)
+    has_baseline = args.baseline is not None
+    if snapshot_path and has_baseline:
+        print("Error: --baseline and --snapshot are mutually exclusive")
+        sys.exit(2)
+    if not snapshot_path and not has_baseline:
+        print("Error: one of --baseline or --snapshot is required")
+        sys.exit(2)
+
+    # Handle snapshot replay mode
+    if snapshot_path:
+        await _run_batch_with_snapshot(args)
+        return
+
     # Handle rerun mode
     if getattr(args, "rerun", None):
         await _run_rerun(args)
@@ -1061,3 +1114,260 @@ def _run_watch(args: argparse.Namespace) -> None:
 
     if args.alert_threshold and summary.consecutive_failures_at_end >= args.alert_threshold:
         sys.exit(1)
+
+
+async def _run_batch_with_snapshot(args: argparse.Namespace) -> None:
+    """Run batch comparison using a saved snapshot as baseline."""
+    from xpyd_acc.batch_compare import (
+        DatasetSample,
+        SampleResult,
+        _collect_output,
+        _find_first_divergence,
+        _tokenize,
+        classify_divergence,
+        compute_report,
+        export_csv,
+        export_markdown,
+        format_report,
+        load_dataset,
+    )
+    from xpyd_acc.output_compare import MatchConfig, normalized_match
+    from xpyd_acc.sampling import SamplingParams
+    from xpyd_acc.snapshot import load_snapshot, validate_snapshot_dataset
+
+    sampling = SamplingParams.from_args(args)
+    snapshot = load_snapshot(args.snapshot)
+    samples = load_dataset(args.dataset)
+    validate_snapshot_dataset(snapshot, samples)
+
+    # Apply template if specified
+    if args.template:
+        from xpyd_acc.templates import resolve_template
+
+        template = resolve_template(args.template)
+        print(f"Using template: {template.name}")
+        for sample in samples:
+            variables = {"prompt": sample.prompt, **sample.metadata}
+            sample.prompt = template.render(variables)
+
+    print(f"Using snapshot from {snapshot.captured_at} ({len(snapshot.samples)} samples)")
+    print(f"Target: {args.target}")
+
+    if not args.skip_healthcheck:
+        await _preflight_healthcheck([args.target], api_key=args.api_key)
+
+    snap_by_id = {s.sample_id: s for s in snapshot.samples}
+
+    match_config = MatchConfig(
+        normalize_whitespace=args.normalize_whitespace,
+        ignore_case=args.ignore_case,
+        numeric_tolerance=args.numeric_tolerance,
+    )
+    effective_match = match_config if (
+        match_config.normalize_whitespace
+        or match_config.ignore_case
+        or match_config.numeric_tolerance is not None
+    ) else None
+
+    import asyncio
+
+    semaphore = asyncio.Semaphore(args.concurrency or 5)
+    results: list[SampleResult] = []
+    completed = 0
+    total = len(samples)
+
+    use_progress = not args.no_progress and sys.stderr.isatty()
+    progress_ctx = None
+    task_id = None
+
+    if use_progress:
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            TextColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+        )
+
+        progress_ctx = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("•"),
+            TimeElapsedColumn(),
+            TextColumn("•"),
+            TimeRemainingColumn(),
+        )
+
+    def on_progress_update(done: int, total: int) -> None:
+        if progress_ctx is not None and task_id is not None:
+            progress_ctx.update(task_id, completed=done)
+
+    async def process_one(sample: DatasetSample) -> SampleResult:
+        nonlocal completed
+        snap_sample = snap_by_id[sample.id]
+        baseline_text = snap_sample.output
+        baseline_lp = snap_sample.logprobs
+
+        async with semaphore:
+            target_text, target_lp = await _collect_output(
+                args.target, sample.prompt,
+                model=args.model or snapshot.model,
+                max_tokens=args.max_tokens or 64,
+                api_key=args.api_key or "no-key",
+                retries=args.retries or 3,
+                retry_delay=args.retry_delay or 1.0,
+                sampling_params=sampling,
+                timeout=args.timeout or 120.0,
+            )
+
+        b_tokens = _tokenize(baseline_text)
+        t_tokens = _tokenize(target_text)
+        exact = normalized_match(baseline_text, target_text, effective_match)
+        div_idx = _find_first_divergence(b_tokens, t_tokens)
+
+        b_lp_at_div = None
+        t_lp_at_div = None
+        gap = None
+
+        if div_idx is not None and div_idx < len(target_lp):
+            lp_entry = target_lp[div_idx]
+            t_lp_at_div = lp_entry.get("logprob")
+            top_lps = lp_entry.get("top_logprobs", [])
+            if len(top_lps) >= 2:
+                gap = abs(top_lps[0].get("logprob", 0) - top_lps[1].get("logprob", 0))
+        if div_idx is not None and div_idx < len(baseline_lp):
+            b_lp_at_div = baseline_lp[div_idx].get("logprob")
+
+        threshold = args.logprob_gap_threshold or 0.1
+        classification = "match" if exact else classify_divergence(gap, threshold=threshold)
+        ctx_len = len(_tokenize(sample.prompt))
+
+        completed += 1
+        on_progress_update(completed, total)
+
+        return SampleResult(
+            sample_id=sample.id,
+            prompt=sample.prompt,
+            baseline_output=baseline_text,
+            target_output=target_text,
+            exact_match=exact,
+            first_divergence_index=div_idx,
+            baseline_logprob_at_divergence=b_lp_at_div,
+            target_logprob_at_divergence=t_lp_at_div,
+            logprob_gap=gap,
+            classification=classification,
+            context_length=ctx_len,
+        )
+
+    if progress_ctx is not None:
+        progress_ctx.start()
+        task_id = progress_ctx.add_task("Comparing samples", total=total)
+
+    try:
+        tasks = [process_one(s) for s in samples]
+        results = list(await asyncio.gather(*tasks))
+    finally:
+        if progress_ctx is not None:
+            progress_ctx.stop()
+
+    report = compute_report(results, logprob_gap_threshold=args.logprob_gap_threshold or 0.1)
+
+    print()
+    print(format_report(report))
+
+    if args.csv:
+        export_csv(report, args.csv)
+        print(f"\nCSV exported to {args.csv}")
+
+    if args.json_path:
+        from pathlib import Path
+        Path(args.json_path).write_text(report.to_json())
+        print(f"\nJSON exported to {args.json_path}")
+
+    if args.markdown:
+        export_markdown(report, args.markdown)
+        print(f"\nMarkdown exported to {args.markdown}")
+
+    if report.divergent_samples > 0:
+        sys.exit(1)
+
+
+async def _run_snapshot(args: argparse.Namespace) -> None:
+    """Run snapshot capture."""
+    from xpyd_acc.batch_compare import load_dataset
+    from xpyd_acc.config import load_config
+    from xpyd_acc.sampling import SamplingParams
+    from xpyd_acc.snapshot import capture_snapshot, save_snapshot
+
+    cfg = load_config(args.config)
+    defaults = cfg.get("defaults", {}) if cfg else {}
+
+    sampling = SamplingParams.from_args(args)
+    samples = load_dataset(args.dataset)
+
+    # Apply template if specified
+    if args.template:
+        from xpyd_acc.templates import resolve_template
+
+        template = resolve_template(args.template)
+        print(f"Using template: {template.name}")
+        for sample in samples:
+            variables = {"prompt": sample.prompt, **sample.metadata}
+            sample.prompt = template.render(variables)
+
+    print(f"Capturing snapshot: {len(samples)} samples from {args.baseline}")
+
+    use_progress = not args.no_progress and sys.stderr.isatty()
+    progress_ctx = None
+    task_id = None
+
+    if use_progress:
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            TextColumn,
+            TimeElapsedColumn,
+            TimeRemainingColumn,
+        )
+
+        progress_ctx = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TextColumn("•"),
+            TimeElapsedColumn(),
+            TextColumn("•"),
+            TimeRemainingColumn(),
+        )
+
+    def on_progress(completed: int, total: int) -> None:
+        if progress_ctx is not None and task_id is not None:
+            progress_ctx.update(task_id, completed=completed)
+
+    if progress_ctx is not None:
+        progress_ctx.start()
+        task_id = progress_ctx.add_task("Capturing snapshot", total=len(samples))
+
+    try:
+        snap = await capture_snapshot(
+            samples,
+            args.baseline,
+            model=args.model or defaults.get("model", "default"),
+            max_tokens=args.max_tokens or defaults.get("max_tokens", 64),
+            api_key=args.api_key or defaults.get("api_key", "no-key"),
+            concurrency=args.concurrency or defaults.get("concurrency", 5),
+            retries=args.retries or defaults.get("retries", 3),
+            retry_delay=args.retry_delay or defaults.get("retry_delay", 1.0),
+            sampling_params=sampling,
+            timeout=args.timeout or defaults.get("timeout", 120.0),
+            on_progress=on_progress if use_progress else None,
+        )
+    finally:
+        if progress_ctx is not None:
+            progress_ctx.stop()
+
+    save_snapshot(snap, args.output)
+    print(f"\nSnapshot saved to {args.output} ({len(snap.samples)} samples)")

--- a/src/xpyd_acc/snapshot.py
+++ b/src/xpyd_acc/snapshot.py
@@ -1,0 +1,151 @@
+"""Snapshot baseline capture & replay for batch comparisons."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from xpyd_acc.batch_compare import DatasetSample, _collect_output
+from xpyd_acc.log import get_logger
+
+logger = get_logger("snapshot")
+
+
+@dataclass
+class SnapshotSample:
+    """Captured baseline output for a single sample."""
+
+    sample_id: str
+    prompt: str
+    output: str
+    logprobs: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class Snapshot:
+    """Captured baseline outputs for an entire dataset."""
+
+    captured_at: str
+    endpoint_url: str
+    model: str
+    samples: list[SnapshotSample] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        """Serialize snapshot to JSON."""
+        return json.dumps(asdict(self), indent=2)
+
+    @classmethod
+    def from_json(cls, text: str) -> Snapshot:
+        """Deserialize snapshot from JSON string."""
+        data = json.loads(text)
+        samples = [SnapshotSample(**s) for s in data.get("samples", [])]
+        return cls(
+            captured_at=data["captured_at"],
+            endpoint_url=data["endpoint_url"],
+            model=data["model"],
+            samples=samples,
+        )
+
+
+async def capture_snapshot(
+    samples: list[DatasetSample],
+    baseline_url: str,
+    *,
+    model: str = "default",
+    max_tokens: int = 64,
+    api_key: str = "no-key",
+    concurrency: int = 5,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+    sampling_params: Any | None = None,
+    timeout: float = 120.0,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> Snapshot:
+    """Capture baseline outputs for all samples.
+
+    Sends each sample prompt to the baseline endpoint and stores the output
+    and logprobs for later replay.
+    """
+    logger.info(
+        "Capturing snapshot: %d samples from %s", len(samples), baseline_url,
+    )
+    semaphore = asyncio.Semaphore(concurrency)
+    completed = 0
+    total = len(samples)
+
+    async def _capture_one(sample: DatasetSample) -> SnapshotSample:
+        nonlocal completed
+        async with semaphore:
+            text, logprobs = await _collect_output(
+                baseline_url, sample.prompt, model=model,
+                max_tokens=max_tokens, api_key=api_key,
+                retries=retries, retry_delay=retry_delay,
+                sampling_params=sampling_params, timeout=timeout,
+            )
+        completed += 1
+        if on_progress is not None:
+            on_progress(completed, total)
+        return SnapshotSample(
+            sample_id=sample.id,
+            prompt=sample.prompt,
+            output=text,
+            logprobs=logprobs,
+        )
+
+    tasks = [_capture_one(s) for s in samples]
+    snap_samples = await asyncio.gather(*tasks)
+
+    return Snapshot(
+        captured_at=datetime.now(timezone.utc).isoformat(),
+        endpoint_url=baseline_url,
+        model=model,
+        samples=list(snap_samples),
+    )
+
+
+def save_snapshot(snapshot: Snapshot, path: str | Path) -> None:
+    """Write snapshot to a JSON file."""
+    path = Path(path)
+    path.write_text(snapshot.to_json())
+    logger.info("Snapshot saved to %s (%d samples)", path, len(snapshot.samples))
+
+
+def load_snapshot(path: str | Path) -> Snapshot:
+    """Load snapshot from a JSON file."""
+    path = Path(path)
+    text = path.read_text()
+    snapshot = Snapshot.from_json(text)
+    logger.info(
+        "Snapshot loaded from %s (%d samples, captured %s)",
+        path, len(snapshot.samples), snapshot.captured_at,
+    )
+    return snapshot
+
+
+def validate_snapshot_dataset(
+    snapshot: Snapshot, samples: list[DatasetSample],
+) -> None:
+    """Validate that snapshot sample IDs match the dataset.
+
+    Raises ValueError if there is a mismatch.
+    """
+    snap_ids = {s.sample_id for s in snapshot.samples}
+    dataset_ids = {s.id for s in samples}
+
+    missing = dataset_ids - snap_ids
+    extra = snap_ids - dataset_ids
+
+    if missing or extra:
+        parts = []
+        if missing:
+            examples = sorted(missing)[:5]
+            parts.append(f"missing from snapshot: {examples}")
+        if extra:
+            examples = sorted(extra)[:5]
+            parts.append(f"extra in snapshot: {examples}")
+        msg = f"Snapshot/dataset mismatch: {'; '.join(parts)}"
+        raise ValueError(msg)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,178 @@
+"""Tests for snapshot baseline capture & replay."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_acc.batch_compare import DatasetSample
+from xpyd_acc.snapshot import (
+    Snapshot,
+    SnapshotSample,
+    capture_snapshot,
+    load_snapshot,
+    save_snapshot,
+    validate_snapshot_dataset,
+)
+
+
+class TestSnapshotSerialization:
+    """Test Snapshot JSON round-trip."""
+
+    def test_to_json_and_from_json(self):
+        snap = Snapshot(
+            captured_at="2026-04-04T20:00:00+00:00",
+            endpoint_url="http://baseline:8000",
+            model="test-model",
+            samples=[
+                SnapshotSample(
+                    sample_id="0",
+                    prompt="What is 2+2?",
+                    output="4",
+                    logprobs=[{"token": "4", "logprob": -0.01}],
+                ),
+                SnapshotSample(
+                    sample_id="1",
+                    prompt="Hello",
+                    output="Hi there!",
+                    logprobs=[],
+                ),
+            ],
+        )
+        json_str = snap.to_json()
+        loaded = Snapshot.from_json(json_str)
+        assert loaded.captured_at == snap.captured_at
+        assert loaded.endpoint_url == snap.endpoint_url
+        assert loaded.model == snap.model
+        assert len(loaded.samples) == 2
+        assert loaded.samples[0].sample_id == "0"
+        assert loaded.samples[0].output == "4"
+        assert loaded.samples[1].prompt == "Hello"
+
+    def test_empty_snapshot(self):
+        snap = Snapshot(
+            captured_at="2026-01-01T00:00:00+00:00",
+            endpoint_url="http://x:8000",
+            model="m",
+        )
+        loaded = Snapshot.from_json(snap.to_json())
+        assert len(loaded.samples) == 0
+
+
+class TestSaveLoad:
+    """Test file I/O for snapshots."""
+
+    def test_save_and_load(self, tmp_path: Path):
+        snap = Snapshot(
+            captured_at="2026-04-04T20:00:00+00:00",
+            endpoint_url="http://baseline:8000",
+            model="test-model",
+            samples=[
+                SnapshotSample(
+                    sample_id="s1",
+                    prompt="prompt1",
+                    output="output1",
+                    logprobs=[{"token": "out", "logprob": -0.5}],
+                ),
+            ],
+        )
+        path = tmp_path / "snap.json"
+        save_snapshot(snap, path)
+        assert path.exists()
+
+        loaded = load_snapshot(path)
+        assert loaded.model == "test-model"
+        assert len(loaded.samples) == 1
+        assert loaded.samples[0].output == "output1"
+
+
+class TestValidateSnapshotDataset:
+    """Test snapshot/dataset validation."""
+
+    def test_matching(self):
+        snap = Snapshot(
+            captured_at="t", endpoint_url="u", model="m",
+            samples=[
+                SnapshotSample(sample_id="0", prompt="p0", output="o0"),
+                SnapshotSample(sample_id="1", prompt="p1", output="o1"),
+            ],
+        )
+        dataset = [
+            DatasetSample(id="0", prompt="p0"),
+            DatasetSample(id="1", prompt="p1"),
+        ]
+        # Should not raise
+        validate_snapshot_dataset(snap, dataset)
+
+    def test_missing_from_snapshot(self):
+        snap = Snapshot(
+            captured_at="t", endpoint_url="u", model="m",
+            samples=[SnapshotSample(sample_id="0", prompt="p0", output="o0")],
+        )
+        dataset = [
+            DatasetSample(id="0", prompt="p0"),
+            DatasetSample(id="1", prompt="p1"),
+        ]
+        with pytest.raises(ValueError, match="missing from snapshot"):
+            validate_snapshot_dataset(snap, dataset)
+
+    def test_extra_in_snapshot(self):
+        snap = Snapshot(
+            captured_at="t", endpoint_url="u", model="m",
+            samples=[
+                SnapshotSample(sample_id="0", prompt="p0", output="o0"),
+                SnapshotSample(sample_id="99", prompt="px", output="ox"),
+            ],
+        )
+        dataset = [DatasetSample(id="0", prompt="p0")]
+        with pytest.raises(ValueError, match="extra in snapshot"):
+            validate_snapshot_dataset(snap, dataset)
+
+
+class TestCaptureSnapshot:
+    """Test capture_snapshot with mocked HTTP."""
+
+    @pytest.mark.asyncio
+    async def test_capture(self):
+        samples = [
+            DatasetSample(id="a", prompt="hello"),
+            DatasetSample(id="b", prompt="world"),
+        ]
+
+        call_count = 0
+
+        async def mock_collect(url, prompt, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return (f"reply-{prompt}", [{"token": "r", "logprob": -0.1}])
+
+        with patch("xpyd_acc.snapshot._collect_output", side_effect=mock_collect):
+            snap = await capture_snapshot(
+                samples, "http://baseline:8000", model="m",
+            )
+
+        assert call_count == 2
+        assert len(snap.samples) == 2
+        assert snap.endpoint_url == "http://baseline:8000"
+        assert snap.model == "m"
+        assert snap.samples[0].output == "reply-hello"
+        assert snap.samples[1].output == "reply-world"
+        assert snap.captured_at  # non-empty
+
+    @pytest.mark.asyncio
+    async def test_capture_with_progress(self):
+        samples = [DatasetSample(id="x", prompt="test")]
+        progress_calls = []
+
+        async def mock_collect(url, prompt, **kwargs):
+            return ("out", [])
+
+        with patch("xpyd_acc.snapshot._collect_output", side_effect=mock_collect):
+            await capture_snapshot(
+                samples, "http://b:8000",
+                on_progress=lambda done, total: progress_calls.append((done, total)),
+            )
+
+        assert progress_calls == [(1, 1)]


### PR DESCRIPTION
## Summary

Add snapshot baseline capture & replay to eliminate redundant baseline API calls during repeated comparisons.

### Changes
- **`snapshot.py`** module: `Snapshot`/`SnapshotSample` dataclasses, `capture_snapshot()`, `save_snapshot()`, `load_snapshot()`, `validate_snapshot_dataset()`
- **CLI**: `xpyd-acc snapshot capture` subcommand with progress bars, template support, sampling params
- **CLI**: `batch-compare --snapshot <path>` flag (mutually exclusive with `--baseline`)
- **Tests**: 8 new tests covering serialization, file I/O, validation, and async capture
- **ROADMAP.md**: Added M30

### Usage
```bash
# Capture baseline once
xpyd-acc snapshot capture --baseline http://baseline:8000 --dataset data.jsonl --output snap.json

# Replay without baseline endpoint
xpyd-acc batch-compare --snapshot snap.json --target http://target:8000 --dataset data.jsonl
```

### Test results
377 passed, 0 failures

Closes #67