### PR TITLE
feat: Model Fingerprinting via Deterministic Probes (M55)

### DIFF
--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -593,6 +593,21 @@ def main(argv: list[str] | None = None) -> None:
         help="Export analysis as JSON",
     )
 
+    # --- fingerprint ---
+    fp_cmd = sub.add_parser("fingerprint", help="Model fingerprinting via deterministic probes")
+    fp_cmd.add_argument("--baseline", required=True, help="Baseline endpoint URL")
+    fp_cmd.add_argument("--target", default=None, help="Target endpoint URL (compare two)")
+    fp_cmd.add_argument("--model", default="default", help="Model name")
+    fp_cmd.add_argument("--api-key", default=None, help="API key")
+    fp_cmd.add_argument("--max-tokens", type=int, default=16, help="Max tokens per probe")
+    fp_cmd.add_argument(
+        "--json", dest="fp_json", default=None,
+        help="Export fingerprint(s) as JSON",
+    )
+    fp_cmd.add_argument("--retries", type=int, default=3, help="Retry count")
+    fp_cmd.add_argument("--retry-delay", type=float, default=1.0, help="Retry base delay")
+    fp_cmd.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout per request")
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -648,6 +663,11 @@ def main(argv: list[str] | None = None) -> None:
     # Handle 'explain' subcommand (M52)
     if args.command == "explain":
         _run_explain(args)
+        return
+
+    # Handle 'fingerprint' subcommand (M55)
+    if args.command == "fingerprint":
+        _run_fingerprint(args)
         return
 
     # Handle 'filter' subcommand (M42)
@@ -2453,3 +2473,67 @@ def _run_explain(args: argparse.Namespace) -> None:
         print(f"Exported to {args.explain_json}")
     else:
         print(format_explain(result))
+
+
+def _run_fingerprint(args: argparse.Namespace) -> None:
+    """Handle the 'fingerprint' subcommand (M55)."""
+    import asyncio
+    import json as _json
+    from pathlib import Path
+
+    from xpyd_acc.fingerprint import collect_fingerprint, compare_fingerprints
+
+    api_key = args.api_key or "no-key"
+
+    async def _go():
+        fp_baseline = await collect_fingerprint(
+            args.baseline,
+            api_key=api_key,
+            model=args.model,
+            max_tokens=args.max_tokens,
+            timeout=args.timeout,
+            retries=args.retries,
+            retry_delay=args.retry_delay,
+        )
+        print(f"Baseline fingerprint: {fp_baseline.hash}  ({fp_baseline.endpoint})")
+
+        result: dict = fp_baseline.to_dict()
+
+        if args.target:
+            fp_target = await collect_fingerprint(
+                args.target,
+                api_key=api_key,
+                model=args.model,
+                max_tokens=args.max_tokens,
+                timeout=args.timeout,
+                retries=args.retries,
+                retry_delay=args.retry_delay,
+            )
+            print(f"Target fingerprint:   {fp_target.hash}  ({fp_target.endpoint})")
+
+            cmp = compare_fingerprints(fp_baseline, fp_target)
+            if cmp.match:
+                print("\n✅ Fingerprints MATCH — endpoints produce identical probe outputs")
+            else:
+                ndiff = len(cmp.differing_probes)
+                print(
+                    f"\n❌ Fingerprints DIFFER — "
+                    f"{ndiff}/{cmp.total_probes} probes diverged"
+                )
+                for d in cmp.differing_probes:
+                    print(f"  Probe {d['probe_index']}: {d['prompt'][:40]}")
+                    print(f"    baseline: {d['output_a'][:60]}")
+                    print(f"    target:   {d['output_b'][:60]}")
+            result = {
+                "baseline": fp_baseline.to_dict(),
+                "target": fp_target.to_dict(),
+                "comparison": cmp.to_dict(),
+            }
+            if not cmp.match:
+                raise SystemExit(1)
+
+        if args.fp_json:
+            Path(args.fp_json).write_text(_json.dumps(result, indent=2))
+            print(f"\nExported to {args.fp_json}")
+
+    asyncio.run(_go())

--- a/src/xpyd_acc/fingerprint.py
+++ b/src/xpyd_acc/fingerprint.py
@@ -1,0 +1,163 @@
+"""Model fingerprinting: deterministic probes to identify endpoint behavior."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+from xpyd_acc.log import get_logger
+
+logger = get_logger("fingerprint")
+
+# Fixed probes designed to elicit deterministic, model-characteristic responses.
+# Temperature=0, seed=42, max_tokens=16 to keep outputs short and stable.
+DEFAULT_PROBES = [
+    "What is 2+2?",
+    "Complete: The capital of France is",
+    "Translate to French: hello",
+    "What comes after 1, 1, 2, 3, 5?",
+    "Repeat exactly: alpha bravo charlie",
+]
+
+
+@dataclass
+class ProbeResult:
+    """Result of a single fingerprint probe."""
+
+    prompt: str
+    output: str
+    tokens: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Fingerprint:
+    """A model fingerprint built from deterministic probes."""
+
+    endpoint: str
+    model: str
+    hash: str
+    probes: list[ProbeResult]
+    probe_count: int
+
+    def matches(self, other: Fingerprint) -> bool:
+        """Check if two fingerprints are identical."""
+        return self.hash == other.hash
+
+    def diff(self, other: Fingerprint) -> list[dict[str, Any]]:
+        """Return per-probe diffs where outputs differ."""
+        diffs: list[dict[str, Any]] = []
+        for i, (a, b) in enumerate(zip(self.probes, other.probes)):
+            if a.output != b.output:
+                diffs.append({
+                    "probe_index": i,
+                    "prompt": a.prompt,
+                    "output_a": a.output,
+                    "output_b": b.output,
+                })
+        return diffs
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict."""
+        return {
+            "endpoint": self.endpoint,
+            "model": self.model,
+            "hash": self.hash,
+            "probe_count": self.probe_count,
+            "probes": [
+                {"prompt": p.prompt, "output": p.output, "tokens": p.tokens}
+                for p in self.probes
+            ],
+        }
+
+
+@dataclass
+class FingerprintComparison:
+    """Result of comparing two fingerprints."""
+
+    match: bool
+    hash_a: str
+    hash_b: str
+    endpoint_a: str
+    endpoint_b: str
+    differing_probes: list[dict[str, Any]]
+    total_probes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict."""
+        return {
+            "match": self.match,
+            "hash_a": self.hash_a,
+            "hash_b": self.hash_b,
+            "endpoint_a": self.endpoint_a,
+            "endpoint_b": self.endpoint_b,
+            "differing_probes": self.differing_probes,
+            "total_probes": self.total_probes,
+        }
+
+
+def _compute_hash(probes: list[ProbeResult]) -> str:
+    """Compute SHA-256 hash from probe outputs."""
+    hasher = hashlib.sha256()
+    for p in probes:
+        hasher.update(p.output.encode("utf-8"))
+    return hasher.hexdigest()[:16]
+
+
+async def collect_fingerprint(
+    endpoint: str,
+    *,
+    api_key: str = "no-key",
+    model: str = "default",
+    probes: list[str] | None = None,
+    max_tokens: int = 16,
+    timeout: float = 30.0,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+) -> Fingerprint:
+    """Send deterministic probes to an endpoint and build a fingerprint."""
+    from xpyd_acc.logprobs import LogprobsCollector
+    from xpyd_acc.sampling import SamplingParams
+
+    probe_prompts = probes if probes is not None else DEFAULT_PROBES
+    collector = LogprobsCollector(endpoint, api_key=api_key, model=model)
+    sampling = SamplingParams(temperature=0, seed=42)
+
+    results: list[ProbeResult] = []
+    for prompt in probe_prompts:
+        logger.info("Probing: %s", prompt[:50])
+        lr = await collector.collect(
+            prompt,
+            max_tokens=max_tokens,
+            timeout=timeout,
+            retries=retries,
+            retry_delay=retry_delay,
+            sampling_params=sampling,
+        )
+        tokens = [t.token for t in lr.tokens]
+        output = "".join(tokens)
+        results.append(ProbeResult(prompt=prompt, output=output, tokens=tokens))
+
+    fp_hash = _compute_hash(results)
+    logger.info("Fingerprint for %s: %s", endpoint, fp_hash)
+    return Fingerprint(
+        endpoint=endpoint,
+        model=lr.model if results else model,
+        hash=fp_hash,
+        probes=results,
+        probe_count=len(results),
+    )
+
+
+def compare_fingerprints(a: Fingerprint, b: Fingerprint) -> FingerprintComparison:
+    """Compare two fingerprints and return a comparison result."""
+    diffs = a.diff(b)
+    return FingerprintComparison(
+        match=a.matches(b),
+        hash_a=a.hash,
+        hash_b=b.hash,
+        endpoint_a=a.endpoint,
+        endpoint_b=b.endpoint,
+        differing_probes=diffs,
+        total_probes=min(a.probe_count, b.probe_count),
+    )

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,210 @@
+"""Tests for model fingerprinting (M55)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xpyd_acc.fingerprint import (
+    DEFAULT_PROBES,
+    Fingerprint,
+    ProbeResult,
+    _compute_hash,
+    collect_fingerprint,
+    compare_fingerprints,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for _compute_hash
+# ---------------------------------------------------------------------------
+
+def test_compute_hash_deterministic():
+    probes = [ProbeResult(prompt="a", output="hello")]
+    assert _compute_hash(probes) == _compute_hash(probes)
+
+
+def test_compute_hash_different_outputs():
+    a = [ProbeResult(prompt="a", output="hello")]
+    b = [ProbeResult(prompt="a", output="world")]
+    assert _compute_hash(a) != _compute_hash(b)
+
+
+def test_compute_hash_length():
+    probes = [ProbeResult(prompt="a", output="x")]
+    assert len(_compute_hash(probes)) == 16
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint dataclass tests
+# ---------------------------------------------------------------------------
+
+def _make_fp(endpoint: str, outputs: list[str]) -> Fingerprint:
+    probes = [ProbeResult(prompt=f"p{i}", output=o) for i, o in enumerate(outputs)]
+    return Fingerprint(
+        endpoint=endpoint,
+        model="test-model",
+        hash=_compute_hash(probes),
+        probes=probes,
+        probe_count=len(probes),
+    )
+
+
+def test_fingerprint_matches_same():
+    fp = _make_fp("http://a", ["x", "y"])
+    fp2 = _make_fp("http://b", ["x", "y"])
+    assert fp.matches(fp2)
+
+
+def test_fingerprint_no_match():
+    fp = _make_fp("http://a", ["x", "y"])
+    fp2 = _make_fp("http://b", ["x", "z"])
+    assert not fp.matches(fp2)
+
+
+def test_fingerprint_diff_empty():
+    fp = _make_fp("http://a", ["x", "y"])
+    fp2 = _make_fp("http://b", ["x", "y"])
+    assert fp.diff(fp2) == []
+
+
+def test_fingerprint_diff_reports_changes():
+    fp = _make_fp("http://a", ["x", "y", "z"])
+    fp2 = _make_fp("http://b", ["x", "CHANGED", "z"])
+    diffs = fp.diff(fp2)
+    assert len(diffs) == 1
+    assert diffs[0]["probe_index"] == 1
+    assert diffs[0]["output_a"] == "y"
+    assert diffs[0]["output_b"] == "CHANGED"
+
+
+def test_fingerprint_to_dict():
+    fp = _make_fp("http://a", ["x"])
+    d = fp.to_dict()
+    assert d["endpoint"] == "http://a"
+    assert d["hash"] == fp.hash
+    assert len(d["probes"]) == 1
+    assert d["probes"][0]["output"] == "x"
+
+
+# ---------------------------------------------------------------------------
+# FingerprintComparison tests
+# ---------------------------------------------------------------------------
+
+def test_compare_fingerprints_match():
+    fp1 = _make_fp("http://a", ["x", "y"])
+    fp2 = _make_fp("http://b", ["x", "y"])
+    cmp = compare_fingerprints(fp1, fp2)
+    assert cmp.match is True
+    assert cmp.differing_probes == []
+    assert cmp.total_probes == 2
+
+
+def test_compare_fingerprints_mismatch():
+    fp1 = _make_fp("http://a", ["x", "y"])
+    fp2 = _make_fp("http://b", ["x", "z"])
+    cmp = compare_fingerprints(fp1, fp2)
+    assert cmp.match is False
+    assert len(cmp.differing_probes) == 1
+
+
+def test_comparison_to_dict():
+    fp1 = _make_fp("http://a", ["x"])
+    fp2 = _make_fp("http://b", ["y"])
+    cmp = compare_fingerprints(fp1, fp2)
+    d = cmp.to_dict()
+    assert "match" in d
+    assert d["match"] is False
+    assert d["total_probes"] == 1
+
+
+# ---------------------------------------------------------------------------
+# collect_fingerprint (mocked)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_collect_fingerprint_basic():
+    """collect_fingerprint calls LogprobsCollector for each probe."""
+    mock_token = MagicMock()
+    mock_token.token = "4"
+    mock_result = MagicMock()
+    mock_result.tokens = [mock_token]
+    mock_result.model = "test-model"
+
+    with patch("xpyd_acc.logprobs.LogprobsCollector") as MockCollector:
+        instance = MockCollector.return_value
+        instance.collect = AsyncMock(return_value=mock_result)
+
+        fp = await collect_fingerprint("http://test:8000", model="test-model")
+
+    assert fp.endpoint == "http://test:8000"
+    assert fp.probe_count == len(DEFAULT_PROBES)
+    assert instance.collect.call_count == len(DEFAULT_PROBES)
+    assert len(fp.hash) == 16
+
+
+@pytest.mark.asyncio
+async def test_collect_fingerprint_custom_probes():
+    """Custom probes override the default set."""
+    mock_token = MagicMock()
+    mock_token.token = "ok"
+    mock_result = MagicMock()
+    mock_result.tokens = [mock_token]
+    mock_result.model = "m"
+
+    with patch("xpyd_acc.logprobs.LogprobsCollector") as MockCollector:
+        instance = MockCollector.return_value
+        instance.collect = AsyncMock(return_value=mock_result)
+
+        fp = await collect_fingerprint("http://x", probes=["hello", "world"])
+
+    assert fp.probe_count == 2
+    assert instance.collect.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_collect_fingerprint_uses_temperature_zero():
+    """Fingerprint collection uses temperature=0, seed=42."""
+    mock_token = MagicMock()
+    mock_token.token = "t"
+    mock_result = MagicMock()
+    mock_result.tokens = [mock_token]
+    mock_result.model = "m"
+
+    with patch("xpyd_acc.logprobs.LogprobsCollector") as MockCollector:
+        instance = MockCollector.return_value
+        instance.collect = AsyncMock(return_value=mock_result)
+
+        await collect_fingerprint("http://x", probes=["hi"])
+
+    call_kwargs = instance.collect.call_args
+    sp = call_kwargs.kwargs.get("sampling_params") or call_kwargs[1].get("sampling_params")
+    assert sp is not None
+    assert sp.temperature == 0
+    assert sp.seed == 42
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_probes_hash():
+    assert _compute_hash([]) == _compute_hash([])
+
+
+def test_fingerprint_diff_different_lengths():
+    """diff handles mismatched probe counts (zips to shorter)."""
+    fp1 = _make_fp("http://a", ["x", "y", "z"])
+    fp2 = _make_fp("http://b", ["x", "y"])
+    diffs = fp1.diff(fp2)
+    assert diffs == []  # first two match, third ignored by zip
+
+
+def test_fingerprint_json_roundtrip():
+    fp = _make_fp("http://a", ["hello", "world"])
+    d = fp.to_dict()
+    s = json.dumps(d)
+    loaded = json.loads(s)
+    assert loaded["hash"] == fp.hash
+    assert len(loaded["probes"]) == 2


### PR DESCRIPTION
## Summary
Add `xpyd-acc fingerprint` command for quick endpoint identity verification using deterministic probes.

### Changes
- **`src/xpyd_acc/fingerprint.py`**: Core module with `collect_fingerprint()`, `compare_fingerprints()`, `Fingerprint`/`FingerprintComparison` dataclasses
- **`src/xpyd_acc/cli.py`**: New `fingerprint` subcommand with `--baseline`, `--target`, `--json`, `--model`, `--api-key`, `--retries`, `--timeout` flags
- **`tests/test_fingerprint.py`**: 17 tests covering hash computation, comparison, mocked collection, edge cases

### How it works
1. Sends 5 deterministic probes (temperature=0, seed=42, max_tokens=16) to each endpoint
2. Hashes concatenated outputs into a 16-char SHA-256 fingerprint
3. Single endpoint: prints fingerprint hash
4. Two endpoints: compares and reports match/mismatch with per-probe diff
5. Exit 0 on match, exit 1 on mismatch (CI-friendly)

Closes #119