### PR TITLE
feat: add history purge command (M51)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -444,6 +444,20 @@ def main(argv: list[str] | None = None) -> None:
         help="Exit 1 if divergence rate increased in the latest run",
     )
     hist_trend.add_argument("--history-dir", default=None, help="History directory")
+    hist_purge = hist_sub.add_parser("purge", help="Remove old history entries")
+    hist_purge.add_argument(
+        "--older-than", type=int, required=True,
+        help="Remove entries older than N days",
+    )
+    hist_purge.add_argument(
+        "--keep-last", type=int, default=0,
+        help="Always keep the most recent N entries (default: 0)",
+    )
+    hist_purge.add_argument(
+        "--dry-run", action="store_true", default=False,
+        help="Show what would be removed without deleting",
+    )
+    hist_purge.add_argument("--history-dir", default=None, help="History directory")
 
     # benchmark
     bm = sub.add_parser("benchmark", help="Benchmark endpoint latency")
@@ -2030,8 +2044,31 @@ def _run_history(args: argparse.Namespace) -> None:
         elif args.fail_on_regression:
             print("\nPASS: No regression detected.")
 
+    elif args.history_action == "purge":
+        removed = store.purge(
+            older_than_days=args.older_than,
+            keep_last=args.keep_last,
+            dry_run=args.dry_run,
+        )
+        action = "Would remove" if args.dry_run else "Removed"
+        if not removed:
+            print("Nothing to purge.")
+        else:
+            console = Console()
+            table = Table(title=f"{action} {len(removed)} entries")
+            table.add_column("ID", style="dim")
+            table.add_column("Timestamp")
+            table.add_column("Tag")
+            table.add_column("Rate", justify="right")
+            for e in removed:
+                table.add_row(
+                    e.entry_id, e.timestamp[:19], e.tag or "-",
+                    f"{e.divergence_rate:.4f}",
+                )
+            console.print(table)
+
     else:
-        print("Usage: xpyd-acc history {save|list|trend}")
+        print("Usage: xpyd-acc history {save|list|trend|purge}")
 
 
 def _run_summary(args: argparse.Namespace) -> None:

--- a/src/xpyd_acc/history.py
+++ b/src/xpyd_acc/history.py
@@ -118,6 +118,52 @@ class HistoryStore:
             prev_rate = entry.divergence_rate
         return result
 
+    def purge(
+        self,
+        older_than_days: int | None = None,
+        keep_last: int = 0,
+        dry_run: bool = False,
+    ) -> list[HistoryEntry]:
+        """Remove old history entries.
+
+        Args:
+            older_than_days: Remove entries older than this many days.
+            keep_last: Always keep at least this many most recent entries.
+            dry_run: If True, return entries that would be removed without deleting.
+
+        Returns:
+            List of entries that were (or would be) removed.
+        """
+        entries = self.list_entries()
+        if not entries:
+            return []
+
+        # Determine which entries to protect (keep_last most recent)
+        protected: set[str] = set()
+        if keep_last > 0:
+            for entry in entries[-keep_last:]:
+                protected.add(entry.entry_id)
+
+        to_remove: list[HistoryEntry] = []
+        now = datetime.now(timezone.utc)
+
+        for entry in entries:
+            if entry.entry_id in protected:
+                continue
+            if older_than_days is not None:
+                entry_time = datetime.fromisoformat(entry.timestamp)
+                age_days = (now - entry_time).total_seconds() / 86400
+                if age_days > older_than_days:
+                    to_remove.append(entry)
+
+        if not dry_run:
+            for entry in to_remove:
+                entry_file = self.history_dir / f"{entry.entry_id}.json"
+                if entry_file.exists():
+                    entry_file.unlink()
+
+        return to_remove
+
     def has_regression(self, last_n: int | None = None) -> bool:
         """Check if the most recent entry shows increased divergence vs previous."""
         trend_data = self.trend(last_n=last_n)

--- a/tests/test_history_purge.py
+++ b/tests/test_history_purge.py
@@ -1,0 +1,144 @@
+"""Tests for history purge command (M51)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from xpyd_acc.history import HistoryEntry, HistoryStore
+
+
+def _make_entry(
+    store: HistoryStore,
+    entry_id: str,
+    days_ago: int,
+    tag: str = "",
+    rate: float = 0.1,
+) -> HistoryEntry:
+    """Create a history entry with a specific age."""
+    ts = (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat()
+    entry = HistoryEntry(
+        entry_id=entry_id,
+        timestamp=ts,
+        tag=tag,
+        report_path="/tmp/report.json",
+        divergence_rate=rate,
+        sample_count=100,
+        dataset="test",
+        divergent_count=int(rate * 100),
+    )
+    store.history_dir.mkdir(parents=True, exist_ok=True)
+    (store.history_dir / f"{entry_id}.json").write_text(
+        json.dumps(entry.to_dict(), indent=2) + "\n"
+    )
+    return entry
+
+
+def test_purge_older_than(tmp_path: Path) -> None:
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "old1", days_ago=60)
+    _make_entry(store, "old2", days_ago=45)
+    _make_entry(store, "recent", days_ago=5)
+
+    removed = store.purge(older_than_days=30)
+    assert len(removed) == 2
+    assert {e.entry_id for e in removed} == {"old1", "old2"}
+    # Files should be gone
+    assert not (tmp_path / "hist" / "old1.json").exists()
+    assert not (tmp_path / "hist" / "old2.json").exists()
+    assert (tmp_path / "hist" / "recent.json").exists()
+
+
+def test_purge_keep_last(tmp_path: Path) -> None:
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "a", days_ago=90)
+    _make_entry(store, "b", days_ago=60)
+    _make_entry(store, "c", days_ago=30)
+    _make_entry(store, "d", days_ago=5)
+
+    # All are older than 1 day, but keep last 2
+    removed = store.purge(older_than_days=1, keep_last=2)
+    assert len(removed) == 2
+    assert {e.entry_id for e in removed} == {"a", "b"}
+    remaining = store.list_entries()
+    assert len(remaining) == 2
+
+
+def test_purge_dry_run(tmp_path: Path) -> None:
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "old", days_ago=60)
+    _make_entry(store, "new", days_ago=5)
+
+    removed = store.purge(older_than_days=30, dry_run=True)
+    assert len(removed) == 1
+    assert removed[0].entry_id == "old"
+    # File should still exist
+    assert (tmp_path / "hist" / "old.json").exists()
+
+
+def test_purge_empty_store(tmp_path: Path) -> None:
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    removed = store.purge(older_than_days=30)
+    assert removed == []
+
+
+def test_purge_nothing_to_remove(tmp_path: Path) -> None:
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "recent", days_ago=1)
+    removed = store.purge(older_than_days=30)
+    assert removed == []
+
+
+def test_purge_keep_last_protects_all(tmp_path: Path) -> None:
+    """When keep_last >= total entries, nothing is removed."""
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "a", days_ago=90)
+    _make_entry(store, "b", days_ago=60)
+
+    removed = store.purge(older_than_days=1, keep_last=5)
+    assert removed == []
+
+
+def test_purge_cli_integration(tmp_path: Path) -> None:
+    """Test CLI purge subcommand via subprocess."""
+    import subprocess
+
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "old1", days_ago=60)
+    _make_entry(store, "recent", days_ago=5)
+
+    result = subprocess.run(
+        [
+            "xpyd-acc", "history", "purge",
+            "--older-than", "30",
+            "--history-dir", str(tmp_path / "hist"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    combined = result.stdout + result.stderr
+    assert "1" in combined  # 1 entry removed
+    assert not (tmp_path / "hist" / "old1.json").exists()
+    assert (tmp_path / "hist" / "recent.json").exists()
+
+
+def test_purge_cli_dry_run(tmp_path: Path) -> None:
+    """Dry run via CLI doesn't delete files."""
+    import subprocess
+
+    store = HistoryStore(history_dir=tmp_path / "hist")
+    _make_entry(store, "old1", days_ago=60)
+
+    result = subprocess.run(
+        [
+            "xpyd-acc", "history", "purge",
+            "--older-than", "30", "--dry-run",
+            "--history-dir", str(tmp_path / "hist"),
+        ],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    combined = result.stdout + result.stderr
+    assert "Would remove" in combined
+    assert (tmp_path / "hist" / "old1.json").exists()


### PR DESCRIPTION
## Summary
Add `xpyd-acc history purge` subcommand to clean up old history entries.

### Changes
- **`HistoryStore.purge()`** method: removes entries older than N days, with `keep_last` protection and `dry_run` mode
- **CLI**: `history purge --older-than <days> [--keep-last N] [--dry-run] [--history-dir <path>]`
- **Rich output**: table showing removed (or would-be-removed) entries
- **8 tests**: purge logic, keep_last protection, dry-run, empty store, CLI integration

### Usage
```bash
# Remove entries older than 30 days
xpyd-acc history purge --older-than 30

# Keep at least 5 most recent, preview only
xpyd-acc history purge --older-than 7 --keep-last 5 --dry-run
```

Closes #111