### PR TITLE
feat: prompt deduplication for batch comparison

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -250,3 +250,12 @@
 - Request IDs logged at DEBUG level
 - `--no-request-id` flag to disable the feature
 - Tests for request ID generation and header injection
+
+## M34: Prompt Deduplication for Batch Comparison ✅
+- `--deduplicate` flag on `batch-compare` to send each unique prompt only once per endpoint
+- TOML config: `[batch] deduplicate = true`
+- Results mapped back to all samples sharing the same prompt
+- Reduces API calls when dataset contains duplicate prompts
+- Works with single-target batch comparison and rerun mode
+- No behavior change when flag is off (default)
+- Tests for dedup on/off, with and without duplicates

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -259,6 +259,7 @@ async def run_batch(
     sampling_params: Any | None = None,
     timeout: float = 120.0,
     enable_request_ids: bool = True,
+    deduplicate: bool = False,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report.
 
@@ -267,31 +268,63 @@ async def run_batch(
             Receives (completed_count, total_count).
         timeout: HTTP request timeout in seconds (default 120.0).
         enable_request_ids: Attach X-Request-ID headers to API requests.
+        deduplicate: If True, send each unique prompt only once per endpoint
+            and reuse results for duplicate prompts. Saves API calls.
     """
     logger.info("Starting batch comparison: %d samples, concurrency=%d", len(samples), concurrency)
+
+    # Deduplication: group samples by prompt, send unique prompts only once
+    if deduplicate:
+        prompt_groups: dict[str, list[DatasetSample]] = {}
+        for s in samples:
+            prompt_groups.setdefault(s.prompt, []).append(s)
+        unique_prompts = list(prompt_groups.keys())
+        api_calls_saved = (len(samples) - len(unique_prompts)) * 2  # baseline + target
+        logger.info(
+            "Deduplication: %d unique prompts from %d samples (%d API calls saved)",
+            len(unique_prompts), len(samples), api_calls_saved,
+        )
+    else:
+        prompt_groups = {}
+        unique_prompts = []
+
     semaphore = asyncio.Semaphore(concurrency)
     results: list[SampleResult] = []
     completed = 0
 
-    async def process_sample(sample: DatasetSample) -> SampleResult:
+    async def _collect_pair(
+        prompt: str,
+    ) -> tuple[str, list[dict[str, Any]], str, str, list[dict[str, Any]], str]:
+        """Collect outputs from both endpoints for a single prompt."""
         b_rid = str(uuid.uuid4()) if enable_request_ids else ""
         t_rid = str(uuid.uuid4()) if enable_request_ids else ""
         async with semaphore:
             baseline_text, baseline_lp, b_rid_out = await _collect_output(
-                baseline_url, sample.prompt, model=model,
+                baseline_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
                 sampling_params=sampling_params, timeout=timeout,
                 request_id=b_rid if enable_request_ids else None,
             )
             target_text, target_lp, t_rid_out = await _collect_output(
-                target_url, sample.prompt, model=model,
+                target_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
                 sampling_params=sampling_params, timeout=timeout,
                 request_id=t_rid if enable_request_ids else None,
             )
+        return baseline_text, baseline_lp, b_rid_out, target_text, target_lp, t_rid_out
 
+    def _build_result(
+        sample: DatasetSample,
+        baseline_text: str,
+        baseline_lp: list[dict[str, Any]],
+        b_rid_out: str,
+        target_text: str,
+        target_lp: list[dict[str, Any]],
+        t_rid_out: str,
+    ) -> SampleResult:
+        """Build a SampleResult from collected outputs."""
         b_tokens = _tokenize(baseline_text)
         t_tokens = _tokenize(target_text)
 
@@ -338,6 +371,41 @@ async def run_batch(
             context_length=ctx_len,
             request_ids=req_ids,
         )
+
+    _PairResult = tuple[str, list[dict[str, Any]], str, str, list[dict[str, Any]], str]
+
+    if deduplicate:
+        # Send unique prompts only, then fan out results
+        total = len(unique_prompts)
+
+        async def _tracked_unique(prompt: str) -> _PairResult:
+            nonlocal completed
+            result = await _collect_pair(prompt)
+            completed += 1
+            if on_progress is not None:
+                on_progress(completed, total)
+            return result
+
+        tasks = [_tracked_unique(p) for p in unique_prompts]
+        pair_results = await asyncio.gather(*tasks)
+
+        # Map back to all samples
+        prompt_to_pair: dict[str, _PairResult] = {}
+        for prompt, pair in zip(unique_prompts, pair_results):
+            prompt_to_pair[prompt] = pair
+
+        # Build results in original sample order
+        all_results: list[SampleResult] = []
+        for sample in samples:
+            bt, blp, brid, tt, tlp, trid = prompt_to_pair[sample.prompt]
+            all_results.append(_build_result(sample, bt, blp, brid, tt, tlp, trid))
+        results = all_results
+
+        return compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
+
+    async def process_sample(sample: DatasetSample) -> SampleResult:
+        bt, blp, brid, tt, tlp, trid = await _collect_pair(sample.prompt)
+        return _build_result(sample, bt, blp, brid, tt, tlp, trid)
 
     total = len(samples)
 

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -186,6 +186,10 @@ def main(argv: list[str] | None = None) -> None:
         "--no-request-id", action="store_true", default=False,
         help="Disable X-Request-ID headers on API requests",
     )
+    bc.add_argument(
+        "--deduplicate", action="store_true", default=False,
+        help="Send each unique prompt only once per endpoint, reuse results for duplicates",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -652,6 +656,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
                 match_config=effective_match,
                 sampling_params=sampling,
                 timeout=args.timeout,
+                deduplicate=getattr(args, "deduplicate", False),
             )
     finally:
         if progress_ctx is not None:
@@ -862,6 +867,7 @@ async def _run_rerun(args: argparse.Namespace) -> None:
             match_config=effective_match,
             sampling_params=sampling,
             timeout=args.timeout,
+            deduplicate=getattr(args, "deduplicate", False),
         )
     finally:
         if progress_ctx is not None:

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -52,6 +52,7 @@ class BatchConfig:
     dataset: str | None = None
     csv: str | None = None
     fail_threshold: float | None = None
+    deduplicate: bool = False
 
 
 @dataclass
@@ -186,6 +187,7 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
             "dataset": config.batch.dataset,
             "csv": config.batch.csv,
             "fail_threshold": config.batch.fail_threshold,
+            "deduplicate": config.batch.deduplicate,
         }
         for key, config_val in batch_map.items():
             if key in merged and merged[key] is None and config_val is not None:

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -1,0 +1,167 @@
+"""Tests for prompt deduplication in batch comparison."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from xpyd_acc.batch_compare import DatasetSample, run_batch
+
+
+def test_deduplicate_reduces_api_calls() -> None:
+    """With deduplication, duplicate prompts should only trigger one API call each."""
+    samples = [
+        DatasetSample(id="1", prompt="What is 2+2?"),
+        DatasetSample(id="2", prompt="What is 2+2?"),  # duplicate
+        DatasetSample(id="3", prompt="What is 3+3?"),
+        DatasetSample(id="4", prompt="What is 2+2?"),  # duplicate
+    ]
+    mock_output = ("hello world", [], "")
+
+    with patch(
+        "xpyd_acc.batch_compare._collect_output",
+        new_callable=AsyncMock,
+    ) as mock_co:
+        mock_co.return_value = mock_output
+        report = asyncio.run(run_batch(
+            samples,
+            "http://baseline",
+            "http://target",
+            deduplicate=True,
+            enable_request_ids=False,
+        ))
+
+    # 2 unique prompts × 2 endpoints = 4 calls (not 4 × 2 = 8)
+    assert mock_co.call_count == 4
+    assert report.total_samples == 4
+    assert len(report.results) == 4
+
+
+def test_no_deduplicate_sends_all_calls() -> None:
+    """Without deduplication, every sample sends its own API calls."""
+    samples = [
+        DatasetSample(id="1", prompt="What is 2+2?"),
+        DatasetSample(id="2", prompt="What is 2+2?"),
+        DatasetSample(id="3", prompt="What is 3+3?"),
+    ]
+    mock_output = ("hello world", [], "")
+
+    with patch(
+        "xpyd_acc.batch_compare._collect_output",
+        new_callable=AsyncMock,
+    ) as mock_co:
+        mock_co.return_value = mock_output
+        report = asyncio.run(run_batch(
+            samples,
+            "http://baseline",
+            "http://target",
+            deduplicate=False,
+            enable_request_ids=False,
+        ))
+
+    # 3 samples × 2 endpoints = 6
+    assert mock_co.call_count == 6
+    assert report.total_samples == 3
+
+
+def test_deduplicate_no_duplicates() -> None:
+    """Dedup with all unique prompts works same as no-dedup."""
+    samples = [
+        DatasetSample(id="1", prompt="What is 2+2?"),
+        DatasetSample(id="2", prompt="What is 3+3?"),
+        DatasetSample(id="3", prompt="What is 4+4?"),
+    ]
+    mock_output = ("hello world", [], "")
+
+    with patch(
+        "xpyd_acc.batch_compare._collect_output",
+        new_callable=AsyncMock,
+    ) as mock_co:
+        mock_co.return_value = mock_output
+        report = asyncio.run(run_batch(
+            samples,
+            "http://baseline",
+            "http://target",
+            deduplicate=True,
+            enable_request_ids=False,
+        ))
+
+    # 3 unique × 2 endpoints = 6
+    assert mock_co.call_count == 6
+    assert report.total_samples == 3
+
+
+def test_deduplicate_preserves_sample_ids() -> None:
+    """Each result has correct sample_id even with dedup."""
+    samples = [
+        DatasetSample(id="a", prompt="prompt1"),
+        DatasetSample(id="b", prompt="prompt1"),
+        DatasetSample(id="c", prompt="prompt2"),
+    ]
+    mock_output = ("hello world", [], "")
+
+    with patch(
+        "xpyd_acc.batch_compare._collect_output",
+        new_callable=AsyncMock,
+    ) as mock_co:
+        mock_co.return_value = mock_output
+        report = asyncio.run(run_batch(
+            samples,
+            "http://baseline",
+            "http://target",
+            deduplicate=True,
+            enable_request_ids=False,
+        ))
+
+    result_ids = [r.sample_id for r in report.results]
+    assert result_ids == ["a", "b", "c"]
+
+
+def test_deduplicate_progress_callback() -> None:
+    """Progress callback fires once per unique prompt, not per sample."""
+    samples = [
+        DatasetSample(id="1", prompt="p1"),
+        DatasetSample(id="2", prompt="p1"),
+        DatasetSample(id="3", prompt="p2"),
+    ]
+    mock_output = ("hello", [], "")
+    progress_calls: list[tuple[int, int]] = []
+
+    def on_progress(done: int, total: int) -> None:
+        progress_calls.append((done, total))
+
+    with patch(
+        "xpyd_acc.batch_compare._collect_output",
+        new_callable=AsyncMock,
+    ) as mock_co:
+        mock_co.return_value = mock_output
+        asyncio.run(run_batch(
+            samples,
+            "http://baseline",
+            "http://target",
+            deduplicate=True,
+            enable_request_ids=False,
+            on_progress=on_progress,
+        ))
+
+    # 2 unique prompts → 2 progress calls
+    assert len(progress_calls) == 2
+    assert progress_calls[-1] == (2, 2)
+
+
+def test_deduplicate_config_default_false() -> None:
+    """BatchConfig.deduplicate defaults to False."""
+    from xpyd_acc.config import BatchConfig
+
+    cfg = BatchConfig()
+    assert cfg.deduplicate is False
+
+
+def test_deduplicate_config_from_toml() -> None:
+    """BatchConfig picks up deduplicate from TOML."""
+    from xpyd_acc.config import BatchConfig, _parse_section
+
+    raw = {"deduplicate": True, "concurrency": 10}
+    cfg = _parse_section(raw, BatchConfig)
+    assert cfg.deduplicate is True
+    assert cfg.concurrency == 10


### PR DESCRIPTION
## Summary
Add `--deduplicate` flag to `batch-compare` that sends each unique prompt only once per endpoint when the dataset contains duplicate prompts. Results are mapped back to all samples sharing the same prompt, saving API calls.

## Changes
- `run_batch()` accepts `deduplicate` parameter
- `--deduplicate` CLI flag on `batch-compare`
- TOML config: `[batch] deduplicate = true`
- Config → CLI mapping in `config.py`
- Refactored `run_batch()` to extract `_collect_pair()` and `_build_result()` helpers
- ROADMAP.md updated with M34
- 7 new tests, all 406 tests pass

Closes #75