### PR TITLE
feat: response caching for batch comparison

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -268,3 +268,16 @@
 - Usage: `eval "$(xpyd-acc completion bash)"` or save to a file
 - `--output <path>` flag to write directly to a file
 - Tests for completion script generation (non-empty output, valid syntax markers)
+
+## M36: Response Caching for Batch Comparison
+- Content-addressable cache: hash(endpoint_url + model + prompt + sampling_params) → cached response
+- `--cache-dir <path>` flag (default: `.xpyd-acc-cache/`)
+- `--no-cache` flag to bypass cache entirely
+- TOML config: `[batch] cache_dir = ".xpyd-acc-cache"`
+- Cache entries stored as JSON with TTL metadata
+- `--cache-ttl <seconds>` flag (default: 3600) — entries older than TTL are re-fetched
+- `xpyd-acc cache clear` subcommand to purge cached responses
+- `xpyd-acc cache stats` subcommand to show cache size, hit rate, entry count
+- Cache hits logged at INFO level, misses at DEBUG
+- Dramatically speeds up reruns and iterative debugging sessions
+- Tests for cache hit/miss, TTL expiry, clear, stats, and no-cache bypass

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -197,6 +197,7 @@ async def _collect_output(
     sampling_params: Any | None = None,
     timeout: float = 120.0,
     request_id: str | None = None,
+    cache: Any | None = None,
 ) -> tuple[str, list[dict[str, Any]], str]:
     """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list, request_id).
 
@@ -207,10 +208,18 @@ async def _collect_output(
         timeout: HTTP request timeout in seconds (default 120.0).
         request_id: Optional request ID to attach as X-Request-ID header.
             If None, no header is sent.
+        cache: Optional ResponseCache instance for caching responses.
     """
     import httpx
 
     from xpyd_acc.retry import retry_async
+
+    # Check cache first
+    sp_dict = sampling_params.to_payload() if sampling_params is not None else None
+    if cache is not None:
+        entry = cache.get(url, model, prompt, sp_dict)
+        if entry is not None:
+            return entry.text, entry.logprobs, entry.request_id
 
     payload: dict[str, Any] = {
         "model": model,
@@ -239,7 +248,15 @@ async def _collect_output(
         logprobs_content = choice.get("logprobs", {}).get("content", [])
         return text, logprobs_content, rid
 
-    return await retry_async(_do_request, retries=retries, base_delay=retry_delay)
+    text, logprobs_list, out_rid = await retry_async(
+        _do_request, retries=retries, base_delay=retry_delay,
+    )
+
+    # Store in cache
+    if cache is not None:
+        cache.put(url, model, prompt, text, logprobs_list, out_rid, sp_dict)
+
+    return text, logprobs_list, out_rid
 
 
 async def run_batch(
@@ -260,6 +277,7 @@ async def run_batch(
     timeout: float = 120.0,
     enable_request_ids: bool = True,
     deduplicate: bool = False,
+    cache: Any | None = None,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report.
 
@@ -305,6 +323,7 @@ async def run_batch(
                 retries=retries, retry_delay=retry_delay,
                 sampling_params=sampling_params, timeout=timeout,
                 request_id=b_rid if enable_request_ids else None,
+                cache=cache,
             )
             target_text, target_lp, t_rid_out = await _collect_output(
                 target_url, prompt, model=model,
@@ -312,6 +331,7 @@ async def run_batch(
                 retries=retries, retry_delay=retry_delay,
                 sampling_params=sampling_params, timeout=timeout,
                 request_id=t_rid if enable_request_ids else None,
+                cache=cache,
             )
         return baseline_text, baseline_lp, b_rid_out, target_text, target_lp, t_rid_out
 

--- a/src/xpyd_acc/cache.py
+++ b/src/xpyd_acc/cache.py
@@ -1,0 +1,181 @@
+"""Response caching for batch comparison.
+
+Content-addressable cache keyed by hash(endpoint_url + model + prompt + sampling_params).
+Entries stored as JSON files with TTL metadata.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from xpyd_acc.log import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_CACHE_DIR = ".xpyd-acc-cache"
+DEFAULT_TTL = 3600  # 1 hour
+
+
+def _cache_key(
+    url: str,
+    model: str,
+    prompt: str,
+    sampling_params: dict[str, Any] | None = None,
+) -> str:
+    """Generate a deterministic cache key from request parameters."""
+    parts = {
+        "url": url,
+        "model": model,
+        "prompt": prompt,
+        "sampling": sampling_params or {},
+    }
+    raw = json.dumps(parts, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+@dataclass
+class CacheEntry:
+    """A cached API response with metadata."""
+
+    text: str
+    logprobs: list[dict[str, Any]]
+    request_id: str
+    timestamp: float
+    url: str
+    model: str
+    prompt_hash: str
+
+    def is_expired(self, ttl: float) -> bool:
+        return (time.time() - self.timestamp) > ttl
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "text": self.text,
+            "logprobs": self.logprobs,
+            "request_id": self.request_id,
+            "timestamp": self.timestamp,
+            "url": self.url,
+            "model": self.model,
+            "prompt_hash": self.prompt_hash,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CacheEntry:
+        return cls(
+            text=data["text"],
+            logprobs=data["logprobs"],
+            request_id=data["request_id"],
+            timestamp=data["timestamp"],
+            url=data["url"],
+            model=data["model"],
+            prompt_hash=data.get("prompt_hash", ""),
+        )
+
+
+@dataclass
+class CacheStats:
+    """Statistics about cache usage."""
+
+    entry_count: int = 0
+    total_size_bytes: int = 0
+    hits: int = 0
+    misses: int = 0
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return self.hits / total if total > 0 else 0.0
+
+
+class ResponseCache:
+    """Content-addressable response cache backed by filesystem."""
+
+    def __init__(self, cache_dir: str | Path = DEFAULT_CACHE_DIR, ttl: float = DEFAULT_TTL):
+        self.cache_dir = Path(cache_dir)
+        self.ttl = ttl
+        self._hits = 0
+        self._misses = 0
+
+    def _entry_path(self, key: str) -> Path:
+        return self.cache_dir / f"{key}.json"
+
+    def get(
+        self,
+        url: str,
+        model: str,
+        prompt: str,
+        sampling_params: dict[str, Any] | None = None,
+    ) -> CacheEntry | None:
+        """Look up a cached response. Returns None on miss or expired entry."""
+        key = _cache_key(url, model, prompt, sampling_params)
+        path = self._entry_path(key)
+        if not path.exists():
+            self._misses += 1
+            logger.debug("Cache miss: %s", key[:12])
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            entry = CacheEntry.from_dict(data)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            self._misses += 1
+            logger.debug("Cache corrupt, treating as miss: %s", key[:12])
+            path.unlink(missing_ok=True)
+            return None
+        if entry.is_expired(self.ttl):
+            self._misses += 1
+            logger.debug("Cache expired: %s", key[:12])
+            path.unlink(missing_ok=True)
+            return None
+        self._hits += 1
+        logger.info("Cache hit: %s", key[:12])
+        return entry
+
+    def put(
+        self,
+        url: str,
+        model: str,
+        prompt: str,
+        text: str,
+        logprobs: list[dict[str, Any]],
+        request_id: str,
+        sampling_params: dict[str, Any] | None = None,
+    ) -> None:
+        """Store a response in the cache."""
+        key = _cache_key(url, model, prompt, sampling_params)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        entry = CacheEntry(
+            text=text,
+            logprobs=logprobs,
+            request_id=request_id,
+            timestamp=time.time(),
+            url=url,
+            model=model,
+            prompt_hash=key,
+        )
+        path = self._entry_path(key)
+        path.write_text(json.dumps(entry.to_dict(), ensure_ascii=False), encoding="utf-8")
+        logger.debug("Cache store: %s", key[:12])
+
+    def clear(self) -> int:
+        """Remove all cache entries. Returns number of entries removed."""
+        if not self.cache_dir.exists():
+            return 0
+        count = 0
+        for f in self.cache_dir.glob("*.json"):
+            f.unlink()
+            count += 1
+        return count
+
+    def stats(self) -> CacheStats:
+        """Get cache statistics."""
+        s = CacheStats(hits=self._hits, misses=self._misses)
+        if self.cache_dir.exists():
+            for f in self.cache_dir.glob("*.json"):
+                s.entry_count += 1
+                s.total_size_bytes += f.stat().st_size
+        return s

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -190,6 +190,32 @@ def main(argv: list[str] | None = None) -> None:
         "--deduplicate", action="store_true", default=False,
         help="Send each unique prompt only once per endpoint, reuse results for duplicates",
     )
+    bc.add_argument(
+        "--cache-dir", default=None,
+        help="Directory for response cache (default: .xpyd-acc-cache)",
+    )
+    bc.add_argument(
+        "--no-cache", action="store_true", default=False,
+        help="Disable response caching entirely",
+    )
+    bc.add_argument(
+        "--cache-ttl", type=float, default=None,
+        help="Cache entry TTL in seconds (default: 3600)",
+    )
+
+    # Cache management subcommand
+    cache_cmd = sub.add_parser("cache", help="Manage response cache")
+    cache_sub = cache_cmd.add_subparsers(dest="cache_action")
+    cache_clear = cache_sub.add_parser("clear", help="Remove all cached responses")
+    cache_clear.add_argument(
+        "--cache-dir", default=None,
+        help="Cache directory (default: .xpyd-acc-cache)",
+    )
+    cache_stats = cache_sub.add_parser("stats", help="Show cache statistics")
+    cache_stats.add_argument(
+        "--cache-dir", default=None,
+        help="Cache directory (default: .xpyd-acc-cache)",
+    )
 
     rp = sub.add_parser("report", help="Generate HTML report from batch comparison JSON")
     rp.add_argument("--input", required=True, help="Path to batch results JSON file")
@@ -454,6 +480,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_watch(args)
     elif args.command == "snapshot":
         asyncio.run(_run_snapshot(args))
+    elif args.command == "cache":
+        _run_cache(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -648,6 +676,15 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             or match_config.numeric_tolerance is not None
         ) else None
 
+        # Set up response cache
+        batch_cache = None
+        if not getattr(args, "no_cache", False):
+            from xpyd_acc.cache import DEFAULT_CACHE_DIR, DEFAULT_TTL, ResponseCache
+
+            cache_dir = getattr(args, "cache_dir", None) or DEFAULT_CACHE_DIR
+            cache_ttl = getattr(args, "cache_ttl", None) or DEFAULT_TTL
+            batch_cache = ResponseCache(cache_dir=cache_dir, ttl=cache_ttl)
+
         is_multi = len(target_urls) > 1
 
         if is_multi:
@@ -687,10 +724,17 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
                 timeout=args.timeout,
                 deduplicate=getattr(args, "deduplicate", False),
                 enable_request_ids=not getattr(args, "no_request_id", False),
+                cache=batch_cache,
             )
     finally:
         if progress_ctx is not None:
             progress_ctx.stop()
+
+    # Print cache stats if caching was active
+    if batch_cache is not None:
+        cs = batch_cache.stats()
+        if cs.hits + cs.misses > 0:
+            print(f"\nCache: {cs.hits} hits, {cs.misses} misses ({cs.hit_rate:.0%} hit rate)")
 
     if multi_report is not None:
         # Multi-target mode
@@ -1244,6 +1288,26 @@ def _run_aggregate(args: argparse.Namespace) -> None:
         Path(args.json_path).write_text(agg_report.to_json())
         print(f"\nAggregated report exported to {args.json_path}")
 
+
+
+def _run_cache(args: argparse.Namespace) -> None:
+    """Manage response cache."""
+    from xpyd_acc.cache import DEFAULT_CACHE_DIR, DEFAULT_TTL, ResponseCache
+
+    cache_dir = getattr(args, "cache_dir", None) or DEFAULT_CACHE_DIR
+    cache = ResponseCache(cache_dir=cache_dir, ttl=DEFAULT_TTL)
+
+    action = getattr(args, "cache_action", None)
+    if action == "clear":
+        count = cache.clear()
+        print(f"Cleared {count} cached entries from {cache_dir}")
+    elif action == "stats":
+        stats = cache.stats()
+        print(f"Cache directory: {cache_dir}")
+        print(f"Entries: {stats.entry_count}")
+        print(f"Total size: {stats.total_size_bytes:,} bytes")
+    else:
+        print("Usage: xpyd-acc cache {clear|stats}")
 
 
 def _run_watch(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -53,6 +53,8 @@ class BatchConfig:
     csv: str | None = None
     fail_threshold: float | None = None
     deduplicate: bool = False
+    cache_dir: str | None = None
+    cache_ttl: float | None = None
 
 
 @dataclass
@@ -188,6 +190,8 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
             "csv": config.batch.csv,
             "fail_threshold": config.batch.fail_threshold,
             "deduplicate": config.batch.deduplicate,
+            "cache_dir": config.batch.cache_dir,
+            "cache_ttl": config.batch.cache_ttl,
         }
         for key, config_val in batch_map.items():
             if key in merged and merged[key] is None and config_val is not None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,156 @@
+"""Tests for response caching."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.cache import (
+    CacheEntry,
+    CacheStats,
+    ResponseCache,
+    _cache_key,
+)
+
+
+def test_cache_key_deterministic():
+    """Same inputs produce same key."""
+    k1 = _cache_key("http://a", "m", "hello")
+    k2 = _cache_key("http://a", "m", "hello")
+    assert k1 == k2
+
+
+def test_cache_key_varies_with_url():
+    k1 = _cache_key("http://a", "m", "hello")
+    k2 = _cache_key("http://b", "m", "hello")
+    assert k1 != k2
+
+
+def test_cache_key_varies_with_prompt():
+    k1 = _cache_key("http://a", "m", "hello")
+    k2 = _cache_key("http://a", "m", "world")
+    assert k1 != k2
+
+
+def test_cache_key_varies_with_sampling():
+    k1 = _cache_key("http://a", "m", "hello", {"temperature": 0})
+    k2 = _cache_key("http://a", "m", "hello", {"temperature": 1})
+    assert k1 != k2
+
+
+def test_cache_entry_not_expired():
+    e = CacheEntry("txt", [], "rid", time.time(), "url", "m", "h")
+    assert not e.is_expired(3600)
+
+
+def test_cache_entry_expired():
+    e = CacheEntry("txt", [], "rid", time.time() - 7200, "url", "m", "h")
+    assert e.is_expired(3600)
+
+
+def test_cache_entry_roundtrip():
+    e = CacheEntry("txt", [{"token": "a", "logprob": -0.5}], "rid", 100.0, "url", "m", "h")
+    d = e.to_dict()
+    e2 = CacheEntry.from_dict(d)
+    assert e2.text == e.text
+    assert e2.logprobs == e.logprobs
+    assert e2.request_id == e.request_id
+    assert e2.timestamp == e.timestamp
+
+
+def test_cache_miss(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    result = cache.get("http://a", "m", "hello")
+    assert result is None
+
+
+def test_cache_put_and_hit(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    cache.put("http://a", "m", "hello", "world", [{"token": "w"}], "r1")
+    entry = cache.get("http://a", "m", "hello")
+    assert entry is not None
+    assert entry.text == "world"
+    assert entry.logprobs == [{"token": "w"}]
+    assert entry.request_id == "r1"
+
+
+def test_cache_ttl_expiry(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=1)
+    cache.put("http://a", "m", "hello", "world", [], "r1")
+    # Manually expire by modifying the timestamp
+    key = _cache_key("http://a", "m", "hello")
+    path = cache._entry_path(key)
+    data = json.loads(path.read_text())
+    data["timestamp"] = time.time() - 100
+    path.write_text(json.dumps(data))
+    result = cache.get("http://a", "m", "hello")
+    assert result is None
+
+
+def test_cache_no_cache_bypass(tmp_path: Path):
+    """Without a cache object, no caching happens (tested via miss counts)."""
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    cache.get("http://a", "m", "hello")
+    stats = cache.stats()
+    assert stats.misses == 1
+    assert stats.hits == 0
+
+
+def test_cache_clear(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    cache.put("http://a", "m", "p1", "t1", [], "r1")
+    cache.put("http://a", "m", "p2", "t2", [], "r2")
+    assert cache.stats().entry_count == 2
+    count = cache.clear()
+    assert count == 2
+    assert cache.stats().entry_count == 0
+
+
+def test_cache_clear_empty(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    count = cache.clear()
+    assert count == 0
+
+
+def test_cache_stats(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    cache.put("http://a", "m", "p1", "text", [], "r1")
+    cache.get("http://a", "m", "p1")  # hit
+    cache.get("http://a", "m", "p2")  # miss
+    stats = cache.stats()
+    assert stats.entry_count == 1
+    assert stats.hits == 1
+    assert stats.misses == 1
+    assert stats.total_size_bytes > 0
+    assert stats.hit_rate == pytest.approx(0.5)
+
+
+def test_cache_stats_hit_rate_zero():
+    stats = CacheStats()
+    assert stats.hit_rate == 0.0
+
+
+def test_cache_corrupt_entry(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    cache.put("http://a", "m", "hello", "world", [], "r1")
+    key = _cache_key("http://a", "m", "hello")
+    path = cache._entry_path(key)
+    path.write_text("not json")
+    result = cache.get("http://a", "m", "hello")
+    assert result is None
+    assert not path.exists()  # corrupt entry cleaned up
+
+
+def test_cache_with_sampling_params(tmp_path: Path):
+    cache = ResponseCache(cache_dir=tmp_path / "cache", ttl=3600)
+    sp = {"temperature": 0, "seed": 42}
+    cache.put("http://a", "m", "hello", "world", [], "r1", sp)
+    # Same sampling params → hit
+    entry = cache.get("http://a", "m", "hello", sp)
+    assert entry is not None
+    # Different sampling params → miss
+    entry2 = cache.get("http://a", "m", "hello", {"temperature": 1})
+    assert entry2 is None


### PR DESCRIPTION
## Summary

Add content-addressable response caching to avoid redundant API calls during iterative debugging.

## Changes

- **src/xpyd_acc/cache.py**: `ResponseCache` class with filesystem-backed JSON entries, TTL support, `_cache_key()` hashing, `CacheEntry`/`CacheStats` dataclasses
- **src/xpyd_acc/batch_compare.py**: `_collect_output()` and `run_batch()` accept optional `cache` parameter; cache checked before HTTP, stored after
- **src/xpyd_acc/cli.py**: `--cache-dir`, `--no-cache`, `--cache-ttl` flags on `batch-compare`; `cache clear`/`cache stats` subcommands; cache hit rate summary after batch runs
- **src/xpyd_acc/config.py**: `cache_dir` and `cache_ttl` in `BatchConfig` with TOML merge support
- **tests/test_cache.py**: 17 tests covering key generation, hit/miss, TTL expiry, clear, stats, corrupt entries, sampling params
- **ROADMAP.md**: Add M36

## Usage

```bash
# Normal batch run (cache enabled by default)
xpyd-acc batch-compare --baseline http://a --target http://b --dataset data.jsonl

# Disable cache
xpyd-acc batch-compare --no-cache ...

# Custom cache dir and TTL
xpyd-acc batch-compare --cache-dir /tmp/my-cache --cache-ttl 7200 ...

# Manage cache
xpyd-acc cache stats
xpyd-acc cache clear
```

## Testing

All 439 tests pass. Lint clean (ruff + isort).

Closes #81