### PR TITLE
feat(summary): add compact summary command (M48)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -392,3 +392,12 @@
 - Retry, timeout flags supported
 - `bisect.py` module with `run_bisect()` async function
 - 10 tests covering binary search, edge cases, JSON export, callbacks
+
+## M48: Compact Summary Command ✅
+- `xpyd-acc summary <report.json>` outputs a compact summary of a batch report
+- `--format oneline` (default): single-line summary for CI logs and dashboards
+- `--format json`: compact JSON on one line (for piping to jq, webhooks)
+- `--format kv`: key=value pairs, one per line (for shell scripts)
+- Works with single-target and multi-target reports
+- `summary.py` module with `SummaryData`, `extract_summary()`, `load_and_summarize()`
+- 22 tests covering all formats, edge cases, and CLI integration

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import sys
 
 
@@ -520,6 +521,15 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to config file (default: xpyd-acc.toml)",
     )
 
+    # summary (M48)
+    summary_cmd = sub.add_parser("summary", help="Compact summary of a batch report")
+    summary_cmd.add_argument("report", help="Path to batch report JSON file")
+    summary_cmd.add_argument(
+        "--format", dest="summary_format", default="oneline",
+        choices=["oneline", "json", "kv"],
+        help="Output format (default: oneline)",
+    )
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -556,6 +566,11 @@ def main(argv: list[str] | None = None) -> None:
         except KeyError as exc:
             parser.error(str(exc))
         apply_profile(vars(args), profile)
+
+    # Handle 'summary' subcommand (M48)
+    if args.command == "summary":
+        _run_summary(args)
+        return
 
     # Handle 'filter' subcommand (M42)
     if args.command == "filter":
@@ -1986,6 +2001,25 @@ def _run_history(args: argparse.Namespace) -> None:
 
     else:
         print("Usage: xpyd-acc history {save|list|trend}")
+
+
+def _run_summary(args: argparse.Namespace) -> None:
+    """Run the summary subcommand."""
+    import sys
+    from pathlib import Path
+
+    from xpyd_acc.summary import load_and_summarize
+
+    report_path = Path(args.report)
+    if not report_path.is_file():
+        print(f"Error: report file not found: {report_path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        output = load_and_summarize(report_path, args.summary_format)
+    except (json.JSONDecodeError, OSError) as exc:
+        print(f"Error: failed to read report: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(output)
 
 
 def _run_filter(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/summary.py
+++ b/src/xpyd_acc/summary.py
@@ -1,0 +1,110 @@
+"""Compact summary output for batch reports."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class SummaryData:
+    """Compact summary extracted from a batch report."""
+
+    dataset: str
+    total_samples: int
+    divergent_samples: int
+    divergence_rate: float
+    divergence_index_mean: float | None
+    divergence_index_median: float | None
+    targets: list[str] | None  # None for single-target
+
+    def to_oneline(self) -> str:
+        """Format as a single-line summary string."""
+        parts = [
+            self.dataset,
+            f"{self.total_samples} samples",
+            f"{self.divergent_samples} divergent ({self.divergence_rate:.1%})",
+        ]
+        if self.divergence_index_mean is not None:
+            parts.append(f"mean div index: {self.divergence_index_mean:.1f}")
+        return " | ".join(parts)
+
+    def to_json(self) -> str:
+        """Format as compact single-line JSON."""
+        d: dict[str, Any] = {
+            "dataset": self.dataset,
+            "total_samples": self.total_samples,
+            "divergent_samples": self.divergent_samples,
+            "divergence_rate": round(self.divergence_rate, 4),
+        }
+        if self.divergence_index_mean is not None:
+            d["divergence_index_mean"] = round(self.divergence_index_mean, 1)
+        if self.divergence_index_median is not None:
+            d["divergence_index_median"] = round(self.divergence_index_median, 1)
+        if self.targets is not None:
+            d["targets"] = self.targets
+        return json.dumps(d, separators=(",", ":"))
+
+    def to_kv(self) -> str:
+        """Format as key=value pairs, one per line."""
+        lines = [
+            f"dataset={self.dataset}",
+            f"total_samples={self.total_samples}",
+            f"divergent_samples={self.divergent_samples}",
+            f"divergence_rate={self.divergence_rate:.4f}",
+        ]
+        if self.divergence_index_mean is not None:
+            lines.append(f"divergence_index_mean={self.divergence_index_mean:.1f}")
+        if self.divergence_index_median is not None:
+            lines.append(f"divergence_index_median={self.divergence_index_median:.1f}")
+        if self.targets is not None:
+            lines.append(f"targets={','.join(self.targets)}")
+        return "\n".join(lines)
+
+    def format(self, fmt: str = "oneline") -> str:
+        """Format the summary in the requested format."""
+        formatters = {
+            "oneline": self.to_oneline,
+            "json": self.to_json,
+            "kv": self.to_kv,
+        }
+        formatter = formatters.get(fmt)
+        if formatter is None:
+            msg = f"Unknown format: {fmt!r} (choose from: {', '.join(formatters)})"
+            raise ValueError(msg)
+        return formatter()
+
+
+def extract_summary(report_data: dict[str, Any]) -> SummaryData:
+    """Extract a SummaryData from a parsed batch report dict."""
+    dataset = report_data.get("dataset", "unknown")
+    total = report_data.get("total_samples", 0)
+    divergent = report_data.get("divergent_samples", 0)
+    rate = report_data.get("divergence_rate", 0.0)
+    mean_idx = report_data.get("divergence_index_mean")
+    median_idx = report_data.get("divergence_index_median")
+
+    # Multi-target reports have per_target key
+    targets = None
+    if "per_target" in report_data and isinstance(report_data["per_target"], dict):
+        targets = list(report_data["per_target"].keys())
+
+    return SummaryData(
+        dataset=dataset,
+        total_samples=total,
+        divergent_samples=divergent,
+        divergence_rate=rate,
+        divergence_index_mean=mean_idx,
+        divergence_index_median=median_idx,
+        targets=targets,
+    )
+
+
+def load_and_summarize(path: str | Path, fmt: str = "oneline") -> str:
+    """Load a JSON report file and return a formatted summary string."""
+    report_path = Path(path)
+    data = json.loads(report_path.read_text(encoding="utf-8"))
+    summary = extract_summary(data)
+    return summary.format(fmt)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,193 @@
+"""Tests for M48: Compact Summary Command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.summary import SummaryData, extract_summary, load_and_summarize
+
+
+@pytest.fixture()
+def basic_report() -> dict:
+    return {
+        "dataset": "gsm8k",
+        "total_samples": 100,
+        "divergent_samples": 12,
+        "divergence_rate": 0.12,
+        "divergence_index_mean": 5.3,
+        "divergence_index_median": 4.0,
+        "results": [],
+    }
+
+
+@pytest.fixture()
+def basic_report_file(tmp_path: Path, basic_report: dict) -> Path:
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(basic_report), encoding="utf-8")
+    return p
+
+
+class TestSummaryData:
+    def test_to_oneline(self) -> None:
+        s = SummaryData("gsm8k", 100, 12, 0.12, 5.3, 4.0, None)
+        line = s.to_oneline()
+        assert "gsm8k" in line
+        assert "100 samples" in line
+        assert "12 divergent (12.0%)" in line
+        assert "mean div index: 5.3" in line
+
+    def test_to_oneline_no_divergence(self) -> None:
+        s = SummaryData("mmlu", 50, 0, 0.0, None, None, None)
+        line = s.to_oneline()
+        assert "0 divergent (0.0%)" in line
+        assert "mean div index" not in line
+
+    def test_to_json(self) -> None:
+        s = SummaryData("gsm8k", 100, 12, 0.12, 5.3, 4.0, None)
+        parsed = json.loads(s.to_json())
+        assert parsed["dataset"] == "gsm8k"
+        assert parsed["total_samples"] == 100
+        assert parsed["divergent_samples"] == 12
+        assert parsed["divergence_rate"] == 0.12
+        assert parsed["divergence_index_mean"] == 5.3
+        assert "targets" not in parsed
+
+    def test_to_json_with_targets(self) -> None:
+        s = SummaryData("gsm8k", 100, 12, 0.12, None, None, ["http://a", "http://b"])
+        parsed = json.loads(s.to_json())
+        assert parsed["targets"] == ["http://a", "http://b"]
+
+    def test_to_kv(self) -> None:
+        s = SummaryData("gsm8k", 100, 12, 0.12, 5.3, 4.0, None)
+        kv = s.to_kv()
+        assert "dataset=gsm8k" in kv
+        assert "total_samples=100" in kv
+        assert "divergent_samples=12" in kv
+        assert "divergence_rate=0.1200" in kv
+        assert "divergence_index_mean=5.3" in kv
+
+    def test_to_kv_with_targets(self) -> None:
+        s = SummaryData("x", 10, 1, 0.1, None, None, ["a", "b"])
+        kv = s.to_kv()
+        assert "targets=a,b" in kv
+        assert "divergence_index_mean" not in kv
+
+    def test_format_oneline(self) -> None:
+        s = SummaryData("test", 10, 1, 0.1, None, None, None)
+        assert s.format("oneline") == s.to_oneline()
+
+    def test_format_json(self) -> None:
+        s = SummaryData("test", 10, 1, 0.1, None, None, None)
+        assert s.format("json") == s.to_json()
+
+    def test_format_kv(self) -> None:
+        s = SummaryData("test", 10, 1, 0.1, None, None, None)
+        assert s.format("kv") == s.to_kv()
+
+    def test_format_unknown_raises(self) -> None:
+        s = SummaryData("test", 10, 1, 0.1, None, None, None)
+        with pytest.raises(ValueError, match="Unknown format"):
+            s.format("xml")
+
+
+class TestExtractSummary:
+    def test_basic(self, basic_report: dict) -> None:
+        s = extract_summary(basic_report)
+        assert s.dataset == "gsm8k"
+        assert s.total_samples == 100
+        assert s.divergent_samples == 12
+        assert s.divergence_rate == 0.12
+        assert s.divergence_index_mean == 5.3
+        assert s.targets is None
+
+    def test_multi_target(self) -> None:
+        report = {
+            "dataset": "mmlu",
+            "total_samples": 50,
+            "divergent_samples": 5,
+            "divergence_rate": 0.1,
+            "per_target": {"http://a:8000": {}, "http://b:8000": {}},
+        }
+        s = extract_summary(report)
+        assert s.targets == ["http://a:8000", "http://b:8000"]
+
+    def test_missing_fields_defaults(self) -> None:
+        s = extract_summary({})
+        assert s.dataset == "unknown"
+        assert s.total_samples == 0
+        assert s.divergent_samples == 0
+        assert s.divergence_rate == 0.0
+        assert s.divergence_index_mean is None
+        assert s.targets is None
+
+
+class TestLoadAndSummarize:
+    def test_oneline(self, basic_report_file: Path) -> None:
+        result = load_and_summarize(basic_report_file, "oneline")
+        assert "gsm8k" in result
+        assert "100 samples" in result
+
+    def test_json(self, basic_report_file: Path) -> None:
+        result = load_and_summarize(basic_report_file, "json")
+        parsed = json.loads(result)
+        assert parsed["total_samples"] == 100
+
+    def test_kv(self, basic_report_file: Path) -> None:
+        result = load_and_summarize(basic_report_file, "kv")
+        assert "dataset=gsm8k" in result
+
+    def test_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_and_summarize(tmp_path / "nonexistent.json")
+
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        p = tmp_path / "bad.json"
+        p.write_text("not json", encoding="utf-8")
+        with pytest.raises(json.JSONDecodeError):
+            load_and_summarize(p)
+
+
+class TestCLI:
+    def test_summary_oneline(self, basic_report_file: Path) -> None:
+        import io
+        from unittest.mock import patch
+
+        from xpyd_acc.cli import main
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_out:
+            main(["summary", str(basic_report_file)])
+        output = mock_out.getvalue().strip()
+        assert "gsm8k" in output
+        assert "100 samples" in output
+
+    def test_summary_json_format(self, basic_report_file: Path) -> None:
+        import io
+        from unittest.mock import patch
+
+        from xpyd_acc.cli import main
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_out:
+            main(["summary", str(basic_report_file), "--format", "json"])
+        parsed = json.loads(mock_out.getvalue().strip())
+        assert parsed["dataset"] == "gsm8k"
+
+    def test_summary_kv_format(self, basic_report_file: Path) -> None:
+        import io
+        from unittest.mock import patch
+
+        from xpyd_acc.cli import main
+
+        with patch("sys.stdout", new_callable=io.StringIO) as mock_out:
+            main(["summary", str(basic_report_file), "--format", "kv"])
+        output = mock_out.getvalue().strip()
+        assert "dataset=gsm8k" in output
+
+    def test_summary_missing_file(self, tmp_path: Path) -> None:
+        from xpyd_acc.cli import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["summary", str(tmp_path / "nope.json")])
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
Add `xpyd-acc summary <report.json>` subcommand for compact batch report summaries.

## Changes
- New `summary.py` module with `SummaryData`, `extract_summary()`, `load_and_summarize()`
- CLI subcommand with `--format oneline|json|kv`
- 22 tests covering all formats, edge cases, CLI integration
- ROADMAP.md updated with M48

## Output Formats
- **oneline**: `gsm8k | 100 samples | 12 divergent (12.0%) | mean div index: 5.3`
- **json**: compact JSON for piping to jq/webhooks
- **kv**: key=value pairs for shell scripts

Closes #105