### PR TITLE
feat: M59 — Cost Estimation from API Usage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -503,3 +503,13 @@
 - Rich terminal output with stats tables
 - Works with JSONL, CSV, JSON array formats
 - 15 tests covering stats computation, duplicates, template, JSON export, CLI
+
+## M59: Cost Estimation from API Usage ✅
+- `cost.py` module: extract token usage from OpenAI-compatible API responses
+- `TokenUsage` dataclass: prompt_tokens, completion_tokens, total_tokens
+- `CostConfig`: configurable per-million-token pricing (input/output)
+- `UsageSummary`: aggregate usage across multiple requests with cost estimation
+- `extract_usage()` parses `usage` field from API response JSON
+- `format_usage_summary()` for terminal display
+- JSON export via `UsageSummary.to_json()`
+- 16 tests covering usage extraction, cost calculation, formatting, serialization

--- a/src/xpyd_acc/cost.py
+++ b/src/xpyd_acc/cost.py
@@ -1,0 +1,117 @@
+"""Cost estimation from API usage data.
+
+Tracks prompt_tokens and completion_tokens from API responses
+and estimates cost based on configurable per-token pricing.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class TokenUsage:
+    """Token usage for a single API call."""
+
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass
+class CostConfig:
+    """Per-token pricing configuration.
+
+    Prices are in USD per 1M tokens (industry standard notation).
+    """
+
+    input_price_per_m: float = 0.0
+    output_price_per_m: float = 0.0
+
+    def estimate(self, usage: TokenUsage) -> float:
+        """Estimate cost in USD for given token usage."""
+        input_cost = (usage.prompt_tokens / 1_000_000) * self.input_price_per_m
+        output_cost = (usage.completion_tokens / 1_000_000) * self.output_price_per_m
+        return input_cost + output_cost
+
+
+@dataclass
+class UsageSummary:
+    """Aggregated usage and cost for a batch run."""
+
+    total_prompt_tokens: int = 0
+    total_completion_tokens: int = 0
+    num_requests: int = 0
+    estimated_cost_usd: float | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        return self.total_prompt_tokens + self.total_completion_tokens
+
+    def add(self, usage: TokenUsage) -> None:
+        """Add a single request's usage."""
+        self.total_prompt_tokens += usage.prompt_tokens
+        self.total_completion_tokens += usage.completion_tokens
+        self.num_requests += 1
+
+    def apply_cost(self, config: CostConfig) -> None:
+        """Calculate estimated cost from a pricing config."""
+        total_usage = TokenUsage(
+            prompt_tokens=self.total_prompt_tokens,
+            completion_tokens=self.total_completion_tokens,
+        )
+        self.estimated_cost_usd = config.estimate(total_usage)
+
+    def to_dict(self) -> dict:
+        """Serialize to dictionary."""
+        d: dict = {
+            "total_prompt_tokens": self.total_prompt_tokens,
+            "total_completion_tokens": self.total_completion_tokens,
+            "total_tokens": self.total_tokens,
+            "num_requests": self.num_requests,
+        }
+        if self.estimated_cost_usd is not None:
+            d["estimated_cost_usd"] = round(self.estimated_cost_usd, 6)
+        return d
+
+    def to_json(self, path: str | Path) -> None:
+        """Write usage summary to JSON file."""
+        Path(path).write_text(json.dumps(self.to_dict(), indent=2) + "\n")
+
+
+def extract_usage(response_data: dict) -> TokenUsage:
+    """Extract token usage from an OpenAI-compatible API response.
+
+    Args:
+        response_data: Parsed JSON response body.
+
+    Returns:
+        TokenUsage with prompt and completion token counts.
+        Returns zero counts if usage field is missing.
+    """
+    usage = response_data.get("usage")
+    if not usage or not isinstance(usage, dict):
+        return TokenUsage()
+    return TokenUsage(
+        prompt_tokens=usage.get("prompt_tokens", 0),
+        completion_tokens=usage.get("completion_tokens", 0),
+    )
+
+
+def format_usage_summary(summary: UsageSummary) -> str:
+    """Format a usage summary for terminal display."""
+    lines = [
+        "Token Usage Summary",
+        f"  Requests:          {summary.num_requests:,}",
+        f"  Prompt tokens:     {summary.total_prompt_tokens:,}",
+        f"  Completion tokens: {summary.total_completion_tokens:,}",
+        f"  Total tokens:      {summary.total_tokens:,}",
+    ]
+    if summary.estimated_cost_usd is not None:
+        lines.append(f"  Estimated cost:    ${summary.estimated_cost_usd:.4f}")
+    return "\n".join(lines)

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,159 @@
+"""Tests for cost estimation module."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from xpyd_acc.cost import (
+    CostConfig,
+    TokenUsage,
+    UsageSummary,
+    extract_usage,
+    format_usage_summary,
+)
+
+
+class TestTokenUsage:
+    def test_total_tokens(self):
+        u = TokenUsage(prompt_tokens=100, completion_tokens=50)
+        assert u.total_tokens == 150
+
+    def test_defaults(self):
+        u = TokenUsage()
+        assert u.prompt_tokens == 0
+        assert u.completion_tokens == 0
+        assert u.total_tokens == 0
+
+
+class TestCostConfig:
+    def test_estimate_zero_price(self):
+        cfg = CostConfig()
+        usage = TokenUsage(prompt_tokens=1000, completion_tokens=500)
+        assert cfg.estimate(usage) == 0.0
+
+    def test_estimate_with_pricing(self):
+        # $3 per 1M input, $15 per 1M output
+        cfg = CostConfig(input_price_per_m=3.0, output_price_per_m=15.0)
+        usage = TokenUsage(prompt_tokens=1_000_000, completion_tokens=1_000_000)
+        assert cfg.estimate(usage) == 18.0
+
+    def test_estimate_fractional(self):
+        cfg = CostConfig(input_price_per_m=1.0, output_price_per_m=2.0)
+        usage = TokenUsage(prompt_tokens=500_000, completion_tokens=250_000)
+        cost = cfg.estimate(usage)
+        assert abs(cost - 1.0) < 1e-9  # 0.5 + 0.5
+
+
+class TestUsageSummary:
+    def test_add(self):
+        summary = UsageSummary()
+        summary.add(TokenUsage(prompt_tokens=100, completion_tokens=50))
+        summary.add(TokenUsage(prompt_tokens=200, completion_tokens=100))
+        assert summary.total_prompt_tokens == 300
+        assert summary.total_completion_tokens == 150
+        assert summary.total_tokens == 450
+        assert summary.num_requests == 2
+
+    def test_apply_cost(self):
+        summary = UsageSummary(
+            total_prompt_tokens=1_000_000,
+            total_completion_tokens=500_000,
+            num_requests=10,
+        )
+        cfg = CostConfig(input_price_per_m=3.0, output_price_per_m=15.0)
+        summary.apply_cost(cfg)
+        assert summary.estimated_cost_usd is not None
+        assert abs(summary.estimated_cost_usd - 10.5) < 1e-9
+
+    def test_to_dict_without_cost(self):
+        summary = UsageSummary(
+            total_prompt_tokens=100,
+            total_completion_tokens=50,
+            num_requests=1,
+        )
+        d = summary.to_dict()
+        assert d["total_prompt_tokens"] == 100
+        assert d["total_completion_tokens"] == 50
+        assert d["total_tokens"] == 150
+        assert d["num_requests"] == 1
+        assert "estimated_cost_usd" not in d
+
+    def test_to_dict_with_cost(self):
+        summary = UsageSummary(
+            total_prompt_tokens=100,
+            total_completion_tokens=50,
+            num_requests=1,
+            estimated_cost_usd=0.001234,
+        )
+        d = summary.to_dict()
+        assert d["estimated_cost_usd"] == 0.001234
+
+    def test_to_json(self):
+        summary = UsageSummary(
+            total_prompt_tokens=100,
+            total_completion_tokens=50,
+            num_requests=1,
+        )
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        summary.to_json(path)
+        data = json.loads(Path(path).read_text())
+        assert data["total_tokens"] == 150
+        Path(path).unlink()
+
+
+class TestExtractUsage:
+    def test_with_usage(self):
+        resp = {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {
+                "prompt_tokens": 42,
+                "completion_tokens": 10,
+            },
+        }
+        u = extract_usage(resp)
+        assert u.prompt_tokens == 42
+        assert u.completion_tokens == 10
+
+    def test_missing_usage(self):
+        resp = {"choices": [{"message": {"content": "hi"}}]}
+        u = extract_usage(resp)
+        assert u.prompt_tokens == 0
+        assert u.completion_tokens == 0
+
+    def test_null_usage(self):
+        resp = {"usage": None}
+        u = extract_usage(resp)
+        assert u.total_tokens == 0
+
+    def test_partial_usage(self):
+        resp = {"usage": {"prompt_tokens": 10}}
+        u = extract_usage(resp)
+        assert u.prompt_tokens == 10
+        assert u.completion_tokens == 0
+
+
+class TestFormatUsageSummary:
+    def test_format_without_cost(self):
+        summary = UsageSummary(
+            total_prompt_tokens=1000,
+            total_completion_tokens=500,
+            num_requests=5,
+        )
+        text = format_usage_summary(summary)
+        assert "1,000" in text
+        assert "500" in text
+        assert "$" not in text
+
+    def test_format_with_cost(self):
+        summary = UsageSummary(
+            total_prompt_tokens=1000,
+            total_completion_tokens=500,
+            num_requests=5,
+            estimated_cost_usd=0.0123,
+        )
+        text = format_usage_summary(summary)
+        assert "$" in text
+        assert "0.0123" in text


### PR DESCRIPTION
## Summary
Add `cost.py` module for tracking token usage and estimating API costs from OpenAI-compatible responses.

## Changes
- **`src/xpyd_acc/cost.py`**: New module with `TokenUsage`, `CostConfig`, `UsageSummary` dataclasses, `extract_usage()` parser, `format_usage_summary()` formatter, JSON export
- **`tests/test_cost.py`**: 16 tests covering all functionality
- **`ROADMAP.md`**: Added M59 milestone as complete

## Details
- `extract_usage()` gracefully handles missing/null/partial usage fields
- `CostConfig` uses industry-standard per-1M-token pricing
- `UsageSummary.to_json()` for programmatic export

Closes #127