### PR TITLE
feat: add sample annotation for batch reports (M54)

### DIFF
--- a/src/xpyd_acc/annotate.py
+++ b/src/xpyd_acc/annotate.py
@@ -1,0 +1,124 @@
+"""Sample annotation for batch reports — sidecar-based notes and labels."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class SampleAnnotation:
+    """Annotation for a single sample."""
+
+    sample_id: str
+    note: str | None = None
+    labels: list[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        """Return True if annotation has no content."""
+        return not self.note and not self.labels
+
+
+@dataclass
+class AnnotationStore:
+    """Manages annotations stored in a sidecar JSON file."""
+
+    annotations: dict[str, SampleAnnotation] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def sidecar_path(report_path: str | Path) -> Path:
+        """Return the sidecar file path for a given report."""
+        p = Path(report_path)
+        return p.parent / f"{p.name}.annotations.json"
+
+    @classmethod
+    def load(cls, report_path: str | Path) -> "AnnotationStore":
+        """Load annotations from the sidecar file.  Returns empty store if missing."""
+        path = cls.sidecar_path(report_path)
+        if not path.exists():
+            return cls()
+        data = json.loads(path.read_text(encoding="utf-8"))
+        store = cls()
+        for sid, entry in data.get("annotations", {}).items():
+            store.annotations[sid] = SampleAnnotation(
+                sample_id=sid,
+                note=entry.get("note"),
+                labels=entry.get("labels", []),
+            )
+        return store
+
+    def save(self, report_path: str | Path) -> Path:
+        """Persist annotations to the sidecar file.  Returns the path written."""
+        path = self.sidecar_path(report_path)
+        # Remove empty annotations before saving
+        clean = {
+            sid: asdict(ann)
+            for sid, ann in self.annotations.items()
+            if not ann.is_empty()
+        }
+        data: dict[str, Any] = {"annotations": clean}
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        return path
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def set_note(self, sample_id: str, note: str) -> None:
+        """Set or update the note for a sample."""
+        ann = self.annotations.setdefault(sample_id, SampleAnnotation(sample_id=sample_id))
+        ann.note = note
+
+    def add_label(self, sample_id: str, label: str) -> None:
+        """Add a label to a sample (no duplicates)."""
+        ann = self.annotations.setdefault(sample_id, SampleAnnotation(sample_id=sample_id))
+        if label not in ann.labels:
+            ann.labels.append(label)
+
+    def clear(self, sample_id: str) -> bool:
+        """Remove all annotations for a sample.  Returns True if anything was removed."""
+        return self.annotations.pop(sample_id, None) is not None
+
+    def get(self, sample_id: str) -> SampleAnnotation | None:
+        """Return annotation for a sample, or None."""
+        return self.annotations.get(sample_id)
+
+    def list_annotated_ids(self) -> list[str]:
+        """Return sorted list of sample IDs that have annotations."""
+        return sorted(sid for sid, ann in self.annotations.items() if not ann.is_empty())
+
+    def samples_with_label(self, label: str) -> list[str]:
+        """Return sorted list of sample IDs that have a specific label."""
+        return sorted(
+            sid for sid, ann in self.annotations.items() if label in ann.labels
+        )
+
+
+# ------------------------------------------------------------------
+# Helpers for report integration
+# ------------------------------------------------------------------
+
+
+def annotations_for_markdown(
+    store: AnnotationStore,
+    sample_ids: list[str],
+) -> dict[str, str]:
+    """Return a dict mapping sample_id -> human-readable annotation string."""
+    result: dict[str, str] = {}
+    for sid in sample_ids:
+        ann = store.get(sid)
+        if ann is None or ann.is_empty():
+            continue
+        parts: list[str] = []
+        if ann.labels:
+            parts.append(f"[{', '.join(ann.labels)}]")
+        if ann.note:
+            parts.append(ann.note)
+        result[sid] = " ".join(parts)
+    return result

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -535,6 +535,18 @@ def main(argv: list[str] | None = None) -> None:
         "--search", default=None,
         help="Filter by text in prompt or output (case-insensitive)",
     )
+    flt.add_argument(
+        "--annotation-label", default=None,
+        help="Filter by annotation label",
+    )
+    flt.add_argument(
+        "--annotated", action="store_true", default=False,
+        help="Only samples with annotations",
+    )
+    flt.add_argument(
+        "--unannotated", action="store_true", default=False,
+        help="Only samples without annotations",
+    )
 
     cfg_cmd = sub.add_parser("config", help="Configuration utilities")
     cfg_sub = cfg_cmd.add_subparsers(dest="config_command")
@@ -563,6 +575,15 @@ def main(argv: list[str] | None = None) -> None:
         choices=["oneline", "json", "kv"],
         help="Output format (default: oneline)",
     )
+
+    ann_cmd = sub.add_parser("annotate", help="Add notes and labels to batch report samples")
+    ann_cmd.add_argument("--report", required=True, help="Path to batch report JSON")
+    ann_cmd.add_argument("--sample", default=None, help="Sample ID to annotate")
+    ann_cmd.add_argument("--note", default=None, help="Free-text note for the sample")
+    ann_cmd.add_argument("--label", default=None, help="Classification label for the sample")
+    ann_cmd.add_argument("--clear", action="store_true", help="Clear annotations for the sample")
+    ann_cmd.add_argument("--list", dest="list_annotations", action="store_true",
+                         help="List all annotations for the report")
 
     explain_cmd = sub.add_parser("explain", help="Deep-dive analysis of a single sample")
     explain_cmd.add_argument("--report", required=True, help="Path to batch report JSON")
@@ -617,6 +638,11 @@ def main(argv: list[str] | None = None) -> None:
     # Handle 'summary' subcommand (M48)
     if args.command == "summary":
         _run_summary(args)
+        return
+
+    # Handle 'annotate' subcommand (M54)
+    if args.command == "annotate":
+        _run_annotate(args)
         return
 
     # Handle 'explain' subcommand (M52)
@@ -2139,6 +2165,7 @@ def _run_summary(args: argparse.Namespace) -> None:
 
 def _run_filter(args: argparse.Namespace) -> None:
     """Filter samples from a batch report."""
+    from xpyd_acc.annotate import AnnotationStore
     from xpyd_acc.filter import FilterConfig, filter_samples, load_report, save_report
 
     report = load_report(args.input)
@@ -2153,6 +2180,39 @@ def _run_filter(args: argparse.Namespace) -> None:
         search=args.search,
     )
     filtered = filter_samples(report, config)
+
+    # Apply annotation-based filters
+    ann_label = getattr(args, "annotation_label", None)
+    annotated_only = getattr(args, "annotated", False)
+    unannotated_only = getattr(args, "unannotated", False)
+
+    if ann_label or annotated_only or unannotated_only:
+        store = AnnotationStore.load(args.input)
+        results = filtered.get("results", [])
+        kept: list[dict] = []
+        for r in results:
+            sid = r.get("sample_id", "")
+            ann = store.get(sid)
+            has_ann = ann is not None and not ann.is_empty()
+
+            if annotated_only and not has_ann:
+                continue
+            if unannotated_only and has_ann:
+                continue
+            if ann_label:
+                if ann is None or ann_label not in ann.labels:
+                    continue
+            kept.append(r)
+
+        # Recalculate stats
+        total = len(kept)
+        divergent = sum(1 for r in kept if not r.get("exact_match", True))
+        filtered["results"] = kept
+        filtered["total_samples"] = total
+        filtered["divergent_samples"] = divergent
+        filtered["match_samples"] = total - divergent
+        filtered["divergence_rate"] = divergent / total if total else 0.0
+
     save_report(filtered, args.output)
 
     total = filtered["total_samples"]
@@ -2313,6 +2373,65 @@ def _run_cluster(args: argparse.Namespace) -> None:
     if args.cluster_json:
         result.to_json(args.cluster_json)
         console.print(f"\n  Exported to {args.cluster_json}")
+
+
+def _run_annotate(args: argparse.Namespace) -> None:
+    """Handle the 'annotate' subcommand."""
+    from pathlib import Path
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from xpyd_acc.annotate import AnnotationStore
+
+    console = Console()
+    report_path = Path(args.report)
+    if not report_path.exists():
+        console.print(f"[red]Report not found:[/red] {report_path}")
+        raise SystemExit(1)
+
+    store = AnnotationStore.load(report_path)
+
+    if args.list_annotations:
+        ids = store.list_annotated_ids()
+        if not ids:
+            console.print("No annotations found.")
+            return
+        table = Table(title="Annotations")
+        table.add_column("Sample ID")
+        table.add_column("Labels")
+        table.add_column("Note")
+        for sid in ids:
+            ann = store.get(sid)
+            if ann is None:
+                continue
+            table.add_row(sid, ", ".join(ann.labels), ann.note or "")
+        console.print(table)
+        return
+
+    if not args.sample:
+        console.print("[red]--sample is required for add/clear operations[/red]")
+        raise SystemExit(1)
+
+    if args.clear:
+        removed = store.clear(args.sample)
+        store.save(report_path)
+        if removed:
+            console.print(f"Cleared annotations for sample [bold]{args.sample}[/bold]")
+        else:
+            console.print(f"No annotations found for sample [bold]{args.sample}[/bold]")
+        return
+
+    if args.note is None and args.label is None:
+        console.print("[red]Provide --note and/or --label[/red]")
+        raise SystemExit(1)
+
+    if args.note is not None:
+        store.set_note(args.sample, args.note)
+    if args.label is not None:
+        store.add_label(args.sample, args.label)
+    store.save(report_path)
+    console.print(f"Annotated sample [bold]{args.sample}[/bold]")
 
 
 def _run_explain(args: argparse.Namespace) -> None:

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1,0 +1,206 @@
+"""Tests for M54: Sample Annotation for Batch Reports."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.annotate import AnnotationStore, SampleAnnotation, annotations_for_markdown
+
+
+@pytest.fixture()
+def report_file(tmp_path: Path) -> Path:
+    """Create a minimal batch report JSON."""
+    report = {
+        "total_samples": 3,
+        "divergent_samples": 1,
+        "match_samples": 2,
+        "divergence_rate": 0.333,
+        "results": [
+            {"sample_id": "s1", "exact_match": True},
+            {"sample_id": "s2", "exact_match": False},
+            {"sample_id": "s3", "exact_match": True},
+        ],
+    }
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(report))
+    return p
+
+
+# ── SampleAnnotation ──
+
+
+def test_annotation_is_empty():
+    ann = SampleAnnotation(sample_id="s1")
+    assert ann.is_empty()
+    ann.note = "hello"
+    assert not ann.is_empty()
+
+
+def test_annotation_label_not_empty():
+    ann = SampleAnnotation(sample_id="s1", labels=["known_issue"])
+    assert not ann.is_empty()
+
+
+# ── AnnotationStore basic CRUD ──
+
+
+def test_set_note():
+    store = AnnotationStore()
+    store.set_note("s1", "this is a false positive")
+    ann = store.get("s1")
+    assert ann is not None
+    assert ann.note == "this is a false positive"
+
+
+def test_add_label_no_duplicates():
+    store = AnnotationStore()
+    store.add_label("s1", "known_issue")
+    store.add_label("s1", "known_issue")
+    ann = store.get("s1")
+    assert ann is not None
+    assert ann.labels == ["known_issue"]
+
+
+def test_clear():
+    store = AnnotationStore()
+    store.set_note("s1", "note")
+    assert store.clear("s1")
+    assert store.get("s1") is None
+    assert not store.clear("s1")  # second clear returns False
+
+
+def test_list_annotated_ids():
+    store = AnnotationStore()
+    store.set_note("s3", "n3")
+    store.set_note("s1", "n1")
+    assert store.list_annotated_ids() == ["s1", "s3"]
+
+
+def test_samples_with_label():
+    store = AnnotationStore()
+    store.add_label("s1", "known_issue")
+    store.add_label("s2", "false_positive")
+    store.add_label("s3", "known_issue")
+    assert store.samples_with_label("known_issue") == ["s1", "s3"]
+
+
+# ── Persistence (save / load) ──
+
+
+def test_save_and_load(report_file: Path):
+    store = AnnotationStore()
+    store.set_note("s1", "looks good")
+    store.add_label("s2", "known_issue")
+    store.save(report_file)
+
+    sidecar = AnnotationStore.sidecar_path(report_file)
+    assert sidecar.exists()
+
+    loaded = AnnotationStore.load(report_file)
+    assert loaded.get("s1") is not None
+    assert loaded.get("s1").note == "looks good"
+    assert loaded.get("s2").labels == ["known_issue"]
+
+
+def test_load_missing_sidecar(report_file: Path):
+    store = AnnotationStore.load(report_file)
+    assert store.list_annotated_ids() == []
+
+
+def test_empty_annotations_not_saved(report_file: Path):
+    store = AnnotationStore()
+    store.set_note("s1", "note")
+    store.clear("s1")
+    store.save(report_file)
+    data = json.loads(AnnotationStore.sidecar_path(report_file).read_text())
+    assert data["annotations"] == {}
+
+
+# ── annotations_for_markdown helper ──
+
+
+def test_annotations_for_markdown():
+    store = AnnotationStore()
+    store.set_note("s1", "false positive")
+    store.add_label("s1", "known_issue")
+    store.add_label("s2", "fixed")
+
+    result = annotations_for_markdown(store, ["s1", "s2", "s3"])
+    assert "known_issue" in result["s1"]
+    assert "false positive" in result["s1"]
+    assert "fixed" in result["s2"]
+    assert "s3" not in result
+
+
+def test_annotations_for_markdown_empty():
+    store = AnnotationStore()
+    assert annotations_for_markdown(store, ["s1"]) == {}
+
+
+# ── CLI integration (annotate subcommand) ──
+
+
+def test_cli_annotate_note(report_file: Path):
+    from xpyd_acc.cli import main
+
+    main(["annotate", "--report", str(report_file), "--sample", "s1", "--note", "test note"])
+    store = AnnotationStore.load(report_file)
+    assert store.get("s1").note == "test note"
+
+
+def test_cli_annotate_label(report_file: Path):
+    from xpyd_acc.cli import main
+
+    main(["annotate", "--report", str(report_file), "--sample", "s2", "--label", "known_issue"])
+    store = AnnotationStore.load(report_file)
+    assert "known_issue" in store.get("s2").labels
+
+
+def test_cli_annotate_list(report_file: Path, capsys):
+    from xpyd_acc.cli import main
+
+    store = AnnotationStore()
+    store.set_note("s1", "my note")
+    store.save(report_file)
+
+    main(["annotate", "--report", str(report_file), "--list"])
+    out = capsys.readouterr().out
+    assert "s1" in out
+    assert "my note" in out
+
+
+def test_cli_annotate_clear(report_file: Path):
+    from xpyd_acc.cli import main
+
+    # Add then clear
+    main(["annotate", "--report", str(report_file), "--sample", "s1", "--note", "temp"])
+    main(["annotate", "--report", str(report_file), "--sample", "s1", "--clear"])
+    store = AnnotationStore.load(report_file)
+    assert store.get("s1") is None
+
+
+def test_cli_annotate_missing_report(tmp_path: Path):
+    from xpyd_acc.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["annotate", "--report", str(tmp_path / "nope.json"), "--list"])
+    assert exc.value.code == 1
+
+
+def test_cli_annotate_no_sample_no_list(report_file: Path):
+    from xpyd_acc.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["annotate", "--report", str(report_file)])
+    assert exc.value.code == 1
+
+
+def test_cli_annotate_sample_no_action(report_file: Path):
+    from xpyd_acc.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["annotate", "--report", str(report_file), "--sample", "s1"])
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
Add sample annotation support for batch reports via sidecar JSON files.

### Changes
- **`annotate` subcommand**: add/list/clear notes and labels on individual samples
- **Sidecar storage**: `<report>.annotations.json` keeps original report immutable
- **Filter integration**: `--annotation-label`, `--annotated`, `--unannotated` flags
- **`annotations_for_markdown`** helper for report consumers
- **19 tests** covering CRUD, persistence, CLI integration, edge cases

### Usage
```bash
xpyd-acc annotate --report r.json --sample s1 --note 'false positive'
xpyd-acc annotate --report r.json --sample s1 --label known_issue
xpyd-acc annotate --report r.json --list
xpyd-acc filter --input r.json --output f.json --annotation-label known_issue
```

Closes #117