### PR TITLE
feat: custom output normalizers for batch comparison (M45)

### DIFF
--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -334,6 +334,7 @@ async def run_batch(
     deduplicate: bool = False,
     cache: Any | None = None,
     rate_limiter: Any | None = None,
+    normalizers: list | None = None,
 ) -> BatchReport:
     """Run all samples against both endpoints and produce a report.
 
@@ -410,7 +411,7 @@ async def run_batch(
 
         from xpyd_acc.output_compare import normalized_match
 
-        exact = normalized_match(baseline_text, target_text, match_config)
+        exact = normalized_match(baseline_text, target_text, match_config, normalizers=normalizers)
         div_idx = _find_first_divergence(b_tokens, t_tokens)
 
         b_lp_at_div: float | None = None
@@ -850,6 +851,7 @@ async def run_multi_batch(
     match_config: Any | None = None,
     sampling_params: Any | None = None,
     timeout: float = 120.0,
+    normalizers: list | None = None,
 ) -> MultiTargetBatchReport:
     """Run batch comparison of one baseline against multiple targets.
 
@@ -900,7 +902,7 @@ async def run_multi_batch(
 
         from xpyd_acc.output_compare import normalized_match
 
-        exact = normalized_match(baseline_text, target_text, match_config)
+        exact = normalized_match(baseline_text, target_text, match_config, normalizers=normalizers)
         div_idx = _find_first_divergence(b_tokens, t_tokens)
 
         b_lp_at_div: float | None = None

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -191,6 +191,11 @@ def main(argv: list[str] | None = None) -> None:
         help="Send each unique prompt only once per endpoint, reuse results for duplicates",
     )
     bc.add_argument(
+        "--normalizer", action="append", default=None, dest="normalizers",
+        help="Output normalizer (repeatable). Built-in: strip_thinking_tags, "
+             "normalize_json, normalize_numbers. Or module:function for custom.",
+    )
+    bc.add_argument(
         "--rate-limit", type=float, default=None,
         help="Max requests per second to each endpoint",
     )
@@ -849,6 +854,13 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             or match_config.numeric_tolerance is not None
         ) else None
 
+        # Resolve output normalizers
+        normalizer_specs = getattr(args, "normalizers", None) or []
+        resolved_normalizers = None
+        if normalizer_specs:
+            from xpyd_acc.normalizers import resolve_normalizers
+            resolved_normalizers = resolve_normalizers(normalizer_specs)
+
         # Set up response cache
         batch_cache = None
         if not getattr(args, "no_cache", False):
@@ -901,6 +913,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
                 enable_request_ids=not getattr(args, "no_request_id", False),
                 cache=batch_cache,
                 rate_limiter=_rl,
+                normalizers=resolved_normalizers,
             )
     finally:
         if progress_ctx is not None:

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -80,6 +80,7 @@ class MatchingConfig:
     normalize_whitespace: bool = False
     ignore_case: bool = False
     numeric_tolerance: float | None = None
+    normalizers: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -230,5 +231,10 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
             if key in merged and (merged[key] is None or merged[key] is False):
                 if config_val is not None and config_val is not False:
                     merged[key] = config_val
+
+        # Merge normalizers from config if not set via CLI
+        if "normalizers" in merged and not merged["normalizers"]:
+            if config.matching.normalizers:
+                merged["normalizers"] = config.matching.normalizers
 
     return merged

