### PR TITLE
feat: M41 — Webhook Notifications for Divergence Alerts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -320,3 +320,15 @@
 - JSONL remains default for unknown extensions
 - Clear error messages for missing `prompt` column/field, non-array JSON, non-object items
 - 11 tests covering all formats, error cases, and fallback behavior
+
+## M41: Webhook Notifications for Divergence Alerts
+- `--webhook <url>` flag for `batch-compare`
+- POST JSON payload: event, divergence_detected, total_samples, divergent_samples, divergence_rate
+- `--webhook-header 'Key: Value'` for custom headers (repeatable)
+- `--webhook-always` sends on every run, not just on divergence
+- TOML config: `[notifications] webhook_url`, `webhook_headers`, `webhook_always`
+- Environment variable: `XPYD_ACC_WEBHOOK_URL`
+- Priority chain: CLI > env > TOML
+- `notify.py` module with `send_webhook()`, `resolve_webhook_config()`
+- Reuses existing retry logic for delivery reliability
+- Tests for webhook send, skip, retry failure, header parsing, config resolution

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -202,6 +202,18 @@ def main(argv: list[str] | None = None) -> None:
         "--cache-ttl", type=float, default=None,
         help="Cache entry TTL in seconds (default: 3600)",
     )
+    bc.add_argument(
+        "--webhook", default=None, metavar="URL",
+        help="Webhook URL to POST divergence alerts to",
+    )
+    bc.add_argument(
+        "--webhook-header", action="append", default=None, dest="webhook_headers",
+        help="Custom webhook header as 'Key: Value' (repeatable)",
+    )
+    bc.add_argument(
+        "--webhook-always", action="store_true", default=False,
+        help="Send webhook on every run, not just on divergence",
+    )
 
     # Cache management subcommand
     cache_cmd = sub.add_parser("cache", help="Manage response cache")
@@ -894,6 +906,9 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             export_markdown(report, args.markdown)
             print(f"\nMarkdown exported to {args.markdown}")
 
+        # Send webhook notification if configured
+        await _maybe_send_webhook(args, report)
+
         # Determine fail threshold: CLI > env > config > None
         fail_threshold = _resolve_fail_threshold(args, getattr(args, "_config", None))
         if fail_threshold is not None:
@@ -910,6 +925,39 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
                 )
         elif report.divergent_samples > 0:
             sys.exit(1)
