### PR TITLE
feat: Sample Deep-Dive Explain Command (M52)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -556,6 +556,14 @@ def main(argv: list[str] | None = None) -> None:
         help="Output format (default: oneline)",
     )
 
+    explain_cmd = sub.add_parser("explain", help="Deep-dive analysis of a single sample")
+    explain_cmd.add_argument("--report", required=True, help="Path to batch report JSON")
+    explain_cmd.add_argument("--sample", required=True, help="Sample ID to analyze")
+    explain_cmd.add_argument(
+        "--json", dest="explain_json", default=None,
+        help="Export analysis as JSON",
+    )
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -601,6 +609,11 @@ def main(argv: list[str] | None = None) -> None:
     # Handle 'summary' subcommand (M48)
     if args.command == "summary":
         _run_summary(args)
+        return
+
+    # Handle 'explain' subcommand (M52)
+    if args.command == "explain":
+        _run_explain(args)
         return
 
     # Handle 'filter' subcommand (M42)
@@ -2266,3 +2279,24 @@ def _run_cluster(args: argparse.Namespace) -> None:
     if args.cluster_json:
         result.to_json(args.cluster_json)
         console.print(f"\n  Exported to {args.cluster_json}")
+
+
+def _run_explain(args: argparse.Namespace) -> None:
+    """Handle the 'explain' subcommand."""
+    from xpyd_acc.explain import format_explain, load_and_explain
+
+    try:
+        result = load_and_explain(args.report, args.sample)
+    except FileNotFoundError:
+        print(f"Error: report file not found: {args.report}")
+        raise SystemExit(1)
+    except KeyError as exc:
+        print(f"Error: {exc}")
+        raise SystemExit(1)
+
+    if args.explain_json:
+        from pathlib import Path
+        Path(args.explain_json).write_text(result.to_json())
+        print(f"Exported to {args.explain_json}")
+    else:
+        print(format_explain(result))

--- a/src/xpyd_acc/explain.py
+++ b/src/xpyd_acc/explain.py
@@ -1,0 +1,289 @@
+"""Deep-dive analysis of a single sample from a batch report."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class ExplainResult:
+    """Detailed analysis of a single sample."""
+
+    sample_id: str
+    prompt: str
+    baseline_output: str
+    target_output: str
+    exact_match: bool
+    classification: str
+    context_length: int
+    first_divergence_index: int | None
+    baseline_logprob_at_divergence: float | None
+    target_logprob_at_divergence: float | None
+    logprob_gap: float | None
+    baseline_tokens: list[str]
+    target_tokens: list[str]
+    divergence_context: DivergenceContext | None
+    classification_reasoning: str
+    suggested_next_steps: list[str]
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(asdict(self), indent=2)
+
+
+@dataclass
+class DivergenceContext:
+    """Tokens around the divergence point."""
+
+    before: list[TokenPair]
+    at: TokenPair
+    after: list[TokenPair]
+
+
+@dataclass
+class TokenPair:
+    """A pair of tokens at the same position."""
+
+    index: int
+    baseline: str
+    target: str
+    match: bool
+
+
+def _tokenize(text: str) -> list[str]:
+    """Simple whitespace tokenizer matching batch_compare._tokenize."""
+    return text.split()
+
+
+def _build_divergence_context(
+    baseline_tokens: list[str],
+    target_tokens: list[str],
+    divergence_index: int,
+    context_size: int = 5,
+) -> DivergenceContext:
+    """Build context window around divergence point."""
+    max_len = max(len(baseline_tokens), len(target_tokens))
+
+    def _get(tokens: list[str], idx: int) -> str:
+        return tokens[idx] if idx < len(tokens) else "<END>"
+
+    before: list[TokenPair] = []
+    start = max(0, divergence_index - context_size)
+    for i in range(start, divergence_index):
+        b = _get(baseline_tokens, i)
+        t = _get(target_tokens, i)
+        before.append(TokenPair(index=i, baseline=b, target=t, match=(b == t)))
+
+    b_at = _get(baseline_tokens, divergence_index)
+    t_at = _get(target_tokens, divergence_index)
+    at = TokenPair(
+        index=divergence_index, baseline=b_at, target=t_at, match=(b_at == t_at)
+    )
+
+    after: list[TokenPair] = []
+    end = min(max_len, divergence_index + context_size + 1)
+    for i in range(divergence_index + 1, end):
+        b = _get(baseline_tokens, i)
+        t = _get(target_tokens, i)
+        after.append(TokenPair(index=i, baseline=b, target=t, match=(b == t)))
+
+    return DivergenceContext(before=before, at=at, after=after)
+
+
+def _classify_reasoning(classification: str, logprob_gap: float | None) -> str:
+    """Explain why a sample received its classification."""
+    if classification == "match":
+        return "Outputs are identical — no divergence detected."
+    if classification == "likely_bug":
+        gap_str = f"{logprob_gap:.4f}" if logprob_gap is not None else "N/A"
+        return (
+            f"Classification: likely_bug. The logprob gap at divergence ({gap_str}) "
+            "is large, meaning the baseline model was highly confident in a different "
+            "token than what the target produced. This suggests a real precision or "
+            "transfer issue rather than sampling randomness."
+        )
+    if classification == "likely_uncertainty":
+        gap_str = f"{logprob_gap:.4f}" if logprob_gap is not None else "N/A"
+        return (
+            f"Classification: likely_uncertainty. The logprob gap at divergence ({gap_str}) "
+            "is small, meaning the top two token choices had similar probabilities. "
+            "This divergence is likely due to normal sampling non-determinism."
+        )
+    return (
+        "Classification: unknown. Insufficient logprob data to determine "
+        "whether this is a bug or normal variation."
+    )
+
+
+def _suggest_next_steps(
+    classification: str,
+    divergence_index: int | None,
+    context_length: int,
+) -> list[str]:
+    """Suggest next debugging steps based on the analysis."""
+    if classification == "match":
+        return ["No action needed — sample matches."]
+    steps: list[str] = []
+    if classification == "likely_bug":
+        steps.append("Investigate KV cache transfer — run `xpyd-acc diagnose` with cache dumps.")
+        if divergence_index is not None and divergence_index == 0:
+            steps.append("Divergence at token 0 — check prefill stage output.")
+        elif divergence_index is not None and divergence_index > 0:
+            steps.append(
+                f"Divergence at token {divergence_index} — likely decode-stage issue. "
+                "Compare KV cache at that position."
+            )
+        steps.append(
+            "Try `xpyd-acc bisect` to find the minimum context "
+            "length that triggers divergence."
+        )
+    elif classification == "likely_uncertainty":
+        steps.append(
+            "Re-run with temperature=0 and a fixed seed to "
+            "confirm this is sampling noise."
+        )
+        steps.append(
+            "Use `xpyd-acc aggregate` across multiple runs to "
+            "check if this sample is flaky."
+        )
+    else:
+        steps.append("Collect logprobs with `compare-logprobs --top-k 5` for more detail.")
+        steps.append("Re-run with `--verbose` to capture request/response details.")
+    return steps
+
+
+def explain_sample(report_data: dict[str, Any], sample_id: str) -> ExplainResult:
+    """Produce a deep-dive explanation for a single sample in a batch report.
+
+    Parameters
+    ----------
+    report_data:
+        Parsed JSON of a BatchReport (as produced by ``BatchReport.to_json()``).
+    sample_id:
+        The ``sample_id`` to look up.
+
+    Raises
+    ------
+    KeyError
+        If *sample_id* is not found in the report.
+    """
+    results = report_data.get("results", [])
+    sample: dict[str, Any] | None = None
+    for r in results:
+        if r.get("sample_id") == sample_id:
+            sample = r
+            break
+
+    if sample is None:
+        available = [r.get("sample_id", "?") for r in results]
+        raise KeyError(
+            f"Sample '{sample_id}' not found in report. "
+            f"Available IDs: {available}"
+        )
+
+    baseline_output: str = sample.get("baseline_output", "")
+    target_output: str = sample.get("target_output", "")
+    baseline_tokens = _tokenize(baseline_output)
+    target_tokens = _tokenize(target_output)
+    divergence_index: int | None = sample.get("first_divergence_index")
+    classification: str = sample.get("classification", "unknown")
+    logprob_gap: float | None = sample.get("logprob_gap")
+    context_length: int = sample.get("context_length", 0)
+
+    context: DivergenceContext | None = None
+    if divergence_index is not None:
+        context = _build_divergence_context(
+            baseline_tokens, target_tokens, divergence_index
+        )
+
+    reasoning = _classify_reasoning(classification, logprob_gap)
+    next_steps = _suggest_next_steps(classification, divergence_index, context_length)
+
+    return ExplainResult(
+        sample_id=sample.get("sample_id", ""),
+        prompt=sample.get("prompt", ""),
+        baseline_output=baseline_output,
+        target_output=target_output,
+        exact_match=sample.get("exact_match", True),
+        classification=classification,
+        context_length=context_length,
+        first_divergence_index=divergence_index,
+        baseline_logprob_at_divergence=sample.get("baseline_logprob_at_divergence"),
+        target_logprob_at_divergence=sample.get("target_logprob_at_divergence"),
+        logprob_gap=logprob_gap,
+        baseline_tokens=baseline_tokens,
+        target_tokens=target_tokens,
+        divergence_context=context,
+        classification_reasoning=reasoning,
+        suggested_next_steps=next_steps,
+    )
+
+
+def load_and_explain(report_path: str | Path, sample_id: str) -> ExplainResult:
+    """Load a report JSON file and explain a sample."""
+    path = Path(report_path)
+    data = json.loads(path.read_text())
+    return explain_sample(data, sample_id)
+
+
+def format_explain(result: ExplainResult) -> str:
+    """Format an ExplainResult for terminal display."""
+    lines: list[str] = []
+    lines.append(f"═══ Sample: {result.sample_id} ═══")
+    lines.append("")
+    lines.append(f"Classification: {result.classification}")
+    lines.append(f"Context length:  {result.context_length} tokens")
+    lines.append(f"Exact match:     {result.exact_match}")
+    lines.append("")
+
+    # Prompt (truncated)
+    prompt_display = result.prompt[:200] + ("..." if len(result.prompt) > 200 else "")
+    lines.append(f"Prompt: {prompt_display}")
+    lines.append("")
+
+    if result.exact_match:
+        lines.append("✅ Outputs are identical.")
+        lines.append("")
+    else:
+        lines.append(f"First divergence at token index: {result.first_divergence_index}")
+        if result.logprob_gap is not None:
+            lines.append(f"Logprob gap at divergence:       {result.logprob_gap:.6f}")
+        if result.baseline_logprob_at_divergence is not None:
+            val = result.baseline_logprob_at_divergence
+            lines.append(f"Baseline logprob at divergence:  {val:.6f}")
+        if result.target_logprob_at_divergence is not None:
+            val = result.target_logprob_at_divergence
+            lines.append(f"Target logprob at divergence:    {val:.6f}")
+        lines.append("")
+
+        if result.divergence_context is not None:
+            ctx = result.divergence_context
+            lines.append("─── Token Context ───")
+            for tp in ctx.before:
+                marker = "  " if tp.match else "~ "
+                lines.append(f"  [{tp.index:4d}] {marker}{tp.baseline!r}")
+            tp = ctx.at
+            lines.append(f"  [{tp.index:4d}] ▶ baseline: {tp.baseline!r}")
+            lines.append(f"         target:   {tp.target!r}")
+            for tp in ctx.after:
+                marker = "  " if tp.match else "~ "
+                b_str = tp.baseline
+                t_str = tp.target
+                if tp.match:
+                    lines.append(f"  [{tp.index:4d}] {marker}{b_str!r}")
+                else:
+                    lines.append(f"  [{tp.index:4d}] {marker}B:{b_str!r}  T:{t_str!r}")
+            lines.append("")
+
+    lines.append("─── Classification Reasoning ───")
+    lines.append(result.classification_reasoning)
+    lines.append("")
+
+    lines.append("─── Suggested Next Steps ───")
+    for i, step in enumerate(result.suggested_next_steps, 1):
+        lines.append(f"  {i}. {step}")
+
+    return "\n".join(lines)

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,230 @@
+"""Tests for the explain module (M52)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.explain import (
+    explain_sample,
+    format_explain,
+    load_and_explain,
+)
+
+
+def _make_report(*samples: dict) -> dict:
+    """Build a minimal batch report dict."""
+    return {
+        "total_samples": len(samples),
+        "divergent_samples": sum(1 for s in samples if not s.get("exact_match", True)),
+        "match_samples": sum(1 for s in samples if s.get("exact_match", True)),
+        "divergence_rate": 0.0,
+        "results": list(samples),
+    }
+
+
+_MATCH_SAMPLE = {
+    "sample_id": "s1",
+    "prompt": "What is 2+2?",
+    "baseline_output": "The answer is 4.",
+    "target_output": "The answer is 4.",
+    "exact_match": True,
+    "first_divergence_index": None,
+    "baseline_logprob_at_divergence": None,
+    "target_logprob_at_divergence": None,
+    "logprob_gap": None,
+    "classification": "match",
+    "context_length": 5,
+    "request_ids": {},
+}
+
+_BUG_SAMPLE = {
+    "sample_id": "s2",
+    "prompt": "Solve x^2 = 9",
+    "baseline_output": "x = 3 or x = -3",
+    "target_output": "x = 3 or x = 3",
+    "exact_match": False,
+    "first_divergence_index": 5,
+    "baseline_logprob_at_divergence": -0.01,
+    "target_logprob_at_divergence": -2.5,
+    "logprob_gap": 2.0,
+    "classification": "likely_bug",
+    "context_length": 10,
+    "request_ids": {"baseline": "abc", "target": "def"},
+}
+
+_UNCERTAIN_SAMPLE = {
+    "sample_id": "s3",
+    "prompt": "Tell me a joke",
+    "baseline_output": "Why did the chicken cross the road",
+    "target_output": "Why did the duck cross the road",
+    "exact_match": False,
+    "first_divergence_index": 3,
+    "baseline_logprob_at_divergence": -1.2,
+    "target_logprob_at_divergence": -1.3,
+    "logprob_gap": 0.05,
+    "classification": "likely_uncertainty",
+    "context_length": 8,
+    "request_ids": {},
+}
+
+
+class TestExplainSample:
+    """Tests for explain_sample()."""
+
+    def test_match_sample(self) -> None:
+        report = _make_report(_MATCH_SAMPLE)
+        result = explain_sample(report, "s1")
+        assert result.exact_match is True
+        assert result.classification == "match"
+        assert result.divergence_context is None
+        assert "identical" in result.classification_reasoning.lower()
+        assert len(result.suggested_next_steps) >= 1
+
+    def test_bug_sample(self) -> None:
+        report = _make_report(_MATCH_SAMPLE, _BUG_SAMPLE)
+        result = explain_sample(report, "s2")
+        assert result.exact_match is False
+        assert result.classification == "likely_bug"
+        assert result.first_divergence_index == 5
+        assert result.logprob_gap == 2.0
+        assert result.divergence_context is not None
+        assert result.divergence_context.at.index == 5
+        assert "likely_bug" in result.classification_reasoning
+        assert any("KV cache" in s for s in result.suggested_next_steps)
+
+    def test_uncertainty_sample(self) -> None:
+        report = _make_report(_UNCERTAIN_SAMPLE)
+        result = explain_sample(report, "s3")
+        assert result.classification == "likely_uncertainty"
+        assert "likely_uncertainty" in result.classification_reasoning
+        assert any("temperature=0" in s for s in result.suggested_next_steps)
+
+    def test_missing_sample_raises_key_error(self) -> None:
+        report = _make_report(_MATCH_SAMPLE)
+        with pytest.raises(KeyError, match="not_exist"):
+            explain_sample(report, "not_exist")
+
+    def test_divergence_context_window(self) -> None:
+        report = _make_report(_BUG_SAMPLE)
+        result = explain_sample(report, "s2")
+        ctx = result.divergence_context
+        assert ctx is not None
+        # Before tokens should be indices 0..4
+        assert len(ctx.before) == 5
+        assert all(tp.match for tp in ctx.before)
+        # Token 5 in both outputs is "=" — the metadata says divergence is at 5
+        # (the batch_compare module sets this, explain just uses it)
+        assert ctx.at.index == 5
+        assert ctx.at.baseline == "="
+        assert ctx.at.target == "="
+
+    def test_divergence_at_token_zero(self) -> None:
+        sample = {
+            **_BUG_SAMPLE,
+            "sample_id": "s4",
+            "first_divergence_index": 0,
+            "baseline_output": "yes it is",
+            "target_output": "no it is",
+        }
+        report = _make_report(sample)
+        result = explain_sample(report, "s4")
+        assert result.divergence_context is not None
+        assert len(result.divergence_context.before) == 0
+        assert result.divergence_context.at.index == 0
+        assert any("token 0" in s for s in result.suggested_next_steps)
+
+    def test_unknown_classification(self) -> None:
+        sample = {
+            **_BUG_SAMPLE,
+            "sample_id": "s5",
+            "classification": "unknown",
+            "logprob_gap": None,
+        }
+        report = _make_report(sample)
+        result = explain_sample(report, "s5")
+        assert "unknown" in result.classification_reasoning.lower()
+
+
+class TestLoadAndExplain:
+    """Tests for load_and_explain()."""
+
+    def test_load_from_file(self, tmp_path: Path) -> None:
+        report = _make_report(_MATCH_SAMPLE, _BUG_SAMPLE)
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps(report))
+        result = load_and_explain(str(report_path), "s2")
+        assert result.sample_id == "s2"
+        assert result.exact_match is False
+
+    def test_file_not_found(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_and_explain("/nonexistent/path.json", "s1")
+
+
+class TestFormatExplain:
+    """Tests for format_explain()."""
+
+    def test_format_match(self) -> None:
+        report = _make_report(_MATCH_SAMPLE)
+        result = explain_sample(report, "s1")
+        output = format_explain(result)
+        assert "s1" in output
+        assert "identical" in output.lower()
+
+    def test_format_divergent(self) -> None:
+        report = _make_report(_BUG_SAMPLE)
+        result = explain_sample(report, "s2")
+        output = format_explain(result)
+        assert "s2" in output
+        assert "likely_bug" in output
+        assert "Token Context" in output
+        assert "▶" in output  # divergence marker
+
+
+class TestExplainJsonExport:
+    """Tests for JSON serialization."""
+
+    def test_to_json_roundtrip(self) -> None:
+        report = _make_report(_BUG_SAMPLE)
+        result = explain_sample(report, "s2")
+        data = json.loads(result.to_json())
+        assert data["sample_id"] == "s2"
+        assert data["classification"] == "likely_bug"
+        assert data["divergence_context"] is not None
+        assert data["divergence_context"]["at"]["index"] == 5
+
+
+class TestExplainCli:
+    """Tests for CLI integration."""
+
+    def test_explain_cli(self, tmp_path: Path) -> None:
+        from xpyd_acc.cli import main
+
+        report = _make_report(_MATCH_SAMPLE, _BUG_SAMPLE)
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps(report))
+        json_out = tmp_path / "explain.json"
+
+        main(["explain", "--report", str(report_path), "--sample", "s2", "--json", str(json_out)])
+
+        data = json.loads(json_out.read_text())
+        assert data["sample_id"] == "s2"
+
+    def test_explain_cli_missing_sample(self, tmp_path: Path) -> None:
+        from xpyd_acc.cli import main
+
+        report = _make_report(_MATCH_SAMPLE)
+        report_path = tmp_path / "report.json"
+        report_path.write_text(json.dumps(report))
+
+        with pytest.raises(SystemExit):
+            main(["explain", "--report", str(report_path), "--sample", "nope"])
+
+    def test_explain_cli_missing_file(self) -> None:
+        from xpyd_acc.cli import main
+
+        with pytest.raises(SystemExit):
+            main(["explain", "--report", "/nonexistent.json", "--sample", "s1"])


### PR DESCRIPTION
## Summary
Adds `xpyd-acc explain --report <path> --sample <id>` for detailed single-sample analysis from a batch report.

### Features
- Token-by-token alignment with divergence context window (5 tokens before/after)
- Logprob comparison at divergence point
- Classification reasoning (why likely_bug vs likely_uncertainty)
- Suggested next debugging steps
- `--json <path>` export for programmatic use
- Error handling for missing samples and files

### Tests
15 tests covering: match/divergent/uncertainty samples, context window, CLI integration, JSON export, error cases.

Closes #113