### PR TITLE
feat: M58 — Dataset Statistics Command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -492,3 +492,14 @@
 - `--skip-validation` CLI flag for non-standard endpoints
 - TOML config: `[defaults] skip_validation = true`
 - 12 tests covering valid responses, missing fields, malformed structure, skip flag
+
+## M58: Dataset Statistics Command ✅
+- `xpyd-acc dataset-stats <path>` analyzes dataset before batch comparison
+- Character-level stats: min, max, mean, median, p95
+- Estimated token counts using word/0.75 heuristic
+- Duplicate prompt detection and count
+- Template rendering support via `--template <path>`
+- JSON export via `--json <path>`
+- Rich terminal output with stats tables
+- Works with JSONL, CSV, JSON array formats
+- 15 tests covering stats computation, duplicates, template, JSON export, CLI

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -612,6 +612,11 @@ def main(argv: list[str] | None = None) -> None:
     fp_cmd.add_argument("--retry-delay", type=float, default=1.0, help="Retry base delay")
     fp_cmd.add_argument("--timeout", type=float, default=30.0, help="HTTP timeout per request")
 
+    ds = sub.add_parser("dataset-stats", help="Analyze dataset before batch comparison")
+    ds.add_argument("dataset", help="Path to dataset file (JSONL, CSV, JSON)")
+    ds.add_argument("--template", help="Path to prompt template file")
+    ds.add_argument("--json", dest="json_path", help="Export stats as JSON")
+
     args = parser.parse_args(argv)
 
     # Setup logging from verbosity flags
@@ -784,6 +789,8 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_benchmark(args))
     elif args.command == "bisect":
         asyncio.run(_run_bisect(args))
+    elif args.command == "dataset-stats":
+        _run_dataset_stats(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -2544,3 +2551,18 @@ def _run_fingerprint(args: argparse.Namespace) -> None:
             print(f"\nExported to {args.fp_json}")
 
     asyncio.run(_go())
+
+
+def _run_dataset_stats(args: argparse.Namespace) -> None:
+    """Run dataset statistics analysis."""
+    from xpyd_acc.batch_compare import load_dataset
+    from xpyd_acc.dataset_stats import compute_stats, print_stats
+    from xpyd_acc.templates import load_template
+
+    samples = load_dataset(args.dataset)
+    template = load_template(args.template) if args.template else None
+    report = compute_stats(samples, template)
+    print_stats(report)
+    if args.json_path:
+        report.to_json(args.json_path)
+        print(f"\nExported to {args.json_path}")

--- a/src/xpyd_acc/dataset_stats.py
+++ b/src/xpyd_acc/dataset_stats.py
@@ -1,0 +1,146 @@
+"""Dataset statistics analysis for pre-flight inspection."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from rich.console import Console
+from rich.table import Table
+
+from xpyd_acc.batch_compare import DatasetSample
+from xpyd_acc.templates import PromptTemplate
+
+
+@dataclass
+class LengthStats:
+    """Distribution statistics for a sequence of lengths."""
+
+    min: int = 0
+    max: int = 0
+    mean: float = 0.0
+    median: float = 0.0
+    p95: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class DatasetStatsReport:
+    """Full dataset statistics report."""
+
+    sample_count: int = 0
+    char_stats: LengthStats = field(default_factory=LengthStats)
+    token_stats: LengthStats = field(default_factory=LengthStats)
+    duplicate_count: int = 0
+    unique_prompts: int = 0
+    duplicates: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sample_count": self.sample_count,
+            "char_stats": self.char_stats.to_dict(),
+            "token_stats": self.token_stats.to_dict(),
+            "duplicate_count": self.duplicate_count,
+            "unique_prompts": self.unique_prompts,
+            "duplicates": self.duplicates,
+        }
+
+    def to_json(self, path: str | Path) -> None:
+        """Export report as JSON."""
+        p = Path(path)
+        p.write_text(json.dumps(self.to_dict(), indent=2) + "\n")
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count using simple word/0.75 heuristic."""
+    words = len(text.split())
+    return max(1, math.ceil(words / 0.75)) if words > 0 else 0
+
+
+def _compute_length_stats(lengths: list[int]) -> LengthStats:
+    """Compute distribution stats from a list of lengths."""
+    if not lengths:
+        return LengthStats()
+    sorted_lengths = sorted(lengths)
+    n = len(sorted_lengths)
+    p95_idx = min(math.ceil(0.95 * n) - 1, n - 1)
+    return LengthStats(
+        min=sorted_lengths[0],
+        max=sorted_lengths[-1],
+        mean=round(statistics.mean(sorted_lengths), 2),
+        median=round(statistics.median(sorted_lengths), 2),
+        p95=round(float(sorted_lengths[p95_idx]), 2),
+    )
+
+
+def compute_stats(
+    samples: list[DatasetSample],
+    template: PromptTemplate | None = None,
+) -> DatasetStatsReport:
+    """Compute dataset statistics from loaded samples."""
+    if not samples:
+        return DatasetStatsReport()
+
+    prompts: list[str] = []
+    for s in samples:
+        if template is not None:
+            try:
+                prompts.append(template.render(s.metadata if s.metadata else {}))
+            except KeyError:
+                prompts.append(s.prompt)
+        else:
+            prompts.append(s.prompt)
+
+    char_lengths = [len(p) for p in prompts]
+    token_lengths = [estimate_tokens(p) for p in prompts]
+
+    counter = Counter(prompts)
+    duplicates = [
+        {"prompt": p[:120], "count": c} for p, c in counter.most_common() if c > 1
+    ]
+
+    return DatasetStatsReport(
+        sample_count=len(samples),
+        char_stats=_compute_length_stats(char_lengths),
+        token_stats=_compute_length_stats(token_lengths),
+        duplicate_count=sum(c - 1 for c in counter.values() if c > 1),
+        unique_prompts=len(counter),
+        duplicates=duplicates,
+    )
+
+
+def print_stats(report: DatasetStatsReport, console: Console | None = None) -> None:
+    """Print dataset stats to terminal using Rich."""
+    console = console or Console()
+
+    console.print(f"\n[bold]Dataset Statistics[/bold]  ({report.sample_count} samples)")
+    console.print(f"  Unique prompts: {report.unique_prompts}")
+    console.print(f"  Duplicate prompts: {report.duplicate_count}")
+
+    table = Table(title="Prompt Length Distribution")
+    table.add_column("Metric", style="cyan")
+    table.add_column("Characters", justify="right")
+    table.add_column("Est. Tokens", justify="right")
+
+    for label in ("min", "max", "mean", "median", "p95"):
+        table.add_row(
+            label,
+            str(getattr(report.char_stats, label)),
+            str(getattr(report.token_stats, label)),
+        )
+    console.print(table)
+
+    if report.duplicates:
+        dup_table = Table(title="Duplicate Prompts")
+        dup_table.add_column("Count", justify="right", style="red")
+        dup_table.add_column("Prompt (truncated)")
+        for d in report.duplicates[:10]:
+            dup_table.add_row(str(d["count"]), d["prompt"])
+        console.print(dup_table)

--- a/tests/test_dataset_stats.py
+++ b/tests/test_dataset_stats.py
@@ -1,0 +1,159 @@
+"""Tests for dataset_stats module."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xpyd_acc.batch_compare import DatasetSample
+from xpyd_acc.dataset_stats import (
+    DatasetStatsReport,
+    LengthStats,
+    _compute_length_stats,
+    compute_stats,
+    estimate_tokens,
+    print_stats,
+)
+
+
+def _make_sample(prompt: str, sid: str = "") -> DatasetSample:
+    return DatasetSample(id=sid or "s1", prompt=prompt)
+
+
+class TestEstimateTokens:
+    def test_empty(self) -> None:
+        assert estimate_tokens("") == 0
+
+    def test_single_word(self) -> None:
+        assert estimate_tokens("hello") == 2  # ceil(1/0.75)
+
+    def test_multiple_words(self) -> None:
+        result = estimate_tokens("the quick brown fox jumps")
+        assert result == 7  # ceil(5/0.75)
+
+
+class TestComputeLengthStats:
+    def test_empty(self) -> None:
+        stats = _compute_length_stats([])
+        assert stats == LengthStats()
+
+    def test_single(self) -> None:
+        stats = _compute_length_stats([42])
+        assert stats.min == 42
+        assert stats.max == 42
+        assert stats.mean == 42.0
+        assert stats.median == 42.0
+
+    def test_distribution(self) -> None:
+        lengths = list(range(1, 101))  # 1..100
+        stats = _compute_length_stats(lengths)
+        assert stats.min == 1
+        assert stats.max == 100
+        assert stats.mean == 50.5
+        assert stats.p95 == 95.0
+
+
+class TestComputeStats:
+    def test_empty(self) -> None:
+        report = compute_stats([])
+        assert report.sample_count == 0
+
+    def test_basic(self) -> None:
+        samples = [
+            _make_sample("short"),
+            _make_sample("a longer prompt here"),
+            _make_sample("short"),  # duplicate
+        ]
+        report = compute_stats(samples)
+        assert report.sample_count == 3
+        assert report.unique_prompts == 2
+        assert report.duplicate_count == 1
+        assert len(report.duplicates) == 1
+        assert report.duplicates[0]["count"] == 2
+        assert report.char_stats.min == 5
+        assert report.char_stats.max == 20
+
+    def test_no_duplicates(self) -> None:
+        samples = [_make_sample("a"), _make_sample("b"), _make_sample("c")]
+        report = compute_stats(samples)
+        assert report.duplicate_count == 0
+        assert report.duplicates == []
+
+    def test_with_template(self) -> None:
+        from xpyd_acc.templates import PromptTemplate
+
+        template = PromptTemplate(
+            name="test", template="Question: {question}\nAnswer:"
+        )
+        samples = [
+            DatasetSample(id="s1", prompt="ignored", metadata={"question": "Why?"}),
+            DatasetSample(id="s2", prompt="ignored", metadata={"question": "How?"}),
+        ]
+        report = compute_stats(samples, template)
+        assert report.sample_count == 2
+        # Template renders "Question: Why?\nAnswer:" which is > len("ignored")
+        assert report.char_stats.min > 10
+
+
+class TestJsonExport:
+    def test_to_json(self, tmp_path: Path) -> None:
+        samples = [_make_sample("hello world"), _make_sample("foo bar")]
+        report = compute_stats(samples)
+        out = tmp_path / "stats.json"
+        report.to_json(out)
+        data = json.loads(out.read_text())
+        assert data["sample_count"] == 2
+        assert "char_stats" in data
+        assert "token_stats" in data
+        assert data["unique_prompts"] == 2
+
+    def test_roundtrip_dict(self) -> None:
+        report = DatasetStatsReport(
+            sample_count=5,
+            char_stats=LengthStats(min=1, max=100, mean=50.0, median=45.0, p95=90.0),
+            token_stats=LengthStats(min=1, max=50, mean=25.0, median=22.0, p95=45.0),
+            duplicate_count=2,
+            unique_prompts=3,
+            duplicates=[{"prompt": "hi", "count": 3}],
+        )
+        d = report.to_dict()
+        assert d["sample_count"] == 5
+        assert d["char_stats"]["min"] == 1
+
+
+class TestPrintStats:
+    def test_print_no_crash(self) -> None:
+        from io import StringIO
+
+        from rich.console import Console
+
+        buf = StringIO()
+        console = Console(file=buf, force_terminal=False)
+        samples = [_make_sample("hello"), _make_sample("hello"), _make_sample("world")]
+        report = compute_stats(samples)
+        print_stats(report, console)
+        output = buf.getvalue()
+        assert "3 samples" in output
+        assert "Duplicate" in output
+
+
+class TestCLI:
+    def test_dataset_stats_jsonl(self, tmp_path: Path) -> None:
+        ds = tmp_path / "data.jsonl"
+        ds.write_text(
+            '{"prompt": "hello"}\n{"prompt": "world"}\n{"prompt": "hello"}\n'
+        )
+        out = tmp_path / "out.json"
+        from xpyd_acc.cli import main
+
+        main(["dataset-stats", str(ds), "--json", str(out)])
+        data = json.loads(out.read_text())
+        assert data["sample_count"] == 3
+        assert data["duplicate_count"] == 1
+
+    def test_dataset_stats_csv(self, tmp_path: Path) -> None:
+        ds = tmp_path / "data.csv"
+        ds.write_text("prompt\nhello\nworld\n")
+        from xpyd_acc.cli import main
+
+        main(["dataset-stats", str(ds)])  # just no crash


### PR DESCRIPTION
## Summary
Add `xpyd-acc dataset-stats <path>` subcommand for pre-flight dataset inspection before running expensive batch comparisons.

## Changes
- **New module:** `dataset_stats.py` with `compute_stats()`, `print_stats()`, `estimate_tokens()`
- **CLI:** `dataset-stats` subcommand with `--template` and `--json` flags
- **Stats:** Character/token length distribution (min, max, mean, median, p95)
- **Duplicates:** Detection and count of duplicate prompts
- **Template:** Optional prompt template rendering before analysis
- **Export:** JSON export for programmatic use
- **Tests:** 15 tests covering all functionality
- **ROADMAP:** Updated with M58

## Files Changed
- `src/xpyd_acc/dataset_stats.py` (new)
- `tests/test_dataset_stats.py` (new)
- `src/xpyd_acc/cli.py` (subcommand + handler)
- `ROADMAP.md` (M58 entry)

Closes #125