### PR TITLE
feat: M42 — Sample Filtering for Batch Reports

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -321,7 +321,7 @@
 - Clear error messages for missing `prompt` column/field, non-array JSON, non-object items
 - 11 tests covering all formats, error cases, and fallback behavior
 
-## M41: Webhook Notifications for Divergence Alerts
+## M41: Webhook Notifications for Divergence Alerts ✅
 - `--webhook <url>` flag for `batch-compare`
 - POST JSON payload: event, divergence_detected, total_samples, divergent_samples, divergence_rate
 - `--webhook-header 'Key: Value'` for custom headers (repeatable)
@@ -332,3 +332,15 @@
 - `notify.py` module with `send_webhook()`, `resolve_webhook_config()`
 - Reuses existing retry logic for delivery reliability
 - Tests for webhook send, skip, retry failure, header parsing, config resolution
+
+## M42: Sample Filtering for Batch Reports
+- `xpyd-acc filter --input <report.json> --output <filtered.json>` filters samples from existing reports
+- `--classification <value>` filter by classification (likely_bug, likely_uncertainty, match, unknown)
+- `--divergent-only` / `--matched-only` quick filters
+- `--min-logprob-gap <float>` filter samples with logprob gap above threshold
+- `--max-logprob-gap <float>` filter samples with logprob gap below threshold
+- `--min-context-length <int>` / `--max-context-length <int>` filter by context length
+- `--search <text>` filter samples where prompt or output contains text (case-insensitive)
+- Recalculates report statistics for the filtered subset
+- Rich terminal summary of filtered results
+- Tests for all filter criteria and combinations

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -417,6 +417,43 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     # config validate
+        # Filter subcommand (M42)
+    flt = sub.add_parser("filter", help="Filter samples from a batch report")
+    flt.add_argument("--input", required=True, help="Input batch report JSON")
+    flt.add_argument("--output", required=True, help="Output filtered report JSON")
+    flt.add_argument(
+        "--classification", default=None,
+        help="Filter by classification (likely_bug, likely_uncertainty, match, unknown)",
+    )
+    flt.add_argument(
+        "--divergent-only", action="store_true", default=False,
+        help="Keep only divergent samples",
+    )
+    flt.add_argument(
+        "--matched-only", action="store_true", default=False,
+        help="Keep only matched samples",
+    )
+    flt.add_argument(
+        "--min-logprob-gap", type=float, default=None,
+        help="Minimum logprob gap threshold",
+    )
+    flt.add_argument(
+        "--max-logprob-gap", type=float, default=None,
+        help="Maximum logprob gap threshold",
+    )
+    flt.add_argument(
+        "--min-context-length", type=int, default=None,
+        help="Minimum context length",
+    )
+    flt.add_argument(
+        "--max-context-length", type=int, default=None,
+        help="Maximum context length",
+    )
+    flt.add_argument(
+        "--search", default=None,
+        help="Filter by text in prompt or output (case-insensitive)",
+    )
+
     cfg_cmd = sub.add_parser("config", help="Configuration utilities")
     cfg_sub = cfg_cmd.add_subparsers(dest="config_command")
     cfg_validate = cfg_sub.add_parser("validate", help="Validate a TOML config file")
@@ -461,6 +498,11 @@ def main(argv: list[str] | None = None) -> None:
         except KeyError as exc:
             parser.error(str(exc))
         apply_profile(vars(args), profile)
+
+    # Handle 'filter' subcommand (M42)
+    if args.command == "filter":
+        _run_filter(args)
+        return
 
     # Handle 'init' subcommand
     if args.command == "init":
@@ -1822,6 +1864,31 @@ def _run_history(args: argparse.Namespace) -> None:
 
     else:
         print("Usage: xpyd-acc history {save|list|trend}")
+
+
+def _run_filter(args: argparse.Namespace) -> None:
+    """Filter samples from a batch report."""
+    from xpyd_acc.filter import FilterConfig, filter_samples, load_report, save_report
+
+    report = load_report(args.input)
+    config = FilterConfig(
+        classification=args.classification,
+        divergent_only=args.divergent_only,
+        matched_only=args.matched_only,
+        min_logprob_gap=args.min_logprob_gap,
+        max_logprob_gap=args.max_logprob_gap,
+        min_context_length=args.min_context_length,
+        max_context_length=args.max_context_length,
+        search=args.search,
+    )
+    filtered = filter_samples(report, config)
+    save_report(filtered, args.output)
+
+    total = filtered["total_samples"]
+    divergent = filtered["divergent_samples"]
+    rate = filtered["divergence_rate"]
+    print(f"\nFiltered report: {total} samples, {divergent} divergent ({rate:.1%})")
+    print(f"Saved to {args.output}")
 
 
 def _run_init(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/filter.py
+++ b/src/xpyd_acc/filter.py
@@ -1,0 +1,123 @@
+"""Sample filtering for batch comparison reports."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from xpyd_acc.log import get_logger
+
+logger = get_logger("filter")
+
+
+@dataclass
+class FilterConfig:
+    """Configuration for filtering batch report samples."""
+
+    classification: str | None = None
+    divergent_only: bool = False
+    matched_only: bool = False
+    min_logprob_gap: float | None = None
+    max_logprob_gap: float | None = None
+    min_context_length: int | None = None
+    max_context_length: int | None = None
+    search: str | None = None
+
+
+def load_report(path: str | Path) -> dict[str, Any]:
+    """Load a batch report JSON file."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def filter_samples(
+    report: dict[str, Any],
+    config: FilterConfig,
+) -> dict[str, Any]:
+    """Filter samples in a batch report and recalculate statistics."""
+    samples = report.get("samples", [])
+    filtered = _apply_filters(samples, config)
+
+    total = len(filtered)
+    divergent = sum(1 for s in filtered if not s.get("exact_match", True))
+    matched = total - divergent
+    rate = divergent / total if total > 0 else 0.0
+
+    result = dict(report)
+    result["samples"] = filtered
+    result["total_samples"] = total
+    result["divergent_samples"] = divergent
+    result["match_samples"] = matched
+    result["divergence_rate"] = rate
+
+    logger.info(
+        "Filtered %d -> %d samples (divergent=%d, rate=%.2f%%)",
+        len(samples), total, divergent, rate * 100,
+    )
+    return result
+
+
+def _apply_filters(
+    samples: list[dict[str, Any]],
+    config: FilterConfig,
+) -> list[dict[str, Any]]:
+    """Apply all filter criteria (AND logic)."""
+    result = samples
+
+    if config.divergent_only:
+        result = [s for s in result if not s.get("exact_match", True)]
+
+    if config.matched_only:
+        result = [s for s in result if s.get("exact_match", False)]
+
+    if config.classification is not None:
+        result = [
+            s for s in result
+            if s.get("classification") == config.classification
+        ]
+
+    if config.min_logprob_gap is not None:
+        result = [
+            s for s in result
+            if s.get("logprob_gap") is not None
+            and s["logprob_gap"] >= config.min_logprob_gap
+        ]
+
+    if config.max_logprob_gap is not None:
+        result = [
+            s for s in result
+            if s.get("logprob_gap") is not None
+            and s["logprob_gap"] <= config.max_logprob_gap
+        ]
+
+    if config.min_context_length is not None:
+        result = [
+            s for s in result
+            if s.get("context_length", 0) >= config.min_context_length
+        ]
+
+    if config.max_context_length is not None:
+        result = [
+            s for s in result
+            if s.get("context_length", 0) <= config.max_context_length
+        ]
+
+    if config.search is not None:
+        needle = config.search.lower()
+        result = [
+            s for s in result
+            if needle in s.get("prompt", "").lower()
+            or needle in s.get("baseline_output", "").lower()
+            or needle in s.get("target_output", "").lower()
+        ]
+
+    return result
+
+
+def save_report(report: dict[str, Any], path: str | Path) -> None:
+    """Save a filtered report to JSON."""
+    with open(path, "w") as f:
+        json.dump(report, f, indent=2)
+    logger.info("Filtered report saved to %s", path)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,223 @@
+"""Tests for sample filtering (M42)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xpyd_acc.filter import FilterConfig, filter_samples, load_report, save_report
+
+
+def _make_report(samples: list[dict]) -> dict:
+    total = len(samples)
+    divergent = sum(1 for s in samples if not s.get("exact_match", True))
+    return {
+        "total_samples": total,
+        "divergent_samples": divergent,
+        "match_samples": total - divergent,
+        "divergence_rate": divergent / total if total else 0.0,
+        "samples": samples,
+    }
+
+
+def _sample(
+    sid: str = "s1",
+    exact_match: bool = True,
+    classification: str = "match",
+    logprob_gap: float | None = None,
+    context_length: int = 100,
+    prompt: str = "hello",
+    baseline_output: str = "world",
+    target_output: str = "world",
+) -> dict:
+    return {
+        "sample_id": sid,
+        "prompt": prompt,
+        "baseline_output": baseline_output,
+        "target_output": target_output,
+        "exact_match": exact_match,
+        "classification": classification,
+        "logprob_gap": logprob_gap,
+        "context_length": context_length,
+    }
+
+
+class TestFilterSamples:
+    def test_no_filters(self) -> None:
+        report = _make_report([_sample(), _sample(sid="s2")])
+        result = filter_samples(report, FilterConfig())
+        assert result["total_samples"] == 2
+
+    def test_divergent_only(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", exact_match=True),
+            _sample(sid="s2", exact_match=False, classification="likely_bug"),
+        ])
+        result = filter_samples(report, FilterConfig(divergent_only=True))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s2"
+        assert result["divergent_samples"] == 1
+        assert result["divergence_rate"] == 1.0
+
+    def test_matched_only(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", exact_match=True),
+            _sample(sid="s2", exact_match=False),
+        ])
+        result = filter_samples(report, FilterConfig(matched_only=True))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s1"
+
+    def test_classification_filter(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", classification="likely_bug"),
+            _sample(sid="s2", classification="likely_uncertainty"),
+            _sample(sid="s3", classification="likely_bug"),
+        ])
+        result = filter_samples(report, FilterConfig(classification="likely_bug"))
+        assert result["total_samples"] == 2
+        assert all(s["classification"] == "likely_bug" for s in result["samples"])
+
+    def test_min_logprob_gap(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", logprob_gap=0.1),
+            _sample(sid="s2", logprob_gap=0.5),
+            _sample(sid="s3", logprob_gap=None),
+        ])
+        result = filter_samples(report, FilterConfig(min_logprob_gap=0.3))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s2"
+
+    def test_max_logprob_gap(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", logprob_gap=0.1),
+            _sample(sid="s2", logprob_gap=0.5),
+        ])
+        result = filter_samples(report, FilterConfig(max_logprob_gap=0.3))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s1"
+
+    def test_min_context_length(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", context_length=50),
+            _sample(sid="s2", context_length=200),
+        ])
+        result = filter_samples(report, FilterConfig(min_context_length=100))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s2"
+
+    def test_max_context_length(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", context_length=50),
+            _sample(sid="s2", context_length=200),
+        ])
+        result = filter_samples(report, FilterConfig(max_context_length=100))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s1"
+
+    def test_search_in_prompt(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", prompt="What is Python?"),
+            _sample(sid="s2", prompt="Tell me about Rust"),
+        ])
+        result = filter_samples(report, FilterConfig(search="python"))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s1"
+
+    def test_search_in_output(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", baseline_output="Python is great"),
+            _sample(sid="s2", baseline_output="Rust is fast"),
+        ])
+        result = filter_samples(report, FilterConfig(search="GREAT"))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s1"
+
+    def test_search_in_target_output(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", target_output="error occurred"),
+            _sample(sid="s2", target_output="success"),
+        ])
+        result = filter_samples(report, FilterConfig(search="error"))
+        assert result["total_samples"] == 1
+
+    def test_combined_filters(self) -> None:
+        report = _make_report([
+            _sample(
+                sid="s1", exact_match=False, classification="likely_bug",
+                logprob_gap=0.8, context_length=200,
+            ),
+            _sample(
+                sid="s2", exact_match=False, classification="likely_bug",
+                logprob_gap=0.1, context_length=200,
+            ),
+            _sample(
+                sid="s3", exact_match=False,
+                classification="likely_uncertainty",
+                logprob_gap=0.8, context_length=200,
+            ),
+            _sample(
+                sid="s4", exact_match=True, classification="match",
+                logprob_gap=None, context_length=50,
+            ),
+        ])
+        result = filter_samples(report, FilterConfig(
+            divergent_only=True,
+            classification="likely_bug",
+            min_logprob_gap=0.5,
+        ))
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s1"
+
+    def test_empty_result(self) -> None:
+        report = _make_report([_sample()])
+        result = filter_samples(report, FilterConfig(divergent_only=True))
+        assert result["total_samples"] == 0
+        assert result["divergence_rate"] == 0.0
+
+    def test_recalculates_stats(self) -> None:
+        report = _make_report([
+            _sample(sid="s1", exact_match=True),
+            _sample(sid="s2", exact_match=False),
+            _sample(sid="s3", exact_match=False),
+        ])
+        result = filter_samples(report, FilterConfig(divergent_only=True))
+        assert result["total_samples"] == 2
+        assert result["divergent_samples"] == 2
+        assert result["match_samples"] == 0
+        assert result["divergence_rate"] == 1.0
+
+
+class TestLoadSaveReport:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        report = _make_report([_sample()])
+        path = tmp_path / "report.json"
+        save_report(report, path)
+        loaded = load_report(path)
+        assert loaded["total_samples"] == 1
+        assert loaded["samples"][0]["sample_id"] == "s1"
+
+
+class TestCLIIntegration:
+    def test_filter_cli(self, tmp_path: Path) -> None:
+        """Test filter subcommand via CLI."""
+        from xpyd_acc.cli import main
+
+        report = _make_report([
+            _sample(sid="s1", exact_match=True),
+            _sample(sid="s2", exact_match=False, classification="likely_bug"),
+        ])
+        input_path = tmp_path / "input.json"
+        output_path = tmp_path / "output.json"
+        with open(input_path, "w") as f:
+            json.dump(report, f)
+
+        main([
+            "filter", "--input", str(input_path),
+            "--output", str(output_path), "--divergent-only",
+        ])
+
+        with open(output_path) as f:
+            result = json.load(f)
+        assert result["total_samples"] == 1
+        assert result["samples"][0]["sample_id"] == "s2"


### PR DESCRIPTION
## Summary
Add a `filter` subcommand to filter samples from existing batch reports.

## Changes
- **New module**: `src/xpyd_acc/filter.py` — `FilterConfig`, `filter_samples()`, `load_report()`, `save_report()`
- **CLI integration**: `xpyd-acc filter --input <report.json> --output <filtered.json>`
- **Filter criteria** (all combinable with AND logic):
  - `--classification <value>` — filter by classification field
  - `--divergent-only` / `--matched-only` — quick filters
  - `--min-logprob-gap` / `--max-logprob-gap` — logprob gap range
  - `--min-context-length` / `--max-context-length` — context length range
  - `--search <text>` — case-insensitive text search in prompt/output
- **Statistics recalculation** for filtered subset
- **16 tests** covering all filter criteria and combinations
- **ROADMAP.md** updated with M41 ✅ and M42 entry

Closes #93