### PR TITLE
feat: auto-bisect divergence by context length (M47)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -380,3 +380,15 @@
 - `--kl-threshold <float>` flag to flag positions exceeding threshold
 - `distribution.py` module with all metric computations
 - 22 tests covering KL/JS computation, overlap, edge cases
+
+## M47: Auto-Bisect Divergence by Context Length
+- `xpyd-acc bisect --baseline <url> --target <url> --prompt <text> --model <model>`
+- Binary search over prompt prefix lengths to find minimum divergence threshold
+- `--min-length` and `--max-length` to bound search range
+- `BisectResult` dataclass with threshold_length, steps, always/never_diverges
+- JSON export via `--json <path>`
+- Rich terminal progress output with per-step pass/fail
+- Sampling params support (--temperature, --top-p, --seed, --profile)
+- Retry, timeout flags supported
+- `bisect.py` module with `run_bisect()` async function
+- 10 tests covering binary search, edge cases, JSON export, callbacks

--- a/src/xpyd_acc/bisect.py
+++ b/src/xpyd_acc/bisect.py
@@ -1,0 +1,189 @@
+"""Auto-bisect divergence by context length.
+
+Binary search over prompt prefix lengths to find the minimum context
+length where PD disaggregation diverges from baseline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from typing import Callable
+
+from .logprobs import LogprobsCollector, LogprobsComparator
+from .sampling import SamplingParams
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BisectStep:
+    """Result of a single bisect iteration."""
+
+    iteration: int
+    prefix_length: int
+    diverges: bool
+    first_divergence_index: int | None = None
+
+
+@dataclass
+class BisectResult:
+    """Result of the full bisect search."""
+
+    threshold_length: int | None
+    total_iterations: int
+    steps: list[BisectStep] = field(default_factory=list)
+    always_diverges: bool = False
+    never_diverges: bool = False
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(asdict(self), indent=2)
+
+
+async def _check_divergence(
+    baseline_url: str,
+    target_url: str,
+    prompt: str,
+    model: str,
+    prefix_length: int,
+    *,
+    api_key: str | None = None,
+    sampling: SamplingParams | None = None,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+    timeout: float = 120.0,
+) -> tuple[bool, int | None]:
+    """Check if the given prefix length causes divergence."""
+    prefix = prompt[:prefix_length]
+    if not prefix:
+        return False, None
+
+    key = api_key or "no-key"
+    baseline_collector = LogprobsCollector(baseline_url, api_key=key, model=model)
+    target_collector = LogprobsCollector(target_url, api_key=key, model=model)
+
+    baseline_result = await baseline_collector.collect(
+        prefix, timeout=timeout, retries=retries, retry_delay=retry_delay,
+        sampling_params=sampling,
+    )
+    target_result = await target_collector.collect(
+        prefix, timeout=timeout, retries=retries, retry_delay=retry_delay,
+        sampling_params=sampling,
+    )
+
+    comparator = LogprobsComparator()
+    report = comparator.compare(baseline_result, target_result)
+    if report.match:
+        return False, None
+    div_idx = report.divergence.token_index if report.divergence else None
+    return True, div_idx
+
+
+async def run_bisect(
+    baseline_url: str,
+    target_url: str,
+    prompt: str,
+    model: str,
+    *,
+    min_length: int | None = None,
+    max_length: int | None = None,
+    api_key: str | None = None,
+    sampling: SamplingParams | None = None,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+    timeout: float = 120.0,
+    progress_callback: Callable[[int, int, bool], None] | None = None,
+) -> BisectResult:
+    """Binary search for the minimum prefix length that causes divergence.
+
+    Parameters
+    ----------
+    baseline_url : str
+        Baseline (aggregated) endpoint URL.
+    target_url : str
+        Target (disaggregated) endpoint URL.
+    prompt : str
+        Full prompt text.
+    model : str
+        Model name for both endpoints.
+    min_length : int | None
+        Minimum prefix length to test (default 1).
+    max_length : int | None
+        Maximum prefix length to test (default len(prompt)).
+
+    Returns
+    -------
+    BisectResult
+        The bisect search result with threshold_length being the
+        minimum prefix length that causes divergence.
+    """
+    lo = min_length if min_length is not None else 1
+    hi = max_length if max_length is not None else len(prompt)
+    lo = max(1, lo)
+    hi = min(hi, len(prompt))
+
+    if lo > hi:
+        return BisectResult(threshold_length=None, total_iterations=0, never_diverges=True)
+
+    steps: list[BisectStep] = []
+    iteration = 0
+
+    check_kwargs = dict(
+        api_key=api_key, sampling=sampling, retries=retries,
+        retry_delay=retry_delay, timeout=timeout,
+    )
+
+    # Check max length first — if it doesn't diverge, nothing will.
+    iteration += 1
+    diverges_hi, div_idx_hi = await _check_divergence(
+        baseline_url, target_url, prompt, model, hi, **check_kwargs,
+    )
+    steps.append(BisectStep(iteration, hi, diverges_hi, div_idx_hi))
+    logger.info("Bisect step %d: length=%d diverges=%s", iteration, hi, diverges_hi)
+    if progress_callback:
+        progress_callback(iteration, hi, diverges_hi)
+
+    if not diverges_hi:
+        return BisectResult(
+            threshold_length=None, total_iterations=iteration,
+            steps=steps, never_diverges=True,
+        )
+
+    # Check min length — if it diverges, divergence starts at or below min.
+    iteration += 1
+    diverges_lo, div_idx_lo = await _check_divergence(
+        baseline_url, target_url, prompt, model, lo, **check_kwargs,
+    )
+    steps.append(BisectStep(iteration, lo, diverges_lo, div_idx_lo))
+    logger.info("Bisect step %d: length=%d diverges=%s", iteration, lo, diverges_lo)
+    if progress_callback:
+        progress_callback(iteration, lo, diverges_lo)
+
+    if diverges_lo:
+        return BisectResult(
+            threshold_length=lo, total_iterations=iteration,
+            steps=steps, always_diverges=True,
+        )
+
+    # Binary search: lo doesn't diverge, hi does.
+    while lo + 1 < hi:
+        mid = (lo + hi) // 2
+        iteration += 1
+        diverges_mid, div_idx_mid = await _check_divergence(
+            baseline_url, target_url, prompt, model, mid, **check_kwargs,
+        )
+        steps.append(BisectStep(iteration, mid, diverges_mid, div_idx_mid))
+        logger.info("Bisect step %d: length=%d diverges=%s", iteration, mid, diverges_mid)
+        if progress_callback:
+            progress_callback(iteration, mid, diverges_mid)
+
+        if diverges_mid:
+            hi = mid
+        else:
+            lo = mid
+
+    return BisectResult(
+        threshold_length=hi, total_iterations=iteration, steps=steps,
+    )

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -369,6 +369,27 @@ def main(argv: list[str] | None = None) -> None:
         help="Write completion script to file instead of stdout",
     )
 
+    # bisect: auto-bisect divergence by context length
+    bis = sub.add_parser("bisect", help="Binary search for min context length causing divergence")
+    bis.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    bis.add_argument("--target", required=True, help="Target endpoint URL")
+    bis.add_argument("--prompt", required=True, help="Full prompt text to bisect")
+    bis.add_argument("--model", default="default", help="Model name")
+    bis.add_argument("--api-key", default=None, help="API key for endpoints")
+    bis.add_argument("--min-length", type=int, default=None, help="Minimum prefix length")
+    bis.add_argument("--max-length", type=int, default=None, help="Maximum prefix length")
+    bis.add_argument("--retries", type=int, default=None, help="Max retry attempts (default: 3)")
+    bis.add_argument(
+        "--retry-delay", type=float, default=None,
+        help="Base retry delay in seconds (default: 1.0)",
+    )
+    bis.add_argument(
+        "--timeout", type=float, default=None,
+        help="HTTP request timeout in seconds (default: 120.0)",
+    )
+    bis.add_argument("--json", default=None, metavar="PATH", help="Export result as JSON")
+    _add_sampling_args(bis)
+
     # snapshot capture
     sc = sub.add_parser("snapshot", help="Capture baseline outputs as a snapshot")
     sc.add_argument("action", choices=["capture"], help="Snapshot action")
@@ -644,6 +665,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_history(args)
     elif args.command == "benchmark":
         asyncio.run(_run_benchmark(args))
+    elif args.command == "bisect":
+        asyncio.run(_run_bisect(args))
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -2037,3 +2060,50 @@ def _run_config(args: argparse.Namespace) -> None:
             else:
                 print(f"\n⚠️  {path} has warnings but no errors")
                 sys.exit(0)
+
+
+async def _run_bisect(args: argparse.Namespace) -> None:
+    """Run bisect to find minimum divergence context length."""
+    from xpyd_acc.bisect import run_bisect
+    from xpyd_acc.sampling import SamplingParams
+
+    sp = SamplingParams(
+        temperature=getattr(args, "temperature", None),
+        top_p=getattr(args, "top_p", None),
+        seed=getattr(args, "seed", None),
+    )
+
+    def progress(iteration: int, length: int, diverges: bool) -> None:
+        status = "❌ DIVERGES" if diverges else "✅ MATCH"
+        print(f"  Step {iteration}: length={length} → {status}")
+
+    print(f"🔍 Bisecting divergence over prompt length ({len(args.prompt)} chars)...")
+    result = await run_bisect(
+        baseline_url=args.baseline,
+        target_url=args.target,
+        prompt=args.prompt,
+        model=args.model,
+        min_length=getattr(args, "min_length", None),
+        max_length=getattr(args, "max_length", None),
+        api_key=getattr(args, "api_key", None),
+        sampling=sp,
+        retries=args.retries or 3,
+        retry_delay=args.retry_delay or 1.0,
+        timeout=args.timeout or 120.0,
+        progress_callback=progress,
+    )
+
+    print()
+    if result.never_diverges:
+        print("✅ No divergence found at any tested length.")
+    elif result.always_diverges:
+        print(f"❌ Divergence at all tested lengths (minimum tested: {result.threshold_length}).")
+    else:
+        print(f"🎯 Divergence threshold: {result.threshold_length} characters.")
+    print(f"   Total iterations: {result.total_iterations}")
+
+    json_path = getattr(args, "json", None)
+    if json_path:
+        import pathlib
+        pathlib.Path(json_path).write_text(result.to_json())
+        print(f"   Exported to {json_path}")

--- a/tests/test_bisect.py
+++ b/tests/test_bisect.py
@@ -1,0 +1,222 @@
+"""Tests for bisect module — auto-bisect divergence by context length."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_acc.bisect import BisectResult, BisectStep, run_bisect
+
+
+def _make_check_divergence_side_effect(threshold: int):
+    """Return a side effect that diverges when prefix_length >= threshold."""
+
+    async def _side_effect(
+        baseline_url, target_url, prompt, model, prefix_length, **kwargs
+    ):
+        if prefix_length >= threshold:
+            return True, 5  # diverges at token index 5
+        return False, None
+
+    return _side_effect
+
+
+def _always_diverge():
+    async def _side_effect(
+        baseline_url, target_url, prompt, model, prefix_length, **kwargs
+    ):
+        return True, 0
+
+    return _side_effect
+
+
+def _never_diverge():
+    async def _side_effect(
+        baseline_url, target_url, prompt, model, prefix_length, **kwargs
+    ):
+        return False, None
+
+    return _side_effect
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_finds_threshold(mock_check):
+    """Binary search finds the correct divergence threshold."""
+    # Diverges at length >= 50
+    mock_check.side_effect = _make_check_divergence_side_effect(50)
+
+    prompt = "x" * 100
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+        min_length=1, max_length=100,
+    )
+
+    assert result.threshold_length == 50
+    assert not result.always_diverges
+    assert not result.never_diverges
+    assert result.total_iterations > 0
+    assert len(result.steps) > 0
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_never_diverges(mock_check):
+    """No divergence at any length."""
+    mock_check.side_effect = _never_diverge()
+
+    prompt = "x" * 100
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+    )
+
+    assert result.threshold_length is None
+    assert result.never_diverges
+    assert not result.always_diverges
+    assert result.total_iterations == 1  # only checked max
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_always_diverges(mock_check):
+    """Divergence at all lengths."""
+    mock_check.side_effect = _always_diverge()
+
+    prompt = "x" * 100
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+    )
+
+    assert result.threshold_length == 1
+    assert result.always_diverges
+    assert not result.never_diverges
+    assert result.total_iterations == 2  # checked max and min
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_json_export(mock_check):
+    """BisectResult serializes to valid JSON."""
+    mock_check.side_effect = _make_check_divergence_side_effect(30)
+
+    prompt = "x" * 100
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+    )
+
+    json_str = result.to_json()
+    data = json.loads(json_str)
+    assert data["threshold_length"] == 30
+    assert "steps" in data
+    assert "total_iterations" in data
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_with_min_max_bounds(mock_check):
+    """Respects min_length and max_length bounds."""
+    mock_check.side_effect = _make_check_divergence_side_effect(40)
+
+    prompt = "x" * 200
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+        min_length=20, max_length=80,
+    )
+
+    assert result.threshold_length == 40
+    # All tested lengths should be within bounds
+    for step in result.steps:
+        assert 20 <= step.prefix_length <= 80
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_progress_callback(mock_check):
+    """Progress callback is called for each step."""
+    mock_check.side_effect = _make_check_divergence_side_effect(50)
+
+    callbacks = []
+
+    def on_progress(iteration, length, diverges):
+        callbacks.append((iteration, length, diverges))
+
+    prompt = "x" * 100
+    await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+        progress_callback=on_progress,
+    )
+
+    assert len(callbacks) > 0
+    # First callback should be for max length (100)
+    assert callbacks[0][1] == 100
+    assert callbacks[0][2] is True  # diverges at 100 >= 50
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_invalid_range(mock_check):
+    """Returns never_diverges with 0 iterations if min > max."""
+    prompt = "x" * 10
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+        min_length=50, max_length=10,
+    )
+
+    assert result.never_diverges
+    assert result.total_iterations == 0
+    mock_check.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_sampling_params_forwarded(mock_check):
+    """Sampling parameters are forwarded to _check_divergence."""
+    from xpyd_acc.sampling import SamplingParams
+
+    mock_check.side_effect = _never_diverge()
+
+    sp = SamplingParams(temperature=0.0, seed=42)
+    prompt = "x" * 10
+    await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+        sampling=sp,
+    )
+
+    # Check sampling was passed through
+    call_kwargs = mock_check.call_args
+    assert call_kwargs.kwargs.get("sampling") is sp
+
+
+@pytest.mark.asyncio
+@patch("xpyd_acc.bisect._check_divergence")
+async def test_bisect_step_dataclass(mock_check):
+    """BisectStep contains correct data."""
+    mock_check.side_effect = _make_check_divergence_side_effect(50)
+
+    prompt = "x" * 100
+    result = await run_bisect(
+        "http://baseline", "http://target", prompt, "model",
+    )
+
+    for step in result.steps:
+        assert isinstance(step, BisectStep)
+        assert step.iteration > 0
+        assert step.prefix_length > 0
+        assert isinstance(step.diverges, bool)
+        if step.diverges:
+            assert step.first_divergence_index is not None
+
+
+def test_bisect_result_dataclass():
+    """BisectResult fields and to_json work."""
+    result = BisectResult(
+        threshold_length=42,
+        total_iterations=5,
+        steps=[BisectStep(1, 100, True, 3)],
+    )
+    assert result.threshold_length == 42
+    data = json.loads(result.to_json())
+    assert data["threshold_length"] == 42
+    assert len(data["steps"]) == 1


### PR DESCRIPTION
## Summary
Binary search over prompt prefix lengths to find the minimum context length where PD disaggregation diverges from baseline.

## Changes
- `src/xpyd_acc/bisect.py`: `run_bisect()` async function with binary search logic, `BisectResult`/`BisectStep` dataclasses, JSON export
- `src/xpyd_acc/cli.py`: `bisect` subcommand with `--baseline`, `--target`, `--prompt`, `--model`, `--min-length`, `--max-length`, `--json`, sampling params
- `tests/test_bisect.py`: 10 tests covering threshold finding, never/always diverge edge cases, JSON export, bounds, progress callbacks, sampling forwarding
- `ROADMAP.md`: Added M47 milestone

## Testing
All 604 tests pass. Lint clean (ruff + isort).

Closes #103