### PR TITLE
feat(dataset): CSV and JSON Array Format Support (M40)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -312,3 +312,11 @@
 - Exit 0 if valid, exit 1 if errors found
 - Profiles section treated as free-form (no validation)
 - 20 tests covering init, overwrite protection, validation pass/fail, CLI integration
+
+## M40: CSV and JSON Array Dataset Format Support ✅
+- `load_dataset()` auto-detects format by file extension (`.csv`, `.json`, `.jsonl`)
+- CSV support: header row with `prompt` column required, optional `id`, `expected`, metadata
+- JSON array support: `[{"prompt": ...}, ...]` format
+- JSONL remains default for unknown extensions
+- Clear error messages for missing `prompt` column/field, non-array JSON, non-object items
+- 11 tests covering all formats, error cases, and fallback behavior

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -111,12 +111,26 @@ class BatchReport:
 
 
 def load_dataset(path: str | Path) -> list[DatasetSample]:
-    """Load dataset from JSONL file.
+    """Load dataset from JSONL, JSON array, or CSV file.
 
-    Each line should be a JSON object with at least a "prompt" field.
-    Optional fields: "id", "expected", and any other metadata.
+    Format is auto-detected by file extension:
+    - ``.csv`` → CSV with header row (``prompt`` column required)
+    - ``.json`` → JSON array of objects (``prompt`` field required)
+    - ``.jsonl`` or other → JSONL (one JSON object per line, ``prompt`` field required)
+
+    Optional fields for all formats: ``id``, ``expected``, plus arbitrary metadata.
     """
     path = Path(path)
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return _load_csv(path)
+    if suffix == ".json":
+        return _load_json_array(path)
+    return _load_jsonl(path)
+
+
+def _load_jsonl(path: Path) -> list[DatasetSample]:
+    """Load dataset from JSONL file."""
     samples: list[DatasetSample] = []
     with path.open() as f:
         for i, line in enumerate(f):
@@ -127,17 +141,58 @@ def load_dataset(path: str | Path) -> list[DatasetSample]:
             if "prompt" not in obj:
                 msg = f"Line {i + 1}: missing 'prompt' field"
                 raise ValueError(msg)
-            sample_id = str(obj.get("id", i))
-            prompt = obj["prompt"]
-            expected = obj.get("expected")
-            metadata = {k: v for k, v in obj.items() if k not in ("id", "prompt", "expected")}
-            samples.append(DatasetSample(
-                id=sample_id,
-                prompt=prompt,
-                expected=expected,
-                metadata=metadata,
-            ))
+            samples.append(_obj_to_sample(obj, i))
     return samples
+
+
+def _load_json_array(path: Path) -> list[DatasetSample]:
+    """Load dataset from a JSON file containing an array of objects."""
+    with path.open() as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        msg = f"{path}: expected a JSON array, got {type(data).__name__}"
+        raise ValueError(msg)
+    samples: list[DatasetSample] = []
+    for i, obj in enumerate(data):
+        if not isinstance(obj, dict):
+            msg = f"Item {i}: expected a JSON object, got {type(obj).__name__}"
+            raise ValueError(msg)
+        if "prompt" not in obj:
+            msg = f"Item {i}: missing 'prompt' field"
+            raise ValueError(msg)
+        samples.append(_obj_to_sample(obj, i))
+    return samples
+
+
+def _load_csv(path: Path) -> list[DatasetSample]:
+    """Load dataset from a CSV file with a header row."""
+    samples: list[DatasetSample] = []
+    with path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None or "prompt" not in reader.fieldnames:
+            msg = f"{path}: CSV must have a 'prompt' column"
+            raise ValueError(msg)
+        for i, row in enumerate(reader):
+            if not row.get("prompt"):
+                msg = f"Row {i + 1}: empty or missing 'prompt' value"
+                raise ValueError(msg)
+            obj = dict(row)
+            samples.append(_obj_to_sample(obj, i))
+    return samples
+
+
+def _obj_to_sample(obj: dict[str, Any], index: int) -> DatasetSample:
+    """Convert a dict to a DatasetSample."""
+    sample_id = str(obj.get("id", index))
+    prompt = obj["prompt"]
+    expected = obj.get("expected")
+    metadata = {k: v for k, v in obj.items() if k not in ("id", "prompt", "expected")}
+    return DatasetSample(
+        id=sample_id,
+        prompt=prompt,
+        expected=expected,
+        metadata=metadata,
+    )
 
 
 def _tokenize(text: str) -> list[str]:

--- a/tests/test_dataset_formats.py
+++ b/tests/test_dataset_formats.py
@@ -1,0 +1,118 @@
+"""Tests for CSV, JSON array, and JSONL dataset loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.batch_compare import load_dataset
+
+# ── JSONL (existing format) ──────────────────────────────────────────────
+
+
+def test_load_jsonl(tmp_path: Path) -> None:
+    p = tmp_path / "data.jsonl"
+    p.write_text(
+        '{"prompt": "hello"}\n{"id": "x", "prompt": "world", "expected": "ok"}\n'
+    )
+    samples = load_dataset(p)
+    assert len(samples) == 2
+    assert samples[0].prompt == "hello"
+    assert samples[0].id == "0"
+    assert samples[1].id == "x"
+    assert samples[1].expected == "ok"
+
+
+def test_load_jsonl_missing_prompt(tmp_path: Path) -> None:
+    p = tmp_path / "bad.jsonl"
+    p.write_text('{"text": "no prompt"}\n')
+    with pytest.raises(ValueError, match="missing 'prompt'"):
+        load_dataset(p)
+
+
+# ── JSON array ───────────────────────────────────────────────────────────
+
+
+def test_load_json_array(tmp_path: Path) -> None:
+    p = tmp_path / "data.json"
+    data = [
+        {"prompt": "q1", "expected": "a1"},
+        {"id": "s2", "prompt": "q2", "meta": "v"},
+    ]
+    p.write_text(json.dumps(data))
+    samples = load_dataset(p)
+    assert len(samples) == 2
+    assert samples[0].prompt == "q1"
+    assert samples[0].expected == "a1"
+    assert samples[1].id == "s2"
+    assert samples[1].metadata == {"meta": "v"}
+
+
+def test_load_json_array_not_a_list(tmp_path: Path) -> None:
+    p = tmp_path / "bad.json"
+    p.write_text('{"prompt": "oops"}')
+    with pytest.raises(ValueError, match="expected a JSON array"):
+        load_dataset(p)
+
+
+def test_load_json_array_missing_prompt(tmp_path: Path) -> None:
+    p = tmp_path / "bad2.json"
+    p.write_text('[{"text": "no prompt"}]')
+    with pytest.raises(ValueError, match="missing 'prompt'"):
+        load_dataset(p)
+
+
+def test_load_json_array_non_object_item(tmp_path: Path) -> None:
+    p = tmp_path / "bad3.json"
+    p.write_text('["just a string"]')
+    with pytest.raises(ValueError, match="expected a JSON object"):
+        load_dataset(p)
+
+
+# ── CSV ──────────────────────────────────────────────────────────────────
+
+
+def test_load_csv(tmp_path: Path) -> None:
+    p = tmp_path / "data.csv"
+    p.write_text("id,prompt,expected\n1,hello,world\n2,foo,bar\n")
+    samples = load_dataset(p)
+    assert len(samples) == 2
+    assert samples[0].id == "1"
+    assert samples[0].prompt == "hello"
+    assert samples[0].expected == "world"
+    assert samples[1].prompt == "foo"
+
+
+def test_load_csv_no_prompt_column(tmp_path: Path) -> None:
+    p = tmp_path / "bad.csv"
+    p.write_text("id,text\n1,hello\n")
+    with pytest.raises(ValueError, match="must have a 'prompt' column"):
+        load_dataset(p)
+
+
+def test_load_csv_empty_prompt(tmp_path: Path) -> None:
+    p = tmp_path / "empty.csv"
+    p.write_text("id,prompt\n1,\n")
+    with pytest.raises(ValueError, match="empty or missing 'prompt'"):
+        load_dataset(p)
+
+
+def test_load_csv_with_metadata(tmp_path: Path) -> None:
+    p = tmp_path / "meta.csv"
+    p.write_text("prompt,category,difficulty\nWhat is 2+2?,math,easy\n")
+    samples = load_dataset(p)
+    assert len(samples) == 1
+    assert samples[0].metadata == {"category": "math", "difficulty": "easy"}
+
+
+# ── Auto-detection ───────────────────────────────────────────────────────
+
+
+def test_unknown_extension_falls_back_to_jsonl(tmp_path: Path) -> None:
+    p = tmp_path / "data.txt"
+    p.write_text('{"prompt": "from txt"}\n')
+    samples = load_dataset(p)
+    assert len(samples) == 1
+    assert samples[0].prompt == "from txt"


### PR DESCRIPTION
## Summary
Extend `load_dataset()` to support CSV and JSON array formats in addition to JSONL.

### Changes
- Auto-detect format by file extension: `.csv` → CSV, `.json` → JSON array, `.jsonl`/other → JSONL
- CSV: header row with `prompt` column required, optional `id`, `expected`, plus metadata columns
- JSON array: `[{"prompt": ...}, ...]` format with same field conventions
- JSONL behavior unchanged (default fallback)
- Clear error messages for all invalid inputs
- Refactored into `_load_jsonl()`, `_load_json_array()`, `_load_csv()`, `_obj_to_sample()`
- 11 new tests (490 total, all passing)

### Files Changed
- `src/xpyd_acc/batch_compare.py` (refactored `load_dataset`)
- `tests/test_dataset_formats.py` (new)
- `ROADMAP.md` (M40 added)

Closes #89