+
+
+async def _maybe_send_webhook(
+    args: argparse.Namespace,
+    report: object,
+) -> None:
+    """Send webhook notification if configured."""
+    import os
+
+    from xpyd_acc.notify import WebhookPayload, resolve_webhook_config, send_webhook
+
+    config = resolve_webhook_config(
+        cli_url=getattr(args, "webhook", None),
+        cli_headers=getattr(args, "webhook_headers", None),
+        cli_always=getattr(args, "webhook_always", False),
+        env_url=os.environ.get("XPYD_ACC_WEBHOOK_URL"),
+        toml_config=getattr(args, "_config", None),
+    )
+    if config is None:
+        return
+
+    total = getattr(report, "total_samples", 0)
+    divergent = getattr(report, "divergent_samples", 0)
+    rate = getattr(report, "divergence_rate", 0.0)
+
+    payload = WebhookPayload(
+        event="batch_complete",
+        divergence_detected=divergent > 0,
+        total_samples=total,
+        divergent_samples=divergent,
+        divergence_rate=rate,
+    )
+    await send_webhook(config, payload)
 
 
 def _resolve_fail_threshold(

--- a/src/xpyd_acc/notify.py
+++ b/src/xpyd_acc/notify.py
@@ -1,0 +1,135 @@
+"""Webhook notification support for divergence alerts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from xpyd_acc.log import get_logger
+from xpyd_acc.retry import retry_async
+
+logger = get_logger("notify")
+
+
+@dataclass
+class WebhookConfig:
+    """Configuration for webhook notifications."""
+
+    url: str
+    headers: dict[str, str] = field(default_factory=dict)
+    always: bool = False
+
+
+@dataclass
+class WebhookPayload:
+    """Payload sent to webhook endpoint."""
+
+    event: str  # "batch_complete" or "watch_divergence"
+    divergence_detected: bool
+    total_samples: int
+    divergent_samples: int
+    divergence_rate: float
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "event": self.event,
+            "divergence_detected": self.divergence_detected,
+            "total_samples": self.total_samples,
+            "divergent_samples": self.divergent_samples,
+            "divergence_rate": self.divergence_rate,
+            **self.extra,
+        }
+
+
+async def send_webhook(
+    config: WebhookConfig,
+    payload: WebhookPayload,
+    *,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+    timeout: float = 30.0,
+) -> bool:
+    """Send webhook notification. Returns True on success."""
+    if not config.always and not payload.divergence_detected:
+        logger.debug("No divergence and --webhook-always not set; skipping webhook")
+        return False
+
+    data = payload.to_dict()
+    logger.info("Sending webhook to %s (event=%s)", config.url, payload.event)
+
+    async def _do_post() -> bool:
+        headers = {"Content-Type": "application/json", **config.headers}
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(config.url, content=json.dumps(data), headers=headers)
+            resp.raise_for_status()
+            logger.info("Webhook sent successfully (status=%d)", resp.status_code)
+            return True
+
+    try:
+        return await retry_async(_do_post, retries=retries, base_delay=retry_delay)
+    except Exception:
+        logger.error("Webhook delivery failed after %d retries", retries)
+        return False
+
+
+def parse_webhook_headers(header_strings: list[str] | None) -> dict[str, str]:
+    """Parse 'Key: Value' strings into a dict."""
+    if not header_strings:
+        return {}
+    result: dict[str, str] = {}
+    for h in header_strings:
+        if ":" not in h:
+            logger.warning("Ignoring malformed header (no colon): %s", h)
+            continue
+        key, value = h.split(":", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def load_webhook_config_from_toml(config: dict[str, Any]) -> WebhookConfig | None:
+    """Extract webhook config from parsed TOML config dict."""
+    notifications = config.get("notifications", {})
+    url = notifications.get("webhook_url")
+    if not url:
+        return None
+    headers = notifications.get("webhook_headers", {})
+    always = notifications.get("webhook_always", False)
+    return WebhookConfig(url=url, headers=headers, always=always)
+
+
+def resolve_webhook_config(
+    *,
+    cli_url: str | None = None,
+    cli_headers: list[str] | None = None,
+    cli_always: bool = False,
+    env_url: str | None = None,
+    toml_config: dict[str, Any] | None = None,
+) -> WebhookConfig | None:
+    """Resolve webhook config from CLI > env > TOML priority chain."""
+    url = cli_url or env_url
+    toml_wh = load_webhook_config_from_toml(toml_config) if toml_config else None
+
+    if not url and toml_wh:
+        url = toml_wh.url
+
+    if not url:
+        return None
+
+    headers: dict[str, str] = {}
+    always = cli_always
+
+    if toml_wh:
+        headers.update(toml_wh.headers)
+        if not cli_always:
+            always = toml_wh.always
+
+    # CLI headers override TOML headers
+    if cli_headers:
+        headers.update(parse_webhook_headers(cli_headers))
+
+    return WebhookConfig(url=url, headers=headers, always=always)

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,178 @@
+"""Tests for webhook notification support (M41)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from xpyd_acc.notify import (
+    WebhookConfig,
+    WebhookPayload,
+    load_webhook_config_from_toml,
+    parse_webhook_headers,
+    resolve_webhook_config,
+    send_webhook,
+)
+
+
+def _make_payload(*, divergence: bool = True) -> WebhookPayload:
+    return WebhookPayload(
+        event="batch_complete",
+        divergence_detected=divergence,
+        total_samples=100,
+        divergent_samples=5 if divergence else 0,
+        divergence_rate=0.05 if divergence else 0.0,
+    )
+
+
+class TestWebhookPayload:
+    def test_to_dict(self) -> None:
+        p = _make_payload()
+        d = p.to_dict()
+        assert d["event"] == "batch_complete"
+        assert d["divergence_detected"] is True
+        assert d["total_samples"] == 100
+        assert d["divergent_samples"] == 5
+        assert d["divergence_rate"] == 0.05
+
+    def test_to_dict_with_extra(self) -> None:
+        p = _make_payload()
+        p.extra = {"run_id": "abc123"}
+        d = p.to_dict()
+        assert d["run_id"] == "abc123"
+
+
+class TestParseWebhookHeaders:
+    def test_empty(self) -> None:
+        assert parse_webhook_headers(None) == {}
+        assert parse_webhook_headers([]) == {}
+
+    def test_valid_headers(self) -> None:
+        result = parse_webhook_headers(["Authorization: Bearer tok", "X-Custom: val"])
+        assert result == {"Authorization": "Bearer tok", "X-Custom": "val"}
+
+    def test_malformed_header_skipped(self) -> None:
+        result = parse_webhook_headers(["NoColon", "Good: Value"])
+        assert result == {"Good": "Value"}
+
+
+class TestLoadWebhookConfigFromToml:
+    def test_no_notifications_section(self) -> None:
+        assert load_webhook_config_from_toml({}) is None
+
+    def test_no_url(self) -> None:
+        assert load_webhook_config_from_toml({"notifications": {}}) is None
+
+    def test_full_config(self) -> None:
+        cfg = load_webhook_config_from_toml({
+            "notifications": {
+                "webhook_url": "https://example.com/hook",
+                "webhook_headers": {"X-Key": "secret"},
+                "webhook_always": True,
+            }
+        })
+        assert cfg is not None
+        assert cfg.url == "https://example.com/hook"
+        assert cfg.headers == {"X-Key": "secret"}
+        assert cfg.always is True
+
+
+class TestResolveWebhookConfig:
+    def test_no_config(self) -> None:
+        assert resolve_webhook_config() is None
+
+    def test_cli_url_wins(self) -> None:
+        cfg = resolve_webhook_config(
+            cli_url="https://cli.example.com",
+            env_url="https://env.example.com",
+        )
+        assert cfg is not None
+        assert cfg.url == "https://cli.example.com"
+
+    def test_env_url_fallback(self) -> None:
+        cfg = resolve_webhook_config(env_url="https://env.example.com")
+        assert cfg is not None
+        assert cfg.url == "https://env.example.com"
+
+    def test_toml_fallback(self) -> None:
+        cfg = resolve_webhook_config(
+            toml_config={"notifications": {"webhook_url": "https://toml.example.com"}}
+        )
+        assert cfg is not None
+        assert cfg.url == "https://toml.example.com"
+
+    def test_cli_headers_override_toml(self) -> None:
+        cfg = resolve_webhook_config(
+            cli_url="https://example.com",
+            cli_headers=["X-Key: cli-val"],
+            toml_config={"notifications": {
+                "webhook_url": "https://toml.example.com",
+                "webhook_headers": {"X-Key": "toml-val", "X-Other": "kept"},
+            }},
+        )
+        assert cfg is not None
+        assert cfg.headers["X-Key"] == "cli-val"
+        assert cfg.headers["X-Other"] == "kept"
+
+    def test_cli_always_flag(self) -> None:
+        cfg = resolve_webhook_config(cli_url="https://example.com", cli_always=True)
+        assert cfg is not None
+        assert cfg.always is True
+
+
+class TestSendWebhook:
+    @pytest.mark.asyncio
+    async def test_skip_when_no_divergence_and_not_always(self) -> None:
+        config = WebhookConfig(url="https://example.com/hook")
+        payload = _make_payload(divergence=False)
+        result = await send_webhook(config, payload)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_when_always_and_no_divergence(self) -> None:
+        config = WebhookConfig(url="https://example.com/hook", always=True)
+        payload = _make_payload(divergence=False)
+
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = lambda: None
+
+        with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
+            mock_retry.return_value = True
+            result = await send_webhook(config, payload)
+            assert result is True
+            mock_retry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_on_divergence(self) -> None:
+        config = WebhookConfig(url="https://example.com/hook")
+        payload = _make_payload(divergence=True)
+
+        with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
+            mock_retry.return_value = True
+            result = await send_webhook(config, payload)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_send_with_custom_headers(self) -> None:
+        config = WebhookConfig(
+            url="https://example.com/hook",
+            headers={"Authorization": "Bearer tok123"},
+        )
+        payload = _make_payload()
+
+        with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
+            mock_retry.return_value = True
+            result = await send_webhook(config, payload)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_retry_failure(self) -> None:
+        config = WebhookConfig(url="https://example.com/hook")
+        payload = _make_payload()
+
+        with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
+            mock_retry.side_effect = Exception("connection failed")
+            result = await send_webhook(config, payload)
+            assert result is False


### PR DESCRIPTION
## Summary
Add webhook notification support so teams can get real-time alerts when batch comparisons detect divergences.

## Changes
- **New module**: `src/xpyd_acc/notify.py` — `WebhookConfig`, `WebhookPayload`, `send_webhook()`, `resolve_webhook_config()`, config helpers
- **CLI integration**: `--webhook <url>`, `--webhook-header 'Key: Value'`, `--webhook-always` flags on `batch-compare`
- **Config support**: TOML `[notifications]` section, `XPYD_ACC_WEBHOOK_URL` env var
- **Priority chain**: CLI > env > TOML (consistent with other config)
- **Retry**: Reuses existing `retry_async` for reliable delivery
- **Tests**: 19 tests covering payload, headers, config resolution, send/skip/retry

## ROADMAP
Added M41 entry.

Closes #91