### PR TITLE
feat: confidence intervals for divergence rate (M53)

### DIFF
--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -69,6 +69,10 @@ class BatchReport:
     unknown_classification: int = 0
     # Divergence by context length buckets
     divergence_by_context_length: dict[str, dict[str, int]] = field(default_factory=dict)
+    # Confidence interval for divergence rate (Wilson score)
+    divergence_ci_lower: float | None = None
+    divergence_ci_upper: float | None = None
+    confidence_level: float | None = None
 
     def to_markdown(self, *, max_divergent_samples: int = 10) -> str:
         """Serialize the report to a Markdown string."""
@@ -89,6 +93,9 @@ class BatchReport:
             "likely_uncertainty": self.likely_uncertainty,
             "unknown_classification": self.unknown_classification,
             "divergence_by_context_length": self.divergence_by_context_length,
+            "divergence_ci_lower": self.divergence_ci_lower,
+            "divergence_ci_upper": self.divergence_ci_upper,
+            "confidence_level": self.confidence_level,
             "results": [
                 {
                     "sample_id": r.sample_id,
@@ -558,6 +565,16 @@ def compute_report(
     return report
 
 
+def apply_confidence(report: BatchReport, confidence: float = 0.95) -> None:
+    """Compute and attach Wilson CI to a BatchReport in-place."""
+    from xpyd_acc.confidence import wilson_ci
+
+    lower, upper = wilson_ci(report.divergent_samples, report.total_samples, confidence)
+    report.divergence_ci_lower = lower
+    report.divergence_ci_upper = upper
+    report.confidence_level = confidence
+
+
 def _truncate(text: str, max_length: int) -> str:
     """Truncate text to max_length, appending '...' if truncated."""
     if len(text) <= max_length:
@@ -608,8 +625,15 @@ def format_report(report: BatchReport) -> str:
         f"Total samples: {report.total_samples}",
         f"Matches: {report.match_samples}",
         f"Divergent: {report.divergent_samples} ({report.divergence_rate:.1%})",
-        "",
     ]
+
+    if report.divergence_ci_lower is not None and report.divergence_ci_upper is not None:
+        lines.append(
+            f"  {report.confidence_level:.0%} CI: "
+            f"[{report.divergence_ci_lower:.1%}, {report.divergence_ci_upper:.1%}]"
+        )
+
+    lines.append("")
 
     if report.divergent_samples > 0:
         lines.append("--- Classification ---")
@@ -662,6 +686,11 @@ def _to_markdown(report: BatchReport, *, max_divergent_samples: int = 10) -> str
     lines.append(f"| Matches | {report.match_samples} |")
     lines.append(f"| Divergent | {report.divergent_samples} |")
     lines.append(f"| Divergence rate | {report.divergence_rate:.1%} |")
+    if report.divergence_ci_lower is not None and report.divergence_ci_upper is not None:
+        lines.append(
+            f"| {report.confidence_level:.0%} CI | "
+            f"[{report.divergence_ci_lower:.1%}, {report.divergence_ci_upper:.1%}] |"
+        )
     lines.append("")
 
     if report.divergent_samples > 0:

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -191,6 +191,14 @@ def main(argv: list[str] | None = None) -> None:
         "--fail-threshold", type=float, default=None,
         help="Fail (exit 1) if divergence rate exceeds this threshold (0.0–1.0)",
     )
+    bc.add_argument(
+        "--confidence", action="store_true", default=False,
+        help="Compute Wilson score confidence interval for divergence rate",
+    )
+    bc.add_argument(
+        "--confidence-level", type=float, default=0.95,
+        help="Confidence level for CI (default: 0.95)",
+    )
     _add_sampling_args(bc)
     bc.add_argument(
         "--no-request-id", action="store_true", default=False,
@@ -1073,6 +1081,9 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         elif any(r.divergent_samples > 0 for r in multi_report.per_target.values()):
             sys.exit(1)
     else:
+        # Apply confidence interval if requested
+        _maybe_apply_confidence(args, report)
+
         print()
         print(format_report(report))
 
@@ -1099,18 +1110,25 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         # Send webhook notification if configured
         await _maybe_send_webhook(args, report)
 
-        # Determine fail threshold: CLI > env > config > None
         fail_threshold = _resolve_fail_threshold(args, getattr(args, "_config", None))
         if fail_threshold is not None:
-            if report.divergence_rate > fail_threshold:
+            # When confidence is enabled, use CI lower bound for threshold check
+            if getattr(args, "confidence", False) and report.divergence_ci_lower is not None:
+                check_val = report.divergence_ci_lower
+                label = f"CI lower bound {check_val:.1%}"
+            else:
+                check_val = report.divergence_rate
+                label = f"divergence rate {check_val:.1%}"
+
+            if check_val > fail_threshold:
                 print(
-                    f"\n✗ FAIL: divergence rate {report.divergence_rate:.1%}"
+                    f"\n✗ FAIL: {label}"
                     f" exceeds threshold {fail_threshold:.1%}",
                 )
                 sys.exit(1)
             else:
                 print(
-                    f"\n✓ PASS: divergence rate {report.divergence_rate:.1%}"
+                    f"\n✓ PASS: {label}"
                     f" within threshold {fail_threshold:.1%}",
                 )
         elif report.divergent_samples > 0:
@@ -1148,6 +1166,22 @@ async def _maybe_send_webhook(
         divergence_rate=rate,
     )
     await send_webhook(config, payload)
+
+
+def _maybe_apply_confidence(
+    args: argparse.Namespace,
+    report: object,
+) -> None:
+    """Apply confidence interval to report if --confidence flag is set."""
+    confidence = getattr(args, "confidence", False)
+    # Also check TOML config
+    config = getattr(args, "_config", None)
+    if not confidence and config is not None:
+        confidence = getattr(getattr(config, "batch", None), "confidence", False)
+    if confidence and report.total_samples > 0:
+        from xpyd_acc.batch_compare import apply_confidence
+        level = getattr(args, "confidence_level", 0.95)
+        apply_confidence(report, level)
 
 
 def _resolve_fail_threshold(

--- a/src/xpyd_acc/confidence.py
+++ b/src/xpyd_acc/confidence.py
@@ -1,0 +1,76 @@
+"""Wilson score confidence intervals for binomial proportions."""
+
+from __future__ import annotations
+
+import math
+
+
+def wilson_ci(
+    divergent: int,
+    total: int,
+    confidence: float = 0.95,
+) -> tuple[float, float]:
+    """Compute Wilson score confidence interval for a binomial proportion.
+
+    Args:
+        divergent: Number of divergent (positive) samples.
+        total: Total number of samples.
+        confidence: Confidence level (default 0.95 for 95% CI).
+
+    Returns:
+        Tuple of (lower_bound, upper_bound) as floats in [0, 1].
+
+    Raises:
+        ValueError: If inputs are invalid.
+    """
+    if total <= 0:
+        raise ValueError(f"total must be positive, got {total}")
+    if divergent < 0 or divergent > total:
+        raise ValueError(
+            f"divergent must be in [0, total], got {divergent}/{total}"
+        )
+    if not 0 < confidence < 1:
+        raise ValueError(f"confidence must be in (0, 1), got {confidence}")
+
+    # Z-score from normal distribution
+    z = _normal_ppf((1 + confidence) / 2)
+    z2 = z * z
+    n = total
+    p_hat = divergent / n
+
+    denominator = 1 + z2 / n
+    center = p_hat + z2 / (2 * n)
+    spread = z * math.sqrt((p_hat * (1 - p_hat) + z2 / (4 * n)) / n)
+
+    lower = (center - spread) / denominator
+    upper = (center + spread) / denominator
+
+    # Clamp to [0, 1]
+    return max(0.0, lower), min(1.0, upper)
+
+
+def _normal_ppf(p: float) -> float:
+    """Approximate inverse normal CDF (percent point function).
+
+    Uses the rational approximation from Abramowitz and Stegun.
+    Accurate to ~4.5e-4 absolute error.
+    """
+    if p <= 0 or p >= 1:
+        raise ValueError(f"p must be in (0, 1), got {p}")
+
+    if p < 0.5:
+        return -_rational_approx(math.sqrt(-2.0 * math.log(p)))
+    else:
+        return _rational_approx(math.sqrt(-2.0 * math.log(1.0 - p)))
+
+
+def _rational_approx(t: float) -> float:
+    """Rational approximation for inverse normal CDF."""
+    # Coefficients from Peter Acklam's approximation
+    c0 = 2.515517
+    c1 = 0.802853
+    c2 = 0.010328
+    d1 = 1.432788
+    d2 = 0.189269
+    d3 = 0.001308
+    return t - (c0 + c1 * t + c2 * t * t) / (1 + d1 * t + d2 * t * t + d3 * t * t * t)

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -57,6 +57,8 @@ class BatchConfig:
     deduplicate: bool = False
     cache_dir: str | None = None
     cache_ttl: float | None = None
+    confidence: bool = False
+    confidence_level: float = 0.95
 
 
 @dataclass

--- a/src/xpyd_acc/config_validate.py
+++ b/src/xpyd_acc/config_validate.py
@@ -76,6 +76,8 @@ STARTER_CONFIG = """\
 # deduplicate = false
 # cache_dir = ".xpyd-acc-cache"
 # cache_ttl = 3600.0
+# confidence = false
+# confidence_level = 0.95
 
 [kv]
 # max_abs_threshold = 0.001

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,202 @@
+"""Tests for confidence interval computation and integration."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from xpyd_acc.confidence import wilson_ci
+
+
+class TestWilsonCI:
+    """Tests for the wilson_ci function."""
+
+    def test_basic_50_percent(self):
+        """50% divergence on 100 samples."""
+        lower, upper = wilson_ci(50, 100, 0.95)
+        assert 0.39 < lower < 0.42
+        assert 0.58 < upper < 0.61
+
+    def test_zero_divergence(self):
+        """0 out of N divergent."""
+        lower, upper = wilson_ci(0, 100, 0.95)
+        assert lower == 0.0
+        assert 0.0 < upper < 0.05
+
+    def test_all_divergent(self):
+        """N out of N divergent."""
+        lower, upper = wilson_ci(100, 100, 0.95)
+        assert 0.95 < lower <= 1.0
+        assert upper >= 0.99
+
+    def test_single_sample_divergent(self):
+        """1 out of 1 divergent."""
+        lower, upper = wilson_ci(1, 1, 0.95)
+        assert 0.0 < lower
+        assert upper == 1.0
+
+    def test_single_sample_match(self):
+        """0 out of 1 divergent."""
+        lower, upper = wilson_ci(0, 1, 0.95)
+        assert lower == 0.0
+        assert upper < 1.0
+
+    def test_small_sample(self):
+        """Small sample: 1 out of 10."""
+        lower, upper = wilson_ci(1, 10, 0.95)
+        assert lower >= 0.0
+        assert upper <= 1.0
+        assert lower < 0.1
+        assert upper > 0.1
+
+    def test_bounds_always_valid(self):
+        """Lower <= rate <= upper for various inputs."""
+        for div in range(0, 21):
+            lower, upper = wilson_ci(div, 20, 0.95)
+            rate = div / 20
+            assert lower <= rate + 1e-9  # small epsilon for float
+            assert upper >= rate - 1e-9
+            assert 0.0 <= lower <= upper <= 1.0
+
+    def test_higher_confidence_wider(self):
+        """99% CI should be wider than 90% CI."""
+        low90, high90 = wilson_ci(10, 100, 0.90)
+        low99, high99 = wilson_ci(10, 100, 0.99)
+        assert low99 < low90
+        assert high99 > high90
+
+    def test_invalid_total_zero(self):
+        with pytest.raises(ValueError, match="total must be positive"):
+            wilson_ci(0, 0, 0.95)
+
+    def test_invalid_negative_divergent(self):
+        with pytest.raises(ValueError, match="divergent must be in"):
+            wilson_ci(-1, 10, 0.95)
+
+    def test_invalid_divergent_exceeds_total(self):
+        with pytest.raises(ValueError, match="divergent must be in"):
+            wilson_ci(11, 10, 0.95)
+
+    def test_invalid_confidence_zero(self):
+        with pytest.raises(ValueError, match="confidence must be in"):
+            wilson_ci(5, 10, 0.0)
+
+    def test_invalid_confidence_one(self):
+        with pytest.raises(ValueError, match="confidence must be in"):
+            wilson_ci(5, 10, 1.0)
+
+
+class TestApplyConfidence:
+    """Tests for apply_confidence integration with BatchReport."""
+
+    def test_apply_confidence_basic(self):
+        from xpyd_acc.batch_compare import BatchReport, apply_confidence
+
+        report = BatchReport(
+            total_samples=100,
+            divergent_samples=10,
+            match_samples=90,
+            divergence_rate=0.1,
+            results=[],
+        )
+        apply_confidence(report, 0.95)
+        assert report.divergence_ci_lower is not None
+        assert report.divergence_ci_upper is not None
+        assert report.confidence_level == 0.95
+        assert report.divergence_ci_lower < 0.1
+        assert report.divergence_ci_upper > 0.1
+
+    def test_ci_in_json_export(self):
+        from xpyd_acc.batch_compare import BatchReport, apply_confidence
+
+        report = BatchReport(
+            total_samples=50,
+            divergent_samples=5,
+            match_samples=45,
+            divergence_rate=0.1,
+            results=[],
+        )
+        apply_confidence(report, 0.95)
+        data = json.loads(report.to_json())
+        assert "divergence_ci_lower" in data
+        assert "divergence_ci_upper" in data
+        assert "confidence_level" in data
+        assert data["confidence_level"] == 0.95
+
+    def test_ci_none_by_default(self):
+        from xpyd_acc.batch_compare import BatchReport
+
+        report = BatchReport(
+            total_samples=10,
+            divergent_samples=1,
+            match_samples=9,
+            divergence_rate=0.1,
+            results=[],
+        )
+        assert report.divergence_ci_lower is None
+        assert report.divergence_ci_upper is None
+        data = json.loads(report.to_json())
+        assert data["divergence_ci_lower"] is None
+
+    def test_ci_in_markdown_export(self):
+        from xpyd_acc.batch_compare import BatchReport, apply_confidence
+
+        report = BatchReport(
+            total_samples=100,
+            divergent_samples=10,
+            match_samples=90,
+            divergence_rate=0.1,
+            results=[],
+        )
+        apply_confidence(report, 0.95)
+        md = report.to_markdown()
+        assert "95% CI" in md
+        assert "[" in md  # bracket notation for interval
+
+    def test_ci_in_format_report(self):
+        from xpyd_acc.batch_compare import BatchReport, apply_confidence, format_report
+
+        report = BatchReport(
+            total_samples=100,
+            divergent_samples=10,
+            match_samples=90,
+            divergence_rate=0.1,
+            results=[],
+        )
+        apply_confidence(report, 0.95)
+        text = format_report(report)
+        assert "95% CI" in text
+
+    def test_no_ci_in_format_when_not_applied(self):
+        from xpyd_acc.batch_compare import BatchReport, format_report
+
+        report = BatchReport(
+            total_samples=100,
+            divergent_samples=10,
+            match_samples=90,
+            divergence_rate=0.1,
+            results=[],
+        )
+        text = format_report(report)
+        assert "CI" not in text
+
+    def test_apply_confidence_custom_level(self):
+        from xpyd_acc.batch_compare import BatchReport, apply_confidence
+
+        report = BatchReport(
+            total_samples=200,
+            divergent_samples=20,
+            match_samples=180,
+            divergence_rate=0.1,
+            results=[],
+        )
+        apply_confidence(report, 0.99)
+        assert report.confidence_level == 0.99
+        # 99% CI should be wider than default 95%
+        low99 = report.divergence_ci_lower
+        up99 = report.divergence_ci_upper
+
+        apply_confidence(report, 0.90)
+        assert report.divergence_ci_lower > low99
+        assert report.divergence_ci_upper < up99


### PR DESCRIPTION
Closes #115

## Changes
- `confidence.py`: Wilson score CI for binomial proportions (no external deps)
- `BatchReport`: `divergence_ci_lower`, `divergence_ci_upper`, `confidence_level` fields
- CLI: `--confidence` and `--confidence-level` flags on `batch-compare`
- Terminal, JSON, Markdown exports include CI when computed
- `--fail-threshold` + `--confidence`: checks CI lower bound instead of point estimate
- TOML config: `[batch] confidence = true`, `confidence_level = 0.95`
- Config validation updated with new keys
- 20 tests, all 695 pass, lint clean