### PR TITLE
feat: divergence pattern clustering for batch reports (M49)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -521,6 +521,17 @@ def main(argv: list[str] | None = None) -> None:
         help="Path to config file (default: xpyd-acc.toml)",
     )
 
+    # cluster (M49)
+    cluster_cmd = sub.add_parser("cluster", help="Cluster divergent samples by divergence pattern")
+    cluster_cmd.add_argument("--input", required=True, help="Path to batch report JSON file")
+    cluster_cmd.add_argument(
+        "--clusters", type=int, default=None,
+        help="Number of clusters (auto-select if omitted)",
+    )
+    cluster_cmd.add_argument(
+        "--json", dest="cluster_json", default=None, help="Export clusters as JSON",
+    )
+
     # summary (M48)
     summary_cmd = sub.add_parser("summary", help="Compact summary of a batch report")
     summary_cmd.add_argument("report", help="Path to batch report JSON file")
@@ -566,6 +577,11 @@ def main(argv: list[str] | None = None) -> None:
         except KeyError as exc:
             parser.error(str(exc))
         apply_profile(vars(args), profile)
+
+    # Handle 'cluster' subcommand (M49)
+    if args.command == "cluster":
+        _run_cluster(args)
+        return
 
     # Handle 'summary' subcommand (M48)
     if args.command == "summary":
@@ -2141,3 +2157,60 @@ async def _run_bisect(args: argparse.Namespace) -> None:
         import pathlib
         pathlib.Path(json_path).write_text(result.to_json())
         print(f"   Exported to {json_path}")
+
+
+def _run_cluster(args: argparse.Namespace) -> None:
+    """Run the cluster subcommand."""
+    import json
+    from pathlib import Path
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from xpyd_acc.cluster import cluster_divergences
+
+    console = Console()
+    input_path = Path(args.input)
+    if not input_path.exists():
+        console.print(f"[red]Error:[/red] File not found: {input_path}")
+        raise SystemExit(1)
+
+    with open(input_path) as f:
+        report = json.load(f)
+
+    result = cluster_divergences(report, k=args.clusters)
+
+    if result.total_divergent == 0:
+        console.print("[green]No divergent samples to cluster.[/green]")
+        return
+
+    console.print("\n[bold]Divergence Pattern Clustering[/bold]")
+    console.print(f"  Total divergent samples: {result.total_divergent}")
+    console.print(f"  Excluded matched samples: {result.excluded_matched}")
+    console.print(f"  Clusters (K): {result.k}")
+    if result.silhouette_score is not None:
+        console.print(f"  Silhouette score: {result.silhouette_score:.3f}")
+
+    table = Table(title="Clusters")
+    table.add_column("ID", style="cyan")
+    table.add_column("Size", style="green")
+    table.add_column("Avg Div Index", style="yellow")
+    table.add_column("Avg Logprob Gap", style="yellow")
+    table.add_column("Avg Context Len", style="yellow")
+    table.add_column("Representative", style="magenta")
+
+    for c in result.clusters:
+        table.add_row(
+            str(c.cluster_id),
+            str(c.size),
+            f"{c.avg_divergence_index:.1f}",
+            f"{c.avg_logprob_gap:.4f}",
+            f"{c.avg_context_length:.0f}",
+            c.representative_sample_id,
+        )
+
+    console.print(table)
+
+    if args.cluster_json:
+        result.to_json(args.cluster_json)
+        console.print(f"\n  Exported to {args.cluster_json}")

