### PR TITLE
feat: M37 — Result History & Trend Tracking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -281,3 +281,14 @@
 - Cache hits logged at INFO level, misses at DEBUG
 - Dramatically speeds up reruns and iterative debugging sessions
 - Tests for cache hit/miss, TTL expiry, clear, stats, and no-cache bypass
+
+## M37: Result History & Trend Tracking
+- `xpyd-acc history save --report <path> --tag <label>` stores a batch report in local history DB
+- `xpyd-acc history list` shows all saved reports with date, tag, divergence rate
+- `xpyd-acc history trend --last <n>` shows divergence rate trend across last N runs
+- History stored in `~/.xpyd-acc/history/` as timestamped JSON files with metadata
+- `HistoryEntry` dataclass: timestamp, tag, report_path, divergence_rate, sample_count, dataset
+- `HistoryStore` class for save/list/query operations
+- Trend output: table with date, tag, divergence rate, delta from previous run
+- Exit code 1 if trend shows increasing divergence (configurable via `--fail-on-regression`)
+- Tests for save, list, trend calculation, regression detection

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -360,6 +360,23 @@ def main(argv: list[str] | None = None) -> None:
     )
     _add_sampling_args(sc)
 
+    # history
+    hist = sub.add_parser("history", help="Result history & trend tracking")
+    hist_sub = hist.add_subparsers(dest="history_action")
+    hist_save = hist_sub.add_parser("save", help="Save a batch report to history")
+    hist_save.add_argument("--report", required=True, help="Path to batch report JSON")
+    hist_save.add_argument("--tag", default="", help="Label for this run")
+    hist_save.add_argument("--history-dir", default=None, help="History directory")
+    hist_list = hist_sub.add_parser("list", help="List saved history entries")
+    hist_list.add_argument("--history-dir", default=None, help="History directory")
+    hist_trend = hist_sub.add_parser("trend", help="Show divergence rate trend")
+    hist_trend.add_argument("--last", type=int, default=None, help="Show last N entries")
+    hist_trend.add_argument(
+        "--fail-on-regression", action="store_true", default=False,
+        help="Exit 1 if divergence rate increased in the latest run",
+    )
+    hist_trend.add_argument("--history-dir", default=None, help="History directory")
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -482,6 +499,8 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_snapshot(args))
     elif args.command == "cache":
         _run_cache(args)
+    elif args.command == "history":
+        _run_history(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -1615,3 +1634,71 @@ async def _run_snapshot(args: argparse.Namespace) -> None:
 
     save_snapshot(snap, args.output)
     print(f"\nSnapshot saved to {args.output} ({len(snap.samples)} samples)")
+
+
+def _run_history(args: argparse.Namespace) -> None:
+    """Handle history subcommands."""
+    from pathlib import Path
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from xpyd_acc.history import HistoryStore
+
+    history_dir = Path(args.history_dir) if getattr(args, "history_dir", None) else None
+    store = HistoryStore(history_dir=history_dir)
+
+    if args.history_action == "save":
+        entry = store.save(report_path=args.report, tag=args.tag)
+        print(f"Saved: {entry.entry_id} | rate={entry.divergence_rate:.4f} | "
+              f"samples={entry.sample_count} | tag={entry.tag or '(none)'}")
+
+    elif args.history_action == "list":
+        entries = store.list_entries()
+        if not entries:
+            print("No history entries found.")
+            return
+        console = Console()
+        table = Table(title="History Entries")
+        table.add_column("ID", style="dim")
+        table.add_column("Timestamp")
+        table.add_column("Tag")
+        table.add_column("Divergence Rate", justify="right")
+        table.add_column("Samples", justify="right")
+        for e in entries:
+            table.add_row(
+                e.entry_id, e.timestamp[:19], e.tag or "-",
+                f"{e.divergence_rate:.4f}", str(e.sample_count),
+            )
+        console.print(table)
+
+    elif args.history_action == "trend":
+        trend_data = store.trend(last_n=args.last)
+        if not trend_data:
+            print("No history entries for trend analysis.")
+            return
+        console = Console()
+        table = Table(title="Divergence Rate Trend")
+        table.add_column("Timestamp")
+        table.add_column("Tag")
+        table.add_column("Rate", justify="right")
+        table.add_column("Delta", justify="right")
+        table.add_column("Samples", justify="right")
+        for t in trend_data:
+            delta_str = f"{t['delta']:+.4f}" if t['delta'] != 0 else "-"
+            style = "red" if t['delta'] > 0 else ("green" if t['delta'] < 0 else "")
+            table.add_row(
+                t["timestamp"][:19], t["tag"] or "-",
+                f"{t['divergence_rate']:.4f}", delta_str,
+                str(t["sample_count"]), style=style,
+            )
+        console.print(table)
+
+        if args.fail_on_regression and store.has_regression(last_n=args.last):
+            print("\nFAIL: Divergence rate increased in the latest run.")
+            sys.exit(1)
+        elif args.fail_on_regression:
+            print("\nPASS: No regression detected.")
+
+    else:
+        print("Usage: xpyd-acc history {save|list|trend}")

--- a/src/xpyd_acc/history.py
+++ b/src/xpyd_acc/history.py
@@ -1,0 +1,126 @@
+"""Result history & trend tracking for batch comparison reports."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class HistoryEntry:
+    """A single saved batch report summary."""
+
+    entry_id: str
+    timestamp: str
+    tag: str
+    report_path: str
+    divergence_rate: float
+    sample_count: int
+    dataset: str
+    divergent_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> HistoryEntry:
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+def _default_history_dir() -> Path:
+    return Path.home() / ".xpyd-acc" / "history"
+
+
+class HistoryStore:
+    """Manages saved batch report history entries."""
+
+    def __init__(self, history_dir: Path | None = None) -> None:
+        self.history_dir = history_dir or _default_history_dir()
+
+    def save(
+        self,
+        report_path: str,
+        tag: str = "",
+        report_data: dict[str, Any] | None = None,
+    ) -> HistoryEntry:
+        """Save a batch report to history.
+
+        If report_data is not provided, reads from report_path.
+        """
+        if report_data is None:
+            with open(report_path) as f:
+                report_data = json.load(f)
+
+        total = report_data.get("total_samples", 0)
+        divergent = report_data.get("divergent_samples", 0)
+        rate = divergent / total if total > 0 else 0.0
+        dataset = report_data.get("dataset", "unknown")
+
+        entry = HistoryEntry(
+            entry_id=uuid.uuid4().hex[:12],
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            tag=tag,
+            report_path=str(report_path),
+            divergence_rate=round(rate, 6),
+            sample_count=total,
+            dataset=dataset,
+            divergent_count=divergent,
+        )
+
+        self.history_dir.mkdir(parents=True, exist_ok=True)
+        entry_file = self.history_dir / f"{entry.entry_id}.json"
+        entry_file.write_text(json.dumps(entry.to_dict(), indent=2) + "\n")
+        return entry
+
+    def list_entries(self) -> list[HistoryEntry]:
+        """List all history entries, sorted by timestamp ascending."""
+        if not self.history_dir.exists():
+            return []
+        entries: list[HistoryEntry] = []
+        for p in sorted(self.history_dir.glob("*.json")):
+            try:
+                data = json.loads(p.read_text())
+                entries.append(HistoryEntry.from_dict(data))
+            except (json.JSONDecodeError, TypeError, KeyError):
+                continue
+        entries.sort(key=lambda e: e.timestamp)
+        return entries
+
+    def trend(self, last_n: int | None = None) -> list[dict[str, Any]]:
+        """Compute divergence rate trend with deltas.
+
+        Returns list of dicts with: timestamp, tag, divergence_rate, delta.
+        """
+        entries = self.list_entries()
+        if last_n is not None and last_n > 0:
+            entries = entries[-last_n:]
+
+        result: list[dict[str, Any]] = []
+        prev_rate: float | None = None
+        for entry in entries:
+            delta = (
+                round(entry.divergence_rate - prev_rate, 6)
+                if prev_rate is not None
+                else 0.0
+            )
+            result.append({
+                "entry_id": entry.entry_id,
+                "timestamp": entry.timestamp,
+                "tag": entry.tag,
+                "divergence_rate": entry.divergence_rate,
+                "delta": delta,
+                "sample_count": entry.sample_count,
+            })
+            prev_rate = entry.divergence_rate
+        return result
+
+    def has_regression(self, last_n: int | None = None) -> bool:
+        """Check if the most recent entry shows increased divergence vs previous."""
+        trend_data = self.trend(last_n=last_n)
+        if len(trend_data) < 2:
+            return False
+        return trend_data[-1]["delta"] > 0

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,125 @@
+"""Tests for result history & trend tracking (M37)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.history import HistoryEntry, HistoryStore
+
+
+def _make_report(total: int = 100, divergent: int = 10, dataset: str = "gsm8k") -> dict:
+    return {
+        "total_samples": total,
+        "divergent_samples": divergent,
+        "dataset": dataset,
+    }
+
+
+@pytest.fixture()
+def history_dir(tmp_path: Path) -> Path:
+    return tmp_path / "history"
+
+
+@pytest.fixture()
+def store(history_dir: Path) -> HistoryStore:
+    return HistoryStore(history_dir=history_dir)
+
+
+@pytest.fixture()
+def report_file(tmp_path: Path) -> Path:
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(_make_report()))
+    return p
+
+
+class TestHistoryEntry:
+    def test_roundtrip(self) -> None:
+        entry = HistoryEntry(
+            entry_id="abc123",
+            timestamp="2026-01-01T00:00:00+00:00",
+            tag="test",
+            report_path="/tmp/report.json",
+            divergence_rate=0.1,
+            sample_count=100,
+            dataset="gsm8k",
+            divergent_count=10,
+        )
+        d = entry.to_dict()
+        restored = HistoryEntry.from_dict(d)
+        assert restored == entry
+
+
+class TestHistoryStoreSave:
+    def test_save_from_file(self, store: HistoryStore, report_file: Path) -> None:
+        entry = store.save(report_path=str(report_file), tag="v1")
+        assert entry.divergence_rate == pytest.approx(0.1)
+        assert entry.sample_count == 100
+        assert entry.tag == "v1"
+        assert entry.divergent_count == 10
+        # File written
+        files = list(store.history_dir.glob("*.json"))
+        assert len(files) == 1
+
+    def test_save_from_data(self, store: HistoryStore) -> None:
+        data = _make_report(50, 5)
+        entry = store.save(report_path="fake.json", tag="inline", report_data=data)
+        assert entry.divergence_rate == pytest.approx(0.1)
+        assert entry.sample_count == 50
+
+    def test_save_zero_samples(self, store: HistoryStore) -> None:
+        data = _make_report(0, 0)
+        entry = store.save(report_path="empty.json", report_data=data)
+        assert entry.divergence_rate == 0.0
+
+
+class TestHistoryStoreList:
+    def test_list_empty(self, store: HistoryStore) -> None:
+        assert store.list_entries() == []
+
+    def test_list_sorted(self, store: HistoryStore) -> None:
+        store.save("a.json", tag="first", report_data=_make_report(10, 1))
+        store.save("b.json", tag="second", report_data=_make_report(10, 2))
+        entries = store.list_entries()
+        assert len(entries) == 2
+        assert entries[0].tag == "first"
+        assert entries[1].tag == "second"
+
+
+class TestHistoryStoreTrend:
+    def test_trend_deltas(self, store: HistoryStore) -> None:
+        store.save("a.json", tag="run1", report_data=_make_report(100, 10))
+        store.save("b.json", tag="run2", report_data=_make_report(100, 5))
+        store.save("c.json", tag="run3", report_data=_make_report(100, 15))
+        trend = store.trend()
+        assert len(trend) == 3
+        assert trend[0]["delta"] == 0.0  # first entry, no previous
+        assert trend[1]["delta"] == pytest.approx(-0.05)  # 0.05 - 0.10
+        assert trend[2]["delta"] == pytest.approx(0.10)  # 0.15 - 0.05
+
+    def test_trend_last_n(self, store: HistoryStore) -> None:
+        for i in range(5):
+            store.save(f"{i}.json", tag=f"r{i}", report_data=_make_report(100, i * 5))
+        trend = store.trend(last_n=2)
+        assert len(trend) == 2
+
+    def test_trend_empty(self, store: HistoryStore) -> None:
+        assert store.trend() == []
+
+
+class TestHasRegression:
+    def test_regression_detected(self, store: HistoryStore) -> None:
+        store.save("a.json", report_data=_make_report(100, 5))
+        store.save("b.json", report_data=_make_report(100, 10))
+        assert store.has_regression() is True
+
+    def test_no_regression(self, store: HistoryStore) -> None:
+        store.save("a.json", report_data=_make_report(100, 10))
+        store.save("b.json", report_data=_make_report(100, 5))
+        assert store.has_regression() is False
+
+    def test_single_entry_no_regression(self, store: HistoryStore) -> None:
+        store.save("a.json", report_data=_make_report(100, 10))
+        assert store.has_regression() is False


### PR DESCRIPTION
## Summary
Add local result history storage and trend tracking for batch comparison reports.

### Changes
- **`src/xpyd_acc/history.py`**: `HistoryEntry` dataclass and `HistoryStore` class (save/list/trend/has_regression)
- **`src/xpyd_acc/cli.py`**: `xpyd-acc history {save|list|trend}` subcommands with Rich table output
- **`tests/test_history.py`**: 12 tests covering save, list, trend deltas, regression detection
- **`ROADMAP.md`**: M37 milestone added

### New CLI Commands
- `xpyd-acc history save --report <path> --tag <label>` — save batch report to history
- `xpyd-acc history list` — show all saved entries
- `xpyd-acc history trend [--last N] [--fail-on-regression]` — divergence rate trend with deltas

Closes #83