--- a/src/xpyd_acc/config_validate.py
+++ b/src/xpyd_acc/config_validate.py
@@ -87,6 +87,7 @@ STARTER_CONFIG = """\
 # normalize_whitespace = false
 # ignore_case = false
 # numeric_tolerance = 0.001
+# normalizers = ["strip_thinking_tags"]
 
 # [profiles.greedy]
 # temperature = 0.0

--- a/src/xpyd_acc/normalizers.py
+++ b/src/xpyd_acc/normalizers.py
@@ -1,0 +1,132 @@
+"""Custom output normalizers for pre-comparison text transformation.
+
+Normalizers are functions that take a string and return a normalized string.
+They are applied before comparison (after existing tolerance matching in
+MatchConfig).
+
+Built-in normalizers:
+- strip_thinking_tags: Remove <think>...</think> and similar tags
+- normalize_json: Pretty-print JSON strings for canonical comparison
+- normalize_numbers: Round floats to configurable decimal places
+
+Custom normalizers can be loaded from Python modules using the
+``module:function`` syntax.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from typing import Callable
+
+from xpyd_acc.log import get_logger
+
+logger = get_logger("normalizers")
+
+# Type alias for normalizer functions
+Normalizer = Callable[[str], str]
+
+# Regex for <think>...</think>, <thinking>...</thinking>, etc.
+_THINKING_TAG_RE = re.compile(
+    r"<(think|thinking|thought|reasoning)>.*?</\1>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+# Default decimal places for normalize_numbers
+_DEFAULT_PRECISION = 6
+
+
+def strip_thinking_tags(text: str) -> str:
+    """Remove ``<think>...</think>`` and similar reasoning tags.
+
+    Handles ``<think>``, ``<thinking>``, ``<thought>``, ``<reasoning>``
+    (case-insensitive). Strips leading/trailing whitespace after removal.
+    """
+    result = _THINKING_TAG_RE.sub("", text)
+    return result.strip()
+
+
+def normalize_json(text: str) -> str:
+    """Pretty-print JSON strings for canonical comparison.
+
+    If the text is valid JSON, returns a canonically formatted version
+    (sorted keys, 2-space indent). If not valid JSON, returns the text
+    unchanged.
+    """
+    try:
+        parsed = json.loads(text)
+        return json.dumps(parsed, sort_keys=True, indent=2, ensure_ascii=False)
+    except (json.JSONDecodeError, TypeError):
+        return text
+
+
+def normalize_numbers(text: str, *, precision: int = _DEFAULT_PRECISION) -> str:
+    """Round floating-point numbers in the text to *precision* decimal places.
+
+    Integer-like numbers (no decimal point) are left unchanged.
+    """
+    def _round_match(m: re.Match[str]) -> str:
+        s = m.group(0)
+        if "." not in s and "e" not in s.lower():
+            return s  # integer, leave as-is
+        try:
+            return str(round(float(s), precision))
+        except ValueError:
+            return s
+
+    return re.compile(r"-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?").sub(_round_match, text)
+
+
+# Registry of built-in normalizers
+BUILTIN_NORMALIZERS: dict[str, Normalizer] = {
+    "strip_thinking_tags": strip_thinking_tags,
+    "normalize_json": normalize_json,
+    "normalize_numbers": normalize_numbers,
+}
+
+
+def load_normalizer(spec: str) -> Normalizer:
+    """Load a normalizer by name or ``module:function`` spec.
+
+    Built-in names are resolved first. If *spec* contains a colon, it is
+    treated as ``module:function`` and imported dynamically.
+    """
+    if spec in BUILTIN_NORMALIZERS:
+        return BUILTIN_NORMALIZERS[spec]
+
+    if ":" in spec:
+        module_path, func_name = spec.rsplit(":", 1)
+        try:
+            mod = importlib.import_module(module_path)
+        except ModuleNotFoundError as exc:
+            msg = f"Cannot import normalizer module '{module_path}': {exc}"
+            raise ValueError(msg) from exc
+        func = getattr(mod, func_name, None)
+        if func is None:
+            msg = f"Module '{module_path}' has no attribute '{func_name}'"
+            raise ValueError(msg)
+        if not callable(func):
+            msg = f"'{module_path}:{func_name}' is not callable"
+            raise ValueError(msg)
+        return func
+
+    msg = (
+        f"Unknown normalizer '{spec}'. "
+        f"Built-in: {', '.join(sorted(BUILTIN_NORMALIZERS))}. "
+        f"Or use 'module:function' for custom normalizers."
+    )
+    raise ValueError(msg)
+
+
+def resolve_normalizers(specs: list[str]) -> list[Normalizer]:
+    """Resolve a list of normalizer specs into callable normalizers."""
+    return [load_normalizer(s) for s in specs]
+
+
+def apply_normalizers(text: str, normalizers: list[Normalizer]) -> str:
+    """Apply a chain of normalizers to *text* in order."""
+    result = text
+    for norm in normalizers:
+        result = norm(result)
+    return result

--- a/src/xpyd_acc/output_compare.py
+++ b/src/xpyd_acc/output_compare.py
@@ -35,11 +35,22 @@ def _numbers_close(a_str: str, b_str: str, tolerance: float) -> bool:
         return False
 
 
-def normalized_match(text1: str, text2: str, config: MatchConfig | None = None) -> bool:
+def normalized_match(
+    text1: str,
+    text2: str,
+    config: MatchConfig | None = None,
+    normalizers: list | None = None,
+) -> bool:
     """Check whether *text1* and *text2* match under the given tolerances.
 
     With default (None) config, this is strict exact match.
+    *normalizers* is an optional list of callables applied before comparison.
     """
+    if normalizers:
+        from xpyd_acc.normalizers import apply_normalizers
+        text1 = apply_normalizers(text1, normalizers)
+        text2 = apply_normalizers(text2, normalizers)
+
     if config is None:
         return text1 == text2
 

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -1,0 +1,147 @@
+"""Tests for custom output normalizers."""
+
+from __future__ import annotations
+
+import pytest
+
+from xpyd_acc.normalizers import (
+    apply_normalizers,
+    load_normalizer,
+    normalize_json,
+    normalize_numbers,
+    resolve_normalizers,
+    strip_thinking_tags,
+)
+
+
+class TestStripThinkingTags:
+    def test_removes_think_tag(self):
+        text = "<think>some reasoning</think>The answer is 42."
+        assert strip_thinking_tags(text) == "The answer is 42."
+
+    def test_removes_thinking_tag(self):
+        text = "<thinking>step by step</thinking> Result: 5"
+        assert strip_thinking_tags(text) == "Result: 5"
+
+    def test_removes_thought_tag(self):
+        text = "<thought>hmm</thought>Yes"
+        assert strip_thinking_tags(text) == "Yes"
+
+    def test_removes_reasoning_tag(self):
+        text = "<reasoning>logic</reasoning>Done"
+        assert strip_thinking_tags(text) == "Done"
+
+    def test_case_insensitive(self):
+        text = "<THINK>stuff</THINK>answer"
+        assert strip_thinking_tags(text) == "answer"
+
+    def test_multiline(self):
+        text = "<think>\nline1\nline2\n</think>\nResult"
+        assert strip_thinking_tags(text) == "Result"
+
+    def test_no_tags(self):
+        text = "No tags here"
+        assert strip_thinking_tags(text) == "No tags here"
+
+    def test_multiple_tags(self):
+        text = "<think>a</think>middle<think>b</think>end"
+        assert strip_thinking_tags(text) == "middleend"
+
+
+class TestNormalizeJson:
+    def test_valid_json(self):
+        text = '{"b": 2, "a": 1}'
+        result = normalize_json(text)
+        assert result == '{\n  "a": 1,\n  "b": 2\n}'
+
+    def test_not_json(self):
+        text = "just plain text"
+        assert normalize_json(text) == text
+
+    def test_json_array(self):
+        text = "[3, 1, 2]"
+        result = normalize_json(text)
+        assert result == "[\n  3,\n  1,\n  2\n]"
+
+
+class TestNormalizeNumbers:
+    def test_rounds_floats(self):
+        text = "value is 3.141592653589793"
+        result = normalize_numbers(text, precision=2)
+        assert "3.14" in result
+
+    def test_leaves_integers(self):
+        text = "count is 42"
+        assert normalize_numbers(text) == "count is 42"
+
+    def test_scientific_notation(self):
+        text = "1.23e-4"
+        result = normalize_numbers(text, precision=6)
+        assert result == str(round(1.23e-4, 6))
+
+    def test_no_numbers(self):
+        text = "no numbers here"
+        assert normalize_numbers(text) == "no numbers here"
+
+
+class TestLoadNormalizer:
+    def test_builtin_by_name(self):
+        fn = load_normalizer("strip_thinking_tags")
+        assert fn is strip_thinking_tags
+
+    def test_unknown_name_raises(self):
+        with pytest.raises(ValueError, match="Unknown normalizer"):
+            load_normalizer("nonexistent")
+
+    def test_module_function(self):
+        fn = load_normalizer("json:dumps")
+        import json
+        assert fn is json.dumps
+
+    def test_module_not_found(self):
+        with pytest.raises(ValueError, match="Cannot import"):
+            load_normalizer("nonexistent_module_xyz:func")
+
+    def test_function_not_found(self):
+        with pytest.raises(ValueError, match="has no attribute"):
+            load_normalizer("json:nonexistent_func_xyz")
+
+
+class TestResolveNormalizers:
+    def test_resolves_list(self):
+        fns = resolve_normalizers(["strip_thinking_tags", "normalize_json"])
+        assert len(fns) == 2
+        assert fns[0] is strip_thinking_tags
+        assert fns[1] is normalize_json
+
+
+class TestApplyNormalizers:
+    def test_chain(self):
+        text = "<think>reason</think>{\"b\":2,\"a\":1}"
+        fns = [strip_thinking_tags, normalize_json]
+        result = apply_normalizers(text, fns)
+        assert result == '{\n  "a": 1,\n  "b": 2\n}'
+
+    def test_empty_list(self):
+        text = "unchanged"
+        assert apply_normalizers(text, []) == "unchanged"
+
+
+class TestNormalizedMatchIntegration:
+    """Test normalizers integration with normalized_match."""
+
+    def test_match_with_normalizer(self):
+        from xpyd_acc.output_compare import normalized_match
+
+        text1 = "<think>reasoning</think>answer"
+        text2 = "answer"
+        assert not normalized_match(text1, text2)
+        assert normalized_match(text1, text2, normalizers=[strip_thinking_tags])
+
+    def test_match_with_config_and_normalizer(self):
+        from xpyd_acc.output_compare import MatchConfig, normalized_match
+
+        text1 = "<think>x</think>  HELLO  "
+        text2 = "hello"
+        config = MatchConfig(normalize_whitespace=True, ignore_case=True)
+        assert normalized_match(text1, text2, config, normalizers=[strip_thinking_tags])


### PR DESCRIPTION
## Summary
Add a plugin-style output normalizer system for pre-comparison text transformation.

### Changes
- **`normalizers.py`**: Built-in normalizers + plugin loader
  - `strip_thinking_tags`: Removes `<think>...</think>`, `<thinking>`, `<thought>`, `<reasoning>` tags
  - `normalize_json`: Pretty-prints JSON for canonical comparison
  - `normalize_numbers`: Rounds floats to configurable precision
  - Custom normalizers via `module:function` syntax
- **CLI**: `--normalizer <name>` flag (repeatable) on `batch-compare`
- **Config**: `[matching] normalizers = ["strip_thinking_tags"]` in TOML
- **Integration**: Normalizers applied in `normalized_match()` before tolerance matching
- **Tests**: 25 tests covering all built-in normalizers, loader, chaining, and integration

### How it works
Normalizers are functions `str → str` applied in order before comparison. Built-in names are resolved first; `module:function` specs are imported dynamically.

Closes #99