--- a/src/xpyd_acc/cluster.py
+++ b/src/xpyd_acc/cluster.py
@@ -1,0 +1,287 @@
+"""Divergence pattern clustering for batch reports."""
+
+from __future__ import annotations
+
+import json
+import math
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class DivergenceCluster:
+    """A cluster of divergent samples sharing similar divergence patterns."""
+
+    cluster_id: int
+    sample_ids: list[str]
+    size: int
+    centroid: list[float]
+    avg_divergence_index: float
+    avg_logprob_gap: float
+    avg_context_length: float
+    representative_sample_id: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cluster_id": self.cluster_id,
+            "sample_ids": self.sample_ids,
+            "size": self.size,
+            "centroid": self.centroid,
+            "avg_divergence_index": self.avg_divergence_index,
+            "avg_logprob_gap": self.avg_logprob_gap,
+            "avg_context_length": self.avg_context_length,
+            "representative_sample_id": self.representative_sample_id,
+        }
+
+
+@dataclass
+class ClusterResult:
+    """Result of divergence pattern clustering."""
+
+    clusters: list[DivergenceCluster]
+    k: int
+    silhouette_score: float | None
+    total_divergent: int
+    excluded_matched: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "clusters": [c.to_dict() for c in self.clusters],
+            "k": self.k,
+            "silhouette_score": self.silhouette_score,
+            "total_divergent": self.total_divergent,
+            "excluded_matched": self.excluded_matched,
+        }
+
+    def to_json(self, path: str | Path) -> None:
+        """Export cluster result to JSON file."""
+        with open(path, "w") as f:
+            json.dump(self.to_dict(), f, indent=2)
+
+
+def _euclidean(a: list[float], b: list[float]) -> float:
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def _mean_vec(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    n = len(vectors)
+    d = len(vectors[0])
+    return [sum(v[i] for v in vectors) / n for i in range(d)]
+
+
+def _kmeans(
+    features: list[list[float]], k: int, max_iter: int = 100, seed: int = 42
+) -> tuple[list[int], list[list[float]]]:
+    """Simple k-means clustering. Returns (assignments, centroids)."""
+    rng = random.Random(seed)
+    n = len(features)
+    # k-means++ init
+    centroids: list[list[float]] = [features[rng.randint(0, n - 1)][:]]
+    for _ in range(1, k):
+        dists = [min(_euclidean(f, c) ** 2 for c in centroids) for f in features]
+        total = sum(dists)
+        if total == 0:
+            centroids.append(features[rng.randint(0, n - 1)][:])
+            continue
+        r = rng.random() * total
+        cumulative = 0.0
+        for i, d in enumerate(dists):
+            cumulative += d
+            if cumulative >= r:
+                centroids.append(features[i][:])
+                break
+        else:
+            centroids.append(features[-1][:])
+
+    assignments = [0] * n
+    for _ in range(max_iter):
+        # assign
+        new_assignments = []
+        for f in features:
+            dists = [_euclidean(f, c) for c in centroids]
+            new_assignments.append(dists.index(min(dists)))
+        if new_assignments == assignments and _ > 0:
+            break
+        assignments = new_assignments
+        # update centroids
+        for ci in range(k):
+            members = [features[j] for j in range(n) if assignments[j] == ci]
+            if members:
+                centroids[ci] = _mean_vec(members)
+
+    return assignments, centroids
+
+
+def _silhouette_score(features: list[list[float]], assignments: list[int], k: int) -> float:
+    """Compute mean silhouette score."""
+    n = len(features)
+    if n < 2 or k < 2:
+        return 0.0
+
+    scores = []
+    for i in range(n):
+        ci = assignments[i]
+        # intra-cluster distance
+        same = [j for j in range(n) if assignments[j] == ci and j != i]
+        if not same:
+            scores.append(0.0)
+            continue
+        a = sum(_euclidean(features[i], features[j]) for j in same) / len(same)
+        # nearest other cluster distance
+        b = float("inf")
+        for ck in range(k):
+            if ck == ci:
+                continue
+            others = [j for j in range(n) if assignments[j] == ck]
+            if others:
+                avg_d = sum(_euclidean(features[i], features[j]) for j in others) / len(others)
+                b = min(b, avg_d)
+        if b == float("inf"):
+            scores.append(0.0)
+            continue
+        scores.append((b - a) / max(a, b) if max(a, b) > 0 else 0.0)
+    return sum(scores) / len(scores) if scores else 0.0
+
+
+def _extract_features(sample: dict[str, Any]) -> tuple[str, list[float]]:
+    """Extract feature vector from a sample result dict."""
+    sample_id = sample.get("sample_id", sample.get("id", "unknown"))
+    div_index = sample.get("divergence_index") or 0
+    logprob_gap = sample.get("logprob_gap") or 0.0
+    context_length = sample.get("context_length") or 0
+    baseline_len = len(sample.get("baseline_output", "") or "")
+    target_len = len(sample.get("target_output", "") or "")
+    length_ratio = target_len / baseline_len if baseline_len > 0 else 1.0
+    return str(sample_id), [
+        float(div_index), float(logprob_gap), float(context_length), length_ratio,
+    ]
+
+
+def _normalize_features(features: list[list[float]]) -> list[list[float]]:
+    """Min-max normalize each dimension."""
+    if not features:
+        return features
+    d = len(features[0])
+    mins = [min(f[i] for f in features) for i in range(d)]
+    maxs = [max(f[i] for f in features) for i in range(d)]
+    result = []
+    for f in features:
+        row = []
+        for i in range(d):
+            rng = maxs[i] - mins[i]
+            row.append((f[i] - mins[i]) / rng if rng > 0 else 0.0)
+        result.append(row)
+    return result
+
+
+def cluster_divergences(
+    report: dict[str, Any],
+    k: int | None = None,
+) -> ClusterResult:
+    """Cluster divergent samples from a batch report.
+
+    Args:
+        report: Parsed batch report JSON (must have "results" list).
+        k: Number of clusters. If None, auto-select via silhouette score.
+
+    Returns:
+        ClusterResult with cluster assignments and statistics.
+    """
+    results = report.get("results", [])
+    matched = 0
+    divergent_samples: list[dict[str, Any]] = []
+    for s in results:
+        if s.get("match", False):
+            matched += 1
+        else:
+            divergent_samples.append(s)
+
+    total_div = len(divergent_samples)
+
+    # Edge cases
+    if total_div == 0:
+        return ClusterResult(
+            clusters=[], k=0, silhouette_score=None,
+            total_divergent=0, excluded_matched=matched,
+        )
+    if total_div == 1:
+        sid, feat = _extract_features(divergent_samples[0])
+        cluster = DivergenceCluster(
+            cluster_id=0, sample_ids=[sid], size=1, centroid=feat,
+            avg_divergence_index=feat[0], avg_logprob_gap=feat[1],
+            avg_context_length=feat[2], representative_sample_id=sid,
+        )
+        return ClusterResult(
+            clusters=[cluster], k=1, silhouette_score=None,
+            total_divergent=1, excluded_matched=matched,
+        )
+
+    # Extract and normalize features
+    ids_and_feats = [_extract_features(s) for s in divergent_samples]
+    sample_ids = [x[0] for x in ids_and_feats]
+    raw_features = [x[1] for x in ids_and_feats]
+    features = _normalize_features(raw_features)
+
+    # Select K
+    if k is not None:
+        best_k = min(k, total_div)
+        assignments, centroids = _kmeans(features, best_k)
+        sil = _silhouette_score(features, assignments, best_k) if best_k >= 2 else None
+    else:
+        max_k = min(10, total_div - 1)
+        if max_k < 2:
+            best_k = 1
+            assignments = [0] * total_div
+            centroids = [_mean_vec(features)]
+            sil = None
+        else:
+            best_k = 2
+            best_sil = -1.0
+            best_assign: list[int] = []
+            best_cent: list[list[float]] = []
+            for try_k in range(2, max_k + 1):
+                a, c = _kmeans(features, try_k)
+                s = _silhouette_score(features, a, try_k)
+                if s > best_sil:
+                    best_sil = s
+                    best_k = try_k
+                    best_assign = a
+                    best_cent = c
+            assignments = best_assign
+            centroids = best_cent
+            sil = best_sil
+
+    # Build clusters
+    clusters: list[DivergenceCluster] = []
+    for ci in range(best_k):
+        members = [i for i in range(total_div) if assignments[i] == ci]
+        if not members:
+            continue
+        member_ids = [sample_ids[i] for i in members]
+        member_raw = [raw_features[i] for i in members]
+        avg_div = sum(f[0] for f in member_raw) / len(member_raw)
+        avg_gap = sum(f[1] for f in member_raw) / len(member_raw)
+        avg_ctx = sum(f[2] for f in member_raw) / len(member_raw)
+        # Representative: closest to centroid in normalized space
+        member_feats = [features[i] for i in members]
+        dists = [_euclidean(member_feats[j], centroids[ci]) for j in range(len(members))]
+        rep_idx = members[dists.index(min(dists))]
+        clusters.append(DivergenceCluster(
+            cluster_id=ci,
+            sample_ids=member_ids,
+            size=len(members),
+            centroid=centroids[ci],
+            avg_divergence_index=avg_div,
+            avg_logprob_gap=avg_gap,
+            avg_context_length=avg_ctx,
+            representative_sample_id=sample_ids[rep_idx],
+        ))
+
+    return ClusterResult(
+        clusters=clusters, k=best_k, silhouette_score=sil,
+        total_divergent=total_div, excluded_matched=matched,
+    )

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,0 +1,181 @@
+"""Tests for divergence pattern clustering (M49)."""
+
+from __future__ import annotations
+
+import json
+
+from xpyd_acc.cluster import ClusterResult, DivergenceCluster, cluster_divergences
+
+
+def _make_report(samples: list[dict]) -> dict:
+    return {"results": samples}
+
+
+def _make_sample(
+    sid: str, match: bool = False, div_index: int = 0,
+    logprob_gap: float = 0.0, context_length: int = 100,
+    baseline_output: str = "hello", target_output: str = "world",
+) -> dict:
+    return {
+        "sample_id": sid,
+        "match": match,
+        "divergence_index": div_index,
+        "logprob_gap": logprob_gap,
+        "context_length": context_length,
+        "baseline_output": baseline_output,
+        "target_output": target_output,
+    }
+
+
+class TestClusterDivergences:
+    def test_empty_report(self):
+        result = cluster_divergences({"results": []})
+        assert result.total_divergent == 0
+        assert result.clusters == []
+        assert result.k == 0
+
+    def test_all_matched(self):
+        report = _make_report([
+            _make_sample("s1", match=True),
+            _make_sample("s2", match=True),
+        ])
+        result = cluster_divergences(report)
+        assert result.total_divergent == 0
+        assert result.excluded_matched == 2
+
+    def test_single_divergent(self):
+        report = _make_report([
+            _make_sample("s1", match=False, div_index=5, logprob_gap=0.1),
+            _make_sample("s2", match=True),
+        ])
+        result = cluster_divergences(report)
+        assert result.total_divergent == 1
+        assert result.k == 1
+        assert len(result.clusters) == 1
+        assert result.clusters[0].sample_ids == ["s1"]
+        assert result.silhouette_score is None
+
+    def test_two_divergent_auto_k(self):
+        report = _make_report([
+            _make_sample("s1", match=False, div_index=5, logprob_gap=0.1, context_length=100),
+            _make_sample("s2", match=False, div_index=50, logprob_gap=0.9, context_length=1000),
+        ])
+        result = cluster_divergences(report)
+        assert result.total_divergent == 2
+        # With only 2 divergent, max_k = min(10, 2-1) = 1, so k=1
+        assert result.k == 1
+
+    def test_multiple_clusters_manual_k(self):
+        samples = []
+        # Group A: early divergence, low gap
+        for i in range(5):
+            samples.append(_make_sample(f"a{i}", match=False, div_index=2 + i,
+                                        logprob_gap=0.01, context_length=50))
+        # Group B: late divergence, high gap
+        for i in range(5):
+            samples.append(_make_sample(f"b{i}", match=False, div_index=100 + i,
+                                        logprob_gap=0.9, context_length=2000))
+        report = _make_report(samples)
+        result = cluster_divergences(report, k=2)
+        assert result.k == 2
+        assert len(result.clusters) == 2
+        assert result.total_divergent == 10
+        # Each cluster should have 5 members
+        sizes = sorted(c.size for c in result.clusters)
+        assert sizes == [5, 5]
+
+    def test_auto_k_selection(self):
+        samples = []
+        for i in range(6):
+            samples.append(_make_sample(f"a{i}", match=False, div_index=5,
+                                        logprob_gap=0.01, context_length=100))
+        for i in range(6):
+            samples.append(_make_sample(f"b{i}", match=False, div_index=200,
+                                        logprob_gap=0.95, context_length=5000))
+        report = _make_report(samples)
+        result = cluster_divergences(report)
+        assert result.total_divergent == 12
+        assert result.k >= 2
+        assert result.silhouette_score is not None
+        assert result.silhouette_score > 0
+
+    def test_cluster_result_to_dict(self):
+        cluster = DivergenceCluster(
+            cluster_id=0, sample_ids=["s1"], size=1,
+            centroid=[0.5, 0.5, 0.5, 0.5],
+            avg_divergence_index=10.0, avg_logprob_gap=0.5,
+            avg_context_length=200.0, representative_sample_id="s1",
+        )
+        result = ClusterResult(
+            clusters=[cluster], k=1, silhouette_score=0.8,
+            total_divergent=1, excluded_matched=0,
+        )
+        d = result.to_dict()
+        assert d["k"] == 1
+        assert d["silhouette_score"] == 0.8
+        assert len(d["clusters"]) == 1
+        assert d["clusters"][0]["sample_ids"] == ["s1"]
+
+    def test_json_export(self, tmp_path):
+        report = _make_report([
+            _make_sample("s1", match=False, div_index=10, logprob_gap=0.5),
+        ])
+        result = cluster_divergences(report)
+        out = tmp_path / "clusters.json"
+        result.to_json(out)
+        data = json.loads(out.read_text())
+        assert data["total_divergent"] == 1
+        assert len(data["clusters"]) == 1
+
+    def test_representative_sample(self):
+        samples = [
+            _make_sample("s1", match=False, div_index=10, logprob_gap=0.5, context_length=100),
+            _make_sample("s2", match=False, div_index=12, logprob_gap=0.5, context_length=100),
+            _make_sample("s3", match=False, div_index=11, logprob_gap=0.5, context_length=100),
+        ]
+        report = _make_report(samples)
+        result = cluster_divergences(report, k=1)
+        assert result.clusters[0].representative_sample_id in ["s1", "s2", "s3"]
+
+    def test_mixed_matched_and_divergent(self):
+        samples = [
+            _make_sample("m1", match=True),
+            _make_sample("m2", match=True),
+            _make_sample("d1", match=False, div_index=5),
+            _make_sample("d2", match=False, div_index=50),
+            _make_sample("d3", match=False, div_index=100),
+        ]
+        report = _make_report(samples)
+        result = cluster_divergences(report)
+        assert result.excluded_matched == 2
+        assert result.total_divergent == 3
+
+    def test_k_larger_than_samples(self):
+        samples = [
+            _make_sample("s1", match=False, div_index=5),
+            _make_sample("s2", match=False, div_index=10),
+        ]
+        report = _make_report(samples)
+        result = cluster_divergences(report, k=10)
+        # k capped at n_samples
+        assert result.k == 2
+
+
+class TestClusterCLI:
+    def test_cluster_cli(self, tmp_path):
+        """Test cluster CLI integration."""
+        from xpyd_acc.cli import main
+
+        report = _make_report([
+            _make_sample("s1", match=False, div_index=5, logprob_gap=0.1),
+            _make_sample("s2", match=False, div_index=50, logprob_gap=0.9),
+            _make_sample("s3", match=False, div_index=5, logprob_gap=0.15),
+        ])
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps(report))
+        json_out = tmp_path / "clusters.json"
+
+        main(["cluster", "--input", str(report_path), "--json", str(json_out)])
+        assert json_out.exists()
+        data = json.loads(json_out.read_text())
+        assert data["total_divergent"] == 3


### PR DESCRIPTION
## Summary
Add `xpyd-acc cluster` subcommand that groups divergent samples by divergence pattern similarity using K-means clustering.

### Changes
- **`src/xpyd_acc/cluster.py`**: K-means clustering with auto-K selection via silhouette score. Feature vector: divergence index, logprob gap, context length, output length ratio.
- **`src/xpyd_acc/cli.py`**: Added `cluster` subcommand with `--input`, `--clusters`, `--json` flags.
- **`tests/test_cluster.py`**: 12 tests covering all edge cases, clustering, JSON export, CLI integration.

### Acceptance Criteria
- [x] `xpyd-acc cluster --input report.json` groups divergent samples
- [x] Auto-selects K via silhouette score
- [x] `--clusters <n>` overrides auto-selection
- [x] `--json <path>` exports cluster results
- [x] Rich terminal output with per-cluster summary
- [x] Matched samples excluded from clustering
- [x] Graceful fallback when <2 divergent samples
- [x] All 638 tests pass, lint clean

Closes #107