### PR TITLE
feat(benchmark): add endpoint latency benchmarking (M38)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -292,3 +292,14 @@
 - Trend output: table with date, tag, divergence rate, delta from previous run
 - Exit code 1 if trend shows increasing divergence (configurable via `--fail-on-regression`)
 - Tests for save, list, trend calculation, regression detection
+
+## M38: Endpoint Latency Benchmarking ✅
+- `xpyd-acc benchmark <url>` sends N requests and measures latency
+- Reports: min, max, mean, p50, p95, p99 latency statistics
+- `--requests <n>` (default 10) and `--concurrency <n>` (default 1) flags
+- `--prompt`, `--model`, `--max-tokens`, `--api-key` flags
+- JSON export via `--json <path>`
+- Rich terminal output with latency distribution table
+- Sampling params support (--temperature, --top-p, --seed, --profile)
+- Graceful error handling (failed requests counted separately)
+- Tests for stats computation, JSON export, error handling

--- a/src/xpyd_acc/benchmark.py
+++ b/src/xpyd_acc/benchmark.py
@@ -1,0 +1,223 @@
+"""Endpoint latency benchmarking."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import httpx
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_acc.log import get_logger
+from xpyd_acc.sampling import SamplingParams
+
+logger = get_logger("benchmark")
+
+
+@dataclass
+class LatencyStats:
+    """Aggregated latency statistics."""
+
+    count: int
+    min_ms: float
+    max_ms: float
+    mean_ms: float
+    p50_ms: float
+    p95_ms: float
+    p99_ms: float
+    total_seconds: float
+    errors: int
+
+
+@dataclass
+class BenchmarkResult:
+    """Full benchmark result."""
+
+    url: str
+    model: str
+    requests: int
+    concurrency: int
+    latencies_ms: list[float] = field(default_factory=list)
+    error_count: int = 0
+    stats: LatencyStats | None = None
+
+    def compute_stats(self) -> LatencyStats:
+        """Compute latency statistics from collected latencies."""
+        if not self.latencies_ms:
+            self.stats = LatencyStats(
+                count=0,
+                min_ms=0.0,
+                max_ms=0.0,
+                mean_ms=0.0,
+                p50_ms=0.0,
+                p95_ms=0.0,
+                p99_ms=0.0,
+                total_seconds=0.0,
+                errors=self.error_count,
+            )
+            return self.stats
+
+        sorted_lats = sorted(self.latencies_ms)
+        n = len(sorted_lats)
+
+        def percentile(p: float) -> float:
+            k = (n - 1) * p / 100.0
+            f = int(k)
+            c = f + 1
+            if c >= n:
+                return sorted_lats[-1]
+            return sorted_lats[f] + (k - f) * (sorted_lats[c] - sorted_lats[f])
+
+        self.stats = LatencyStats(
+            count=n,
+            min_ms=sorted_lats[0],
+            max_ms=sorted_lats[-1],
+            mean_ms=statistics.mean(sorted_lats),
+            p50_ms=percentile(50),
+            p95_ms=percentile(95),
+            p99_ms=percentile(99),
+            total_seconds=sum(sorted_lats) / 1000.0,
+            errors=self.error_count,
+        )
+        return self.stats
+
+    def to_json(self) -> str:
+        """Serialize to JSON."""
+        data = {
+            "url": self.url,
+            "model": self.model,
+            "requests": self.requests,
+            "concurrency": self.concurrency,
+            "error_count": self.error_count,
+            "stats": asdict(self.stats) if self.stats else None,
+            "latencies_ms": self.latencies_ms,
+        }
+        return json.dumps(data, indent=2)
+
+
+async def _send_request(
+    client: httpx.AsyncClient,
+    url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    api_key: str | None,
+    sampling_params: SamplingParams | None,
+) -> float | None:
+    """Send a single request and return latency in ms, or None on error."""
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    body: dict = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+    }
+    if sampling_params:
+        if sampling_params.temperature is not None:
+            body["temperature"] = sampling_params.temperature
+        if sampling_params.top_p is not None:
+            body["top_p"] = sampling_params.top_p
+        if sampling_params.seed is not None:
+            body["seed"] = sampling_params.seed
+
+    start = time.perf_counter()
+    try:
+        chat_url = url.rstrip("/") + "/v1/chat/completions"
+        resp = await client.post(chat_url, json=body, headers=headers, timeout=120.0)
+        resp.raise_for_status()
+        elapsed = (time.perf_counter() - start) * 1000.0
+        logger.debug("Request completed in %.1fms (status %d)", elapsed, resp.status_code)
+        return elapsed
+    except Exception as exc:
+        logger.warning("Request failed: %s", exc)
+        return None
+
+
+async def run_benchmark(
+    url: str,
+    prompt: str = "Hello",
+    model: str = "default",
+    max_tokens: int = 64,
+    api_key: str | None = None,
+    requests: int = 10,
+    concurrency: int = 1,
+    sampling_params: SamplingParams | None = None,
+    json_path: str | None = None,
+) -> BenchmarkResult:
+    """Run latency benchmark against an endpoint.
+
+    Args:
+        url: Endpoint URL.
+        prompt: Prompt to send.
+        model: Model name.
+        max_tokens: Max tokens to generate.
+        api_key: API key.
+        requests: Number of requests to send.
+        concurrency: Max concurrent requests.
+        sampling_params: Sampling parameters.
+        json_path: Optional path to export JSON results.
+
+    Returns:
+        BenchmarkResult with latency statistics.
+    """
+    console = Console()
+    result = BenchmarkResult(
+        url=url,
+        model=model,
+        requests=requests,
+        concurrency=concurrency,
+    )
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def bounded_request(client: httpx.AsyncClient) -> float | None:
+        async with semaphore:
+            return await _send_request(
+                client, url, model, prompt, max_tokens, api_key, sampling_params,
+            )
+
+    console.print(f"[bold]Benchmarking[/bold] {url}")
+    console.print(f"  Requests: {requests}, Concurrency: {concurrency}, Model: {model}")
+    console.print()
+
+    async with httpx.AsyncClient() as client:
+        tasks = [bounded_request(client) for _ in range(requests)]
+        latencies = await asyncio.gather(*tasks)
+
+    for lat in latencies:
+        if lat is not None:
+            result.latencies_ms.append(lat)
+        else:
+            result.error_count += 1
+
+    stats = result.compute_stats()
+
+    # Rich output
+    table = Table(title="Latency Statistics")
+    table.add_column("Metric", style="bold")
+    table.add_column("Value", justify="right")
+
+    table.add_row("Requests", str(stats.count))
+    table.add_row("Errors", str(stats.errors))
+    table.add_row("Min", f"{stats.min_ms:.1f} ms")
+    table.add_row("Max", f"{stats.max_ms:.1f} ms")
+    table.add_row("Mean", f"{stats.mean_ms:.1f} ms")
+    table.add_row("P50", f"{stats.p50_ms:.1f} ms")
+    table.add_row("P95", f"{stats.p95_ms:.1f} ms")
+    table.add_row("P99", f"{stats.p99_ms:.1f} ms")
+    table.add_row("Total", f"{stats.total_seconds:.2f} s")
+
+    console.print(table)
+
+    if json_path:
+        Path(json_path).write_text(result.to_json())
+        console.print(f"\nJSON report saved to {json_path}")
+
+    return result

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -377,6 +377,22 @@ def main(argv: list[str] | None = None) -> None:
     )
     hist_trend.add_argument("--history-dir", default=None, help="History directory")
 
+    # benchmark
+    bm = sub.add_parser("benchmark", help="Benchmark endpoint latency")
+    bm.add_argument("url", help="Endpoint URL to benchmark")
+    bm.add_argument("--prompt", default="Hello", help="Prompt to send (default: Hello)")
+    bm.add_argument("--model", default=None, help="Model name")
+    bm.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
+    bm.add_argument("--api-key", default=None, help="API key")
+    bm.add_argument(
+        "--requests", type=int, default=10, help="Number of requests (default: 10)",
+    )
+    bm.add_argument(
+        "--concurrency", type=int, default=1, help="Concurrent requests (default: 1)",
+    )
+    bm.add_argument("--json", default=None, dest="json_path", help="Export JSON report to path")
+    _add_sampling_args(bm)
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -501,8 +517,34 @@ def main(argv: list[str] | None = None) -> None:
         _run_cache(args)
     elif args.command == "history":
         _run_history(args)
+    elif args.command == "benchmark":
+        asyncio.run(_run_benchmark(args))
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
+
+
+async def _run_benchmark(args: argparse.Namespace) -> None:
+    """Run endpoint latency benchmark."""
+    from xpyd_acc.benchmark import run_benchmark
+    from xpyd_acc.sampling import SamplingParams
+
+    sp = SamplingParams(
+        temperature=getattr(args, "temperature", None),
+        top_p=getattr(args, "top_p", None),
+        seed=getattr(args, "seed", None),
+    )
+
+    await run_benchmark(
+        url=args.url,
+        prompt=args.prompt,
+        model=args.model,
+        max_tokens=args.max_tokens,
+        api_key=args.api_key,
+        requests=args.requests,
+        concurrency=args.concurrency,
+        sampling_params=sp,
+        json_path=args.json_path,
+    )
 
 
 async def _preflight_healthcheck(

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,145 @@
+"""Tests for benchmark module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from xpyd_acc.benchmark import BenchmarkResult, run_benchmark
+
+
+class TestBenchmarkResult:
+    """Tests for BenchmarkResult dataclass."""
+
+    def test_compute_stats_empty(self) -> None:
+        result = BenchmarkResult(url="http://x", model="m", requests=0, concurrency=1)
+        stats = result.compute_stats()
+        assert stats.count == 0
+        assert stats.mean_ms == 0.0
+
+    def test_compute_stats_single(self) -> None:
+        result = BenchmarkResult(
+            url="http://x", model="m", requests=1, concurrency=1,
+            latencies_ms=[100.0],
+        )
+        stats = result.compute_stats()
+        assert stats.count == 1
+        assert stats.min_ms == 100.0
+        assert stats.max_ms == 100.0
+        assert stats.mean_ms == 100.0
+        assert stats.p50_ms == 100.0
+
+    def test_compute_stats_multiple(self) -> None:
+        lats = [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0]
+        result = BenchmarkResult(
+            url="http://x", model="m", requests=10, concurrency=1,
+            latencies_ms=lats,
+        )
+        stats = result.compute_stats()
+        assert stats.count == 10
+        assert stats.min_ms == 10.0
+        assert stats.max_ms == 100.0
+        assert abs(stats.mean_ms - 55.0) < 0.01
+        assert stats.p50_ms > 0
+
+    def test_to_json(self) -> None:
+        result = BenchmarkResult(
+            url="http://x", model="m", requests=1, concurrency=1,
+            latencies_ms=[50.0],
+        )
+        result.compute_stats()
+        data = json.loads(result.to_json())
+        assert data["url"] == "http://x"
+        assert data["stats"]["count"] == 1
+        assert data["latencies_ms"] == [50.0]
+
+    def test_compute_stats_with_errors(self) -> None:
+        result = BenchmarkResult(
+            url="http://x", model="m", requests=3, concurrency=1,
+            latencies_ms=[50.0], error_count=2,
+        )
+        stats = result.compute_stats()
+        assert stats.count == 1
+        assert stats.errors == 2
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_success() -> None:
+    """Test run_benchmark with mocked HTTP responses."""
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = lambda: None
+
+    with patch("xpyd_acc.benchmark.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = await run_benchmark(
+            url="http://localhost:8000",
+            prompt="Hi",
+            requests=3,
+            concurrency=2,
+        )
+
+    assert result.requests == 3
+    assert result.concurrency == 2
+    assert len(result.latencies_ms) == 3
+    assert result.error_count == 0
+    assert result.stats is not None
+    assert result.stats.count == 3
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_json_export(tmp_path) -> None:
+    """Test JSON export."""
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = lambda: None
+
+    json_file = str(tmp_path / "bench.json")
+
+    with patch("xpyd_acc.benchmark.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        await run_benchmark(
+            url="http://localhost:8000",
+            requests=2,
+            json_path=json_file,
+        )
+
+    with open(json_file) as f:
+        data = json.load(f)
+    assert data["requests"] == 2
+    assert "stats" in data
+
+
+@pytest.mark.asyncio
+async def test_run_benchmark_with_errors() -> None:
+    """Test benchmark handles request errors gracefully."""
+    with patch("xpyd_acc.benchmark.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=httpx.ConnectError("fail"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = await run_benchmark(
+            url="http://localhost:8000",
+            requests=2,
+            concurrency=1,
+        )
+
+    assert result.error_count == 2
+    assert len(result.latencies_ms) == 0
+    assert result.stats is not None
+    assert result.stats.count == 0


### PR DESCRIPTION
## Summary
Add `xpyd-acc benchmark <url>` subcommand for standalone endpoint latency benchmarking.

## Changes
- **src/xpyd_acc/benchmark.py**: New module with `run_benchmark()`, `BenchmarkResult`, `LatencyStats`
- **src/xpyd_acc/cli.py**: Add `benchmark` subcommand with all flags
- **tests/test_benchmark.py**: 8 tests covering stats computation, JSON export, error handling
- **ROADMAP.md**: Add M38 milestone (marked ✅)

## Features
- Sends N requests to endpoint, measures per-request latency
- Reports: min, max, mean, p50, p95, p99
- `--requests`, `--concurrency`, `--json`, `--prompt`, `--model`, sampling params
- Rich terminal table output
- Graceful error handling (failed requests counted separately)

Closes #85