### PR TITLE
feat(batch_compare): report schema versioning and load_report()

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -473,3 +473,13 @@
 - Exit 0 on match, exit 1 on mismatch (CI-friendly)
 - `fingerprint.py` module: `collect_fingerprint()`, `compare_fingerprints()`, dataclasses
 - 17 tests covering hash computation, comparison, mocked collection, edge cases
+
+## M56: Report Schema Version & Backward-Compatible Loading ✅
+- `REPORT_SCHEMA_VERSION` constant in `batch_compare.py` (starts at 1)
+- `to_json()` includes `schema_version` field in every exported report
+- `load_report(path)` function: deserialize JSON back to `BatchReport`
+- Backward compatible: reports without `schema_version` treated as version 1
+- Future-proof: raises `ValueError` if report version is newer than supported
+- Missing optional fields default gracefully (classification, context_length, request_ids)
+- Round-trip fidelity: confidence intervals, request IDs, all statistics preserved
+- 8 tests covering round-trip, missing version, future version, minimal fields, CI fields

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -16,6 +16,9 @@ from xpyd_acc.log import get_logger
 
 logger = get_logger("batch_compare")
 
+# Schema version for JSON report serialisation.  Bump when the report shape changes.
+REPORT_SCHEMA_VERSION = 1
+
 
 @dataclass
 class DatasetSample:
@@ -81,6 +84,7 @@ class BatchReport:
     def to_json(self) -> str:
         """Serialize the report to a JSON string."""
         data: dict[str, Any] = {
+            "schema_version": REPORT_SCHEMA_VERSION,
             "total_samples": self.total_samples,
             "divergent_samples": self.divergent_samples,
             "match_samples": self.match_samples,
@@ -115,6 +119,65 @@ class BatchReport:
             ],
         }
         return json.dumps(data, indent=2)
+
+
+def load_report(path: str | Path) -> BatchReport:
+    """Load a :class:`BatchReport` from a JSON file.
+
+    Validates the ``schema_version`` field.  Reports without a version are
+    treated as version 1 (backward-compatible).  If the version is newer than
+    the current :data:`REPORT_SCHEMA_VERSION`, a :class:`ValueError` is raised
+    so callers know the report was produced by a newer release.
+    """
+    path = Path(path)
+    with path.open() as f:
+        data = json.load(f)
+
+    version = data.get("schema_version", 1)
+    if version > REPORT_SCHEMA_VERSION:
+        msg = (
+            f"Report schema version {version} is newer than supported version "
+            f"{REPORT_SCHEMA_VERSION}. Please upgrade xpyd-acc."
+        )
+        raise ValueError(msg)
+
+    results: list[SampleResult] = []
+    for r in data.get("results", []):
+        results.append(
+            SampleResult(
+                sample_id=r["sample_id"],
+                prompt=r["prompt"],
+                baseline_output=r["baseline_output"],
+                target_output=r["target_output"],
+                exact_match=r["exact_match"],
+                first_divergence_index=r.get("first_divergence_index"),
+                baseline_logprob_at_divergence=r.get("baseline_logprob_at_divergence"),
+                target_logprob_at_divergence=r.get("target_logprob_at_divergence"),
+                logprob_gap=r.get("logprob_gap"),
+                classification=r.get("classification", "unknown"),
+                context_length=r.get("context_length", 0),
+                request_ids=r.get("request_ids", {}),
+            )
+        )
+
+    return BatchReport(
+        total_samples=data["total_samples"],
+        divergent_samples=data["divergent_samples"],
+        match_samples=data["match_samples"],
+        divergence_rate=data["divergence_rate"],
+        results=results,
+        divergence_index_mean=data.get("divergence_index_mean"),
+        divergence_index_median=data.get("divergence_index_median"),
+        logprob_gap_mean=data.get("logprob_gap_mean"),
+        logprob_gap_median=data.get("logprob_gap_median"),
+        likely_bugs=data.get("likely_bugs", 0),
+        likely_uncertainty=data.get("likely_uncertainty", 0),
+        unknown_classification=data.get("unknown_classification", 0),
+        divergence_by_context_length=data.get("divergence_by_context_length", {}),
+        divergence_ci_lower=data.get("divergence_ci_lower"),
+        divergence_ci_upper=data.get("divergence_ci_upper"),
+        confidence_level=data.get("confidence_level"),
+    )
 
 
 def load_dataset(path: str | Path) -> list[DatasetSample]:

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -1,0 +1,162 @@
+"""Tests for report schema versioning and load_report()."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.batch_compare import (
+    REPORT_SCHEMA_VERSION,
+    BatchReport,
+    SampleResult,
+    load_report,
+)
+
+
+def _make_sample(**overrides: object) -> SampleResult:
+    defaults = {
+        "sample_id": "s1",
+        "prompt": "hello",
+        "baseline_output": "world",
+        "target_output": "world",
+        "exact_match": True,
+        "first_divergence_index": None,
+        "baseline_logprob_at_divergence": None,
+        "target_logprob_at_divergence": None,
+        "logprob_gap": None,
+        "classification": "match",
+        "context_length": 5,
+    }
+    defaults.update(overrides)
+    return SampleResult(**defaults)  # type: ignore[arg-type]
+
+
+def _make_report(samples: list[SampleResult] | None = None) -> BatchReport:
+    samples = samples or [_make_sample()]
+    return BatchReport(
+        total_samples=len(samples),
+        divergent_samples=0,
+        match_samples=len(samples),
+        divergence_rate=0.0,
+        results=samples,
+    )
+
+
+# -- to_json includes schema_version ------------------------------------------
+
+def test_to_json_includes_schema_version() -> None:
+    report = _make_report()
+    data = json.loads(report.to_json())
+    assert data["schema_version"] == REPORT_SCHEMA_VERSION
+
+
+def test_schema_version_is_positive_int() -> None:
+    assert isinstance(REPORT_SCHEMA_VERSION, int)
+    assert REPORT_SCHEMA_VERSION >= 1
+
+
+# -- load_report round-trip ----------------------------------------------------
+
+def test_load_report_round_trip(tmp_path: Path) -> None:
+    report = _make_report([_make_sample(), _make_sample(sample_id="s2", exact_match=False,
+                                                         classification="likely_bug")])
+    report.divergent_samples = 1
+    report.match_samples = 1
+    report.divergence_rate = 0.5
+    report.likely_bugs = 1
+    path = tmp_path / "report.json"
+    path.write_text(report.to_json())
+
+    loaded = load_report(path)
+    assert loaded.total_samples == 2
+    assert loaded.divergent_samples == 1
+    assert loaded.divergence_rate == 0.5
+    assert loaded.likely_bugs == 1
+    assert len(loaded.results) == 2
+    assert loaded.results[0].sample_id == "s1"
+    assert loaded.results[1].classification == "likely_bug"
+
+
+# -- backward compat: missing schema_version treated as v1 --------------------
+
+def test_load_report_missing_version(tmp_path: Path) -> None:
+    """Reports produced before schema versioning have no schema_version field."""
+    data = json.loads(_make_report().to_json())
+    del data["schema_version"]
+    path = tmp_path / "old.json"
+    path.write_text(json.dumps(data))
+
+    loaded = load_report(path)
+    assert loaded.total_samples == 1
+
+
+# -- future version raises -----------------------------------------------------
+
+def test_load_report_future_version(tmp_path: Path) -> None:
+    data = json.loads(_make_report().to_json())
+    data["schema_version"] = REPORT_SCHEMA_VERSION + 1
+    path = tmp_path / "future.json"
+    path.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match="newer than supported"):
+        load_report(path)
+
+
+# -- missing optional fields default gracefully --------------------------------
+
+def test_load_report_missing_optional_fields(tmp_path: Path) -> None:
+    """Minimal JSON with only required fields should load without error."""
+    minimal: dict = {
+        "total_samples": 1,
+        "divergent_samples": 0,
+        "match_samples": 1,
+        "divergence_rate": 0.0,
+        "results": [
+            {
+                "sample_id": "s1",
+                "prompt": "hi",
+                "baseline_output": "ho",
+                "target_output": "ho",
+                "exact_match": True,
+            }
+        ],
+    }
+    path = tmp_path / "minimal.json"
+    path.write_text(json.dumps(minimal))
+
+    loaded = load_report(path)
+    assert loaded.total_samples == 1
+    assert loaded.results[0].classification == "unknown"
+    assert loaded.results[0].context_length == 0
+    assert loaded.results[0].request_ids == {}
+
+
+# -- confidence interval fields round-trip -------------------------------------
+
+def test_load_report_confidence_fields(tmp_path: Path) -> None:
+    report = _make_report()
+    report.divergence_ci_lower = 0.01
+    report.divergence_ci_upper = 0.15
+    report.confidence_level = 0.95
+    path = tmp_path / "ci.json"
+    path.write_text(report.to_json())
+
+    loaded = load_report(path)
+    assert loaded.divergence_ci_lower == 0.01
+    assert loaded.divergence_ci_upper == 0.15
+    assert loaded.confidence_level == 0.95
+
+
+# -- request_ids round-trip ----------------------------------------------------
+
+def test_load_report_request_ids(tmp_path: Path) -> None:
+    sample = _make_sample()
+    sample.request_ids = {"baseline": "abc-123", "target": "def-456"}
+    report = _make_report([sample])
+    path = tmp_path / "rid.json"
+    path.write_text(report.to_json())
+
+    loaded = load_report(path)
+    assert loaded.results[0].request_ids == {"baseline": "abc-123", "target": "def-456"}


### PR DESCRIPTION
## M56: Report Schema Version & Backward-Compatible Loading

Closes #121

### Changes
- Added `REPORT_SCHEMA_VERSION` constant (v1) to `batch_compare.py`
- `to_json()` now includes `schema_version` field in every exported report
- New `load_report(path)` function deserializes JSON back to `BatchReport`
  - Backward compatible: reports without `schema_version` treated as v1
  - Future-proof: raises `ValueError` if report version is newer than supported
  - Missing optional fields default gracefully
- 8 new tests in `tests/test_report_schema.py`
- Updated `ROADMAP.md` with M56 entry

### Testing
- All 739 existing tests pass
- 8 new tests pass
- Lint clean (ruff + isort)