### PR TITLE
feat: M60 — Cost Tracking Integration into Batch Compare

### DIFF
--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
 
+from xpyd_acc.cost import TokenUsage, UsageSummary, extract_usage, format_usage_summary
 from xpyd_acc.log import get_logger
 from xpyd_acc.response_validate import validate_chat_response
 
@@ -77,6 +78,8 @@ class BatchReport:
     divergence_ci_lower: float | None = None
     divergence_ci_upper: float | None = None
     confidence_level: float | None = None
+    # Token usage and cost tracking
+    usage: UsageSummary | None = None
 
     def to_markdown(self, *, max_divergent_samples: int = 10) -> str:
         """Serialize the report to a Markdown string."""
@@ -101,6 +104,7 @@ class BatchReport:
             "divergence_ci_lower": self.divergence_ci_lower,
             "divergence_ci_upper": self.divergence_ci_upper,
             "confidence_level": self.confidence_level,
+            "usage": self.usage.to_dict() if self.usage is not None else None,
             "results": [
                 {
                     "sample_id": r.sample_id,
@@ -161,6 +165,17 @@ def load_report(path: str | Path) -> BatchReport:
             )
         )
 
+    # Deserialise usage if present
+    usage_data = data.get("usage")
+    usage: UsageSummary | None = None
+    if usage_data is not None and isinstance(usage_data, dict):
+        usage = UsageSummary(
+            total_prompt_tokens=usage_data.get("total_prompt_tokens", 0),
+            total_completion_tokens=usage_data.get("total_completion_tokens", 0),
+            num_requests=usage_data.get("num_requests", 0),
+            estimated_cost_usd=usage_data.get("estimated_cost_usd"),
+        )
+
     return BatchReport(
         total_samples=data["total_samples"],
         divergent_samples=data["divergent_samples"],
@@ -178,6 +193,7 @@ def load_report(path: str | Path) -> BatchReport:
         divergence_ci_lower=data.get("divergence_ci_lower"),
         divergence_ci_upper=data.get("divergence_ci_upper"),
         confidence_level=data.get("confidence_level"),
+        usage=usage,
     )
 
 
@@ -328,7 +344,7 @@ async def _collect_output(
 ) -> tuple[str, list[dict[str, Any]], str]:
     """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list, request_id).
 
-    Returns a tuple of (generated_text, logprobs_per_token, request_id).
+    Returns a tuple of (generated_text, logprobs_per_token, request_id, token_usage).
     Each logprob entry has: {"token": str, "logprob": float, "top_logprobs": [...]}.
 
     Args:
@@ -347,7 +363,7 @@ async def _collect_output(
     if cache is not None:
         entry = cache.get(url, model, prompt, sp_dict)
         if entry is not None:
-            return entry.text, entry.logprobs, entry.request_id
+            return entry.text, entry.logprobs, entry.request_id, TokenUsage()
 
     payload: dict[str, Any] = {
         "model": model,
@@ -364,7 +380,7 @@ async def _collect_output(
         headers["X-Request-ID"] = rid
         logger.debug("Request ID %s for %s", rid, url)
 
-    async def _do_request() -> tuple[str, list[dict[str, Any]], str]:
+    async def _do_request() -> tuple[str, list[dict[str, Any]], str, TokenUsage]:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(
                 f"{url}/v1/chat/completions", json=payload, headers=headers,
@@ -376,9 +392,10 @@ async def _collect_output(
         choice = data["choices"][0]
         text = choice["message"]["content"]
         logprobs_content = choice.get("logprobs", {}).get("content", [])
-        return text, logprobs_content, rid
+        usage = extract_usage(data)
+        return text, logprobs_content, rid, usage
 
-    text, logprobs_list, out_rid = await retry_async(
+    text, logprobs_list, out_rid, usage = await retry_async(
         _do_request, retries=retries, base_delay=retry_delay,
     )
 
@@ -386,7 +403,7 @@ async def _collect_output(
     if cache is not None:
         cache.put(url, model, prompt, text, logprobs_list, out_rid, sp_dict)
 
-    return text, logprobs_list, out_rid
+    return text, logprobs_list, out_rid, usage
 
 
 async def run_batch(
@@ -446,14 +463,18 @@ async def run_batch(
 
     async def _collect_pair(
         prompt: str,
-    ) -> tuple[str, list[dict[str, Any]], str, str, list[dict[str, Any]], str]:
+    ) -> tuple[
+        str, list[dict[str, Any]], str,
+        str, list[dict[str, Any]], str,
+        TokenUsage, TokenUsage,
+    ]:
         """Collect outputs from both endpoints for a single prompt."""
         b_rid = str(uuid.uuid4()) if enable_request_ids else ""
         t_rid = str(uuid.uuid4()) if enable_request_ids else ""
         async with semaphore:
             if rate_limiter is not None:
                 await rate_limiter.acquire()
-            baseline_text, baseline_lp, b_rid_out = await _collect_output(
+            baseline_text, baseline_lp, b_rid_out, b_usage = await _collect_output(
                 baseline_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -464,7 +485,7 @@ async def run_batch(
             )
             if rate_limiter is not None:
                 await rate_limiter.acquire()
-            target_text, target_lp, t_rid_out = await _collect_output(
+            target_text, target_lp, t_rid_out, t_usage = await _collect_output(
                 target_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -473,7 +494,11 @@ async def run_batch(
                 cache=cache,
                 skip_validation=skip_validation,
             )
-        return baseline_text, baseline_lp, b_rid_out, target_text, target_lp, t_rid_out
+        return (
+            baseline_text, baseline_lp, b_rid_out,
+            target_text, target_lp, t_rid_out,
+            b_usage, t_usage,
+        )
 
     def _build_result(
         sample: DatasetSample,
@@ -532,15 +557,22 @@ async def run_batch(
             request_ids=req_ids,
         )
 
-    _PairResult = tuple[str, list[dict[str, Any]], str, str, list[dict[str, Any]], str]
+    _PairResult = tuple[
+        str, list[dict[str, Any]], str,
+        str, list[dict[str, Any]], str,
+        TokenUsage, TokenUsage,
+    ]
 
     if deduplicate:
         # Send unique prompts only, then fan out results
         total = len(unique_prompts)
+        usage_summary = UsageSummary()
 
         async def _tracked_unique(prompt: str) -> _PairResult:
             nonlocal completed
             result = await _collect_pair(prompt)
+            usage_summary.add(result[6])  # baseline usage
+            usage_summary.add(result[7])  # target usage
             completed += 1
             if on_progress is not None:
                 on_progress(completed, total)
@@ -557,31 +589,40 @@ async def run_batch(
         # Build results in original sample order
         all_results: list[SampleResult] = []
         for sample in samples:
-            bt, blp, brid, tt, tlp, trid = prompt_to_pair[sample.prompt]
+            bt, blp, brid, tt, tlp, trid, _bu, _tu = prompt_to_pair[sample.prompt]
             all_results.append(_build_result(sample, bt, blp, brid, tt, tlp, trid))
         results = all_results
 
-        return compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
+        report = compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
+        report.usage = usage_summary
+        return report
 
-    async def process_sample(sample: DatasetSample) -> SampleResult:
-        bt, blp, brid, tt, tlp, trid = await _collect_pair(sample.prompt)
-        return _build_result(sample, bt, blp, brid, tt, tlp, trid)
+    async def process_sample(sample: DatasetSample) -> tuple[SampleResult, TokenUsage, TokenUsage]:
+        bt, blp, brid, tt, tlp, trid, b_usage, t_usage = await _collect_pair(sample.prompt)
+        return _build_result(sample, bt, blp, brid, tt, tlp, trid), b_usage, t_usage
 
     total = len(samples)
+    usage_summary = UsageSummary()
 
-    async def _tracked_sample(sample: DatasetSample) -> SampleResult:
+    async def _tracked_sample(sample: DatasetSample) -> tuple[SampleResult, TokenUsage, TokenUsage]:
         nonlocal completed
-        result = await process_sample(sample)
+        result_tuple = await process_sample(sample)
         completed += 1
         if on_progress is not None:
             on_progress(completed, total)
-        return result
+        return result_tuple
 
     tasks = [_tracked_sample(s) for s in samples]
-    results = await asyncio.gather(*tasks)
-    results = list(results)
+    raw_results = await asyncio.gather(*tasks)
+    results = []
+    for sr, b_u, t_u in raw_results:
+        results.append(sr)
+        usage_summary.add(b_u)
+        usage_summary.add(t_u)
 
-    return compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
+    report = compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
+    report.usage = usage_summary
+    return report
 
 
 def compute_report(
@@ -735,6 +776,10 @@ def format_report(report: BatchReport) -> str:
                     f"  {bucket:>10s}: {stats['divergent']}/{stats['total']} ({rate:.1%})"
                 )
 
+    if report.usage is not None:
+        lines.append("")
+        lines.append(format_usage_summary(report.usage))
+
     return "\n".join(lines)
 
 
@@ -826,6 +871,19 @@ def _to_markdown(report: BatchReport, *, max_divergent_samples: int = 10) -> str
                 lines.append(f"- **Target:** `{target_preview}`")
                 lines.append("")
 
+    if report.usage is not None:
+        lines.append("## Token Usage")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Requests | {report.usage.num_requests:,} |")
+        lines.append(f"| Prompt tokens | {report.usage.total_prompt_tokens:,} |")
+        lines.append(f"| Completion tokens | {report.usage.total_completion_tokens:,} |")
+        lines.append(f"| Total tokens | {report.usage.total_tokens:,} |")
+        if report.usage.estimated_cost_usd is not None:
+            lines.append(f"| Estimated cost | ${report.usage.estimated_cost_usd:.4f} |")
+        lines.append("")
+
     return "\n".join(lines)
 
 
@@ -838,6 +896,7 @@ class MultiTargetBatchReport:
     per_target: dict[str, BatchReport]
     agreement_matrix: dict[str, dict[str, float]]  # target_url -> target_url -> agreement rate
     total_samples: int
+    usage: UsageSummary | None = None
 
     def to_json(self) -> str:
         """Serialize to JSON string."""
@@ -966,15 +1025,18 @@ async def run_multi_batch(
     semaphore = asyncio.Semaphore(concurrency)
 
     # Step 1: Collect baseline outputs for all samples
+    usage_summary = UsageSummary()
+
     async def collect_baseline(sample: DatasetSample) -> tuple[str, str, list[dict[str, Any]]]:
         async with semaphore:
-            text, lp, _rid = await _collect_output(
+            text, lp, _rid, b_usage = await _collect_output(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
                 sampling_params=sampling_params, timeout=timeout,
                 skip_validation=skip_validation,
             )
+        usage_summary.add(b_usage)
         return sample.id, text, lp
 
     baseline_tasks = [collect_baseline(s) for s in samples]
@@ -992,13 +1054,14 @@ async def run_multi_batch(
     ) -> SampleResult:
         nonlocal completed
         async with semaphore:
-            target_text, target_lp, _rid = await _collect_output(
+            target_text, target_lp, _rid, t_usage = await _collect_output(
                 target_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
                 sampling_params=sampling_params, timeout=timeout,
                 skip_validation=skip_validation,
             )
+        usage_summary.add(t_usage)
 
         baseline_text, baseline_lp = baseline_outputs[sample.id]
         b_tokens = _tokenize(baseline_text)
@@ -1061,6 +1124,7 @@ async def run_multi_batch(
         per_target=per_target,
         agreement_matrix=agreement_matrix,
         total_samples=len(samples),
+        usage=usage_summary,
     )
 
 

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -245,6 +245,14 @@ def main(argv: list[str] | None = None) -> None:
         "--webhook-always", action="store_true", default=False,
         help="Send webhook on every run, not just on divergence",
     )
+    bc.add_argument(
+        "--input-price", type=float, default=None,
+        help="Input token price per 1M tokens (USD) for cost estimation",
+    )
+    bc.add_argument(
+        "--output-price", type=float, default=None,
+        help="Output token price per 1M tokens (USD) for cost estimation",
+    )
 
     # Cache management subcommand
     cache_cmd = sub.add_parser("cache", help="Manage response cache")
@@ -1082,6 +1090,9 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         if cs.hits + cs.misses > 0:
             print(f"\nCache: {cs.hits} hits, {cs.misses} misses ({cs.hit_rate:.0%} hit rate)")
 
+    # Apply cost estimation if pricing is configured
+    _apply_cost_to_report(args, report if report is not None else multi_report)
+
     if multi_report is not None:
         # Multi-target mode
         for url in target_urls:
@@ -1225,6 +1236,41 @@ async def _maybe_send_webhook(
         divergence_rate=rate,
     )
     await send_webhook(config, payload)
+
+
+def _apply_cost_to_report(
+    args: argparse.Namespace,
+    report: object,
+) -> None:
+    """Apply cost estimation to report usage if pricing is configured."""
+    from xpyd_acc.cost import CostConfig
+
+    input_price = getattr(args, "input_price", None)
+    output_price = getattr(args, "output_price", None)
+
+    # Fall back to TOML config
+    config = getattr(args, "_config", None)
+    if config is not None:
+        cost_cfg = getattr(config, "cost", None)
+        if cost_cfg is not None:
+            if input_price is None:
+                input_price = getattr(cost_cfg, "input_price_per_m", None) or None
+            if output_price is None:
+                output_price = getattr(cost_cfg, "output_price_per_m", None) or None
+
+    # If neither price is set, nothing to do
+    if not input_price and not output_price:
+        return
+
+    usage = getattr(report, "usage", None)
+    if usage is None:
+        return
+
+    cost_config = CostConfig(
+        input_price_per_m=input_price or 0.0,
+        output_price_per_m=output_price or 0.0,
+    )
+    usage.apply_cost(cost_config)
 
 
 def _maybe_apply_confidence(

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -88,6 +88,14 @@ class MatchingConfig:
 
 
 @dataclass
+class CostTrackingConfig:
+    """Cost tracking configuration."""
+
+    input_price_per_m: float = 0.0
+    output_price_per_m: float = 0.0
+
+
+@dataclass
 class AppConfig:
     """Top-level application configuration."""
 
@@ -96,6 +104,7 @@ class AppConfig:
     kv: KVConfig = field(default_factory=KVConfig)
     report: ReportConfig = field(default_factory=ReportConfig)
     matching: MatchingConfig = field(default_factory=MatchingConfig)
+    cost: CostTrackingConfig = field(default_factory=CostTrackingConfig)
     profiles_raw: dict[str, Any] = field(default_factory=dict)
 
 
@@ -131,11 +140,12 @@ def load_config(path: str | Path) -> AppConfig:
     kv = _parse_section(raw.get("kv", {}), KVConfig)
     report = _parse_section(raw.get("report", {}), ReportConfig)
     matching = _parse_section(raw.get("matching", {}), MatchingConfig)
+    cost = _parse_section(raw.get("cost", {}), CostTrackingConfig)
     profiles_raw = raw.get("profiles", {})
 
     return AppConfig(
         defaults=defaults, batch=batch, kv=kv, report=report,
-        matching=matching, profiles_raw=profiles_raw,
+        matching=matching, cost=cost, profiles_raw=profiles_raw,
     )
 
 

--- a/src/xpyd_acc/config_validate.py
+++ b/src/xpyd_acc/config_validate.py
@@ -23,6 +23,7 @@ from typing import Any
 
 from xpyd_acc.config import (
     BatchConfig,
+    CostTrackingConfig,
     DefaultsConfig,
     KVConfig,
     MatchingConfig,
@@ -36,6 +37,7 @@ _SECTION_MAP: dict[str, type] = {
     "kv": KVConfig,
     "report": ReportConfig,
     "matching": MatchingConfig,
+    "cost": CostTrackingConfig,
     "profiles": dict,  # special: profiles are free-form
 }
 
@@ -92,6 +94,10 @@ STARTER_CONFIG = """\
 # ignore_case = false
 # numeric_tolerance = 0.001
 # normalizers = ["strip_thinking_tags"]
+
+[cost]
+# input_price_per_m = 0.0   # USD per 1M input tokens
+# output_price_per_m = 0.0  # USD per 1M output tokens
 
 # [profiles.greedy]
 # temperature = 0.0

--- a/src/xpyd_acc/snapshot.py
+++ b/src/xpyd_acc/snapshot.py
@@ -80,7 +80,7 @@ async def capture_snapshot(
     async def _capture_one(sample: DatasetSample) -> SnapshotSample:
         nonlocal completed
         async with semaphore:
-            text, logprobs, _rid = await _collect_output(
+            text, logprobs, _rid, _usage = await _collect_output(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -331,6 +331,7 @@ class TestOnProgressCallback:
         from unittest.mock import AsyncMock, patch
 
         from xpyd_acc.batch_compare import DatasetSample, run_batch
+        from xpyd_acc.cost import TokenUsage
 
         samples = [
             DatasetSample(id="0", prompt="hello"),
@@ -338,7 +339,7 @@ class TestOnProgressCallback:
             DatasetSample(id="2", prompt="test"),
         ]
 
-        mock_output = ("response text", [], "")
+        mock_output = ("response text", [], "", TokenUsage())
 
         progress_calls: list[tuple[int, int]] = []
 
@@ -369,9 +370,10 @@ class TestOnProgressCallback:
         from unittest.mock import AsyncMock, patch
 
         from xpyd_acc.batch_compare import DatasetSample, run_batch
+        from xpyd_acc.cost import TokenUsage
 
         samples = [DatasetSample(id="0", prompt="hello")]
-        mock_output = ("response", [], "")
+        mock_output = ("response", [], "", TokenUsage())
 
         with patch("xpyd_acc.batch_compare._collect_output", new_callable=AsyncMock) as mock_co:
             mock_co.return_value = mock_output

--- a/tests/test_cost_integration.py
+++ b/tests/test_cost_integration.py
@@ -1,0 +1,217 @@
+"""Tests for M60: Cost Tracking Integration into Batch Compare."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_acc.batch_compare import (
+    compute_report,
+    format_report,
+    load_report,
+)
+from xpyd_acc.cost import CostConfig, TokenUsage, UsageSummary
+
+
+class TestBatchReportUsageField:
+    def test_default_none(self):
+        report = compute_report([])
+        assert report.usage is None
+
+    def test_usage_attached(self):
+        report = compute_report([])
+        usage = UsageSummary(
+            total_prompt_tokens=100,
+            total_completion_tokens=50,
+            num_requests=2,
+        )
+        report.usage = usage
+        assert report.usage is not None
+        assert report.usage.total_tokens == 150
+
+
+class TestBatchReportToJsonWithUsage:
+    def test_usage_in_json(self):
+        report = compute_report([])
+        report.usage = UsageSummary(
+            total_prompt_tokens=1000,
+            total_completion_tokens=500,
+            num_requests=5,
+        )
+        data = json.loads(report.to_json())
+        assert data["usage"] is not None
+        assert data["usage"]["total_prompt_tokens"] == 1000
+        assert data["usage"]["total_completion_tokens"] == 500
+        assert data["usage"]["total_tokens"] == 1500
+        assert data["usage"]["num_requests"] == 5
+
+    def test_no_usage_in_json(self):
+        report = compute_report([])
+        data = json.loads(report.to_json())
+        assert data["usage"] is None
+
+    def test_usage_with_cost_in_json(self):
+        report = compute_report([])
+        usage = UsageSummary(
+            total_prompt_tokens=1_000_000,
+            total_completion_tokens=500_000,
+            num_requests=10,
+        )
+        cost_cfg = CostConfig(input_price_per_m=3.0, output_price_per_m=15.0)
+        usage.apply_cost(cost_cfg)
+        report.usage = usage
+        data = json.loads(report.to_json())
+        assert data["usage"]["estimated_cost_usd"] == 10.5
+
+
+class TestLoadReportWithUsage:
+    def test_round_trip(self):
+        report = compute_report([])
+        report.usage = UsageSummary(
+            total_prompt_tokens=200,
+            total_completion_tokens=100,
+            num_requests=3,
+            estimated_cost_usd=0.005,
+        )
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        Path(path).write_text(report.to_json())
+        loaded = load_report(path)
+        assert loaded.usage is not None
+        assert loaded.usage.total_prompt_tokens == 200
+        assert loaded.usage.total_completion_tokens == 100
+        assert loaded.usage.num_requests == 3
+        assert loaded.usage.estimated_cost_usd == 0.005
+        Path(path).unlink()
+
+    def test_load_report_without_usage(self):
+        report = compute_report([])
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            path = f.name
+        Path(path).write_text(report.to_json())
+        loaded = load_report(path)
+        assert loaded.usage is None
+        Path(path).unlink()
+
+
+class TestFormatReportWithUsage:
+    def test_usage_displayed(self):
+        report = compute_report([])
+        report.usage = UsageSummary(
+            total_prompt_tokens=1000,
+            total_completion_tokens=500,
+            num_requests=5,
+        )
+        text = format_report(report)
+        assert "Token Usage Summary" in text
+        assert "1,000" in text
+        assert "500" in text
+
+    def test_usage_with_cost_displayed(self):
+        report = compute_report([])
+        usage = UsageSummary(
+            total_prompt_tokens=1000,
+            total_completion_tokens=500,
+            num_requests=5,
+        )
+        usage.estimated_cost_usd = 0.0123
+        report.usage = usage
+        text = format_report(report)
+        assert "$" in text
+        assert "0.0123" in text
+
+    def test_no_usage_no_section(self):
+        report = compute_report([])
+        text = format_report(report)
+        assert "Token Usage" not in text
+
+
+class TestMarkdownWithUsage:
+    def test_usage_in_markdown(self):
+        report = compute_report([])
+        report.usage = UsageSummary(
+            total_prompt_tokens=2000,
+            total_completion_tokens=800,
+            num_requests=10,
+        )
+        md = report.to_markdown()
+        assert "## Token Usage" in md
+        assert "2,000" in md
+        assert "800" in md
+
+    def test_no_usage_no_section_in_markdown(self):
+        report = compute_report([])
+        md = report.to_markdown()
+        assert "## Token Usage" not in md
+
+
+class TestCostConfigIntegration:
+    def test_toml_cost_section(self):
+        from xpyd_acc.config import load_config
+
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+            f.write("[cost]\ninput_price_per_m = 3.0\noutput_price_per_m = 15.0\n")
+            path = f.name
+        config = load_config(path)
+        assert config.cost.input_price_per_m == 3.0
+        assert config.cost.output_price_per_m == 15.0
+        Path(path).unlink()
+
+    def test_toml_no_cost_section(self):
+        from xpyd_acc.config import load_config
+
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+            f.write("[defaults]\nmodel = 'test'\n")
+            path = f.name
+        config = load_config(path)
+        assert config.cost.input_price_per_m == 0.0
+        assert config.cost.output_price_per_m == 0.0
+        Path(path).unlink()
+
+
+class TestConfigValidateWithCost:
+    def test_cost_section_valid(self):
+        from xpyd_acc.config_validate import validate_config
+
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+            f.write("[cost]\ninput_price_per_m = 3.0\noutput_price_per_m = 15.0\n")
+            path = f.name
+        messages = validate_config(Path(path))
+        assert messages == []
+        Path(path).unlink()
+
+    def test_cost_section_unknown_key(self):
+        from xpyd_acc.config_validate import validate_config
+
+        with tempfile.NamedTemporaryFile(suffix=".toml", delete=False, mode="w") as f:
+            f.write("[cost]\nbogus_key = 1.0\n")
+            path = f.name
+        messages = validate_config(Path(path))
+        assert any("bogus_key" in m for m in messages)
+        Path(path).unlink()
+
+
+class TestCollectOutputReturnsUsage:
+    """Test that _collect_output returns TokenUsage as 4th element."""
+
+    @pytest.mark.asyncio
+    async def test_collect_output_returns_usage(self):
+        from xpyd_acc.batch_compare import _collect_output
+
+        with patch("xpyd_acc.retry.retry_async") as mock_retry:
+            mock_retry.return_value = (
+                "hello",
+                [],
+                "rid-123",
+                TokenUsage(prompt_tokens=10, completion_tokens=5),
+            )
+            text, lp, rid, usage = await _collect_output(
+                "http://fake", "test prompt",
+                skip_validation=True,
+            )
+            assert usage.prompt_tokens == 10
+            assert usage.completion_tokens == 5

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, patch
 
 from xpyd_acc.batch_compare import DatasetSample, run_batch
+from xpyd_acc.cost import TokenUsage
 
 
 def test_deduplicate_reduces_api_calls() -> None:
@@ -16,7 +17,7 @@ def test_deduplicate_reduces_api_calls() -> None:
         DatasetSample(id="3", prompt="What is 3+3?"),
         DatasetSample(id="4", prompt="What is 2+2?"),  # duplicate
     ]
-    mock_output = ("hello world", [], "")
+    mock_output = ("hello world", [], "", TokenUsage())
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -44,7 +45,7 @@ def test_no_deduplicate_sends_all_calls() -> None:
         DatasetSample(id="2", prompt="What is 2+2?"),
         DatasetSample(id="3", prompt="What is 3+3?"),
     ]
-    mock_output = ("hello world", [], "")
+    mock_output = ("hello world", [], "", TokenUsage())
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -71,7 +72,7 @@ def test_deduplicate_no_duplicates() -> None:
         DatasetSample(id="2", prompt="What is 3+3?"),
         DatasetSample(id="3", prompt="What is 4+4?"),
     ]
-    mock_output = ("hello world", [], "")
+    mock_output = ("hello world", [], "", TokenUsage())
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -98,7 +99,7 @@ def test_deduplicate_preserves_sample_ids() -> None:
         DatasetSample(id="b", prompt="prompt1"),
         DatasetSample(id="c", prompt="prompt2"),
     ]
-    mock_output = ("hello world", [], "")
+    mock_output = ("hello world", [], "", TokenUsage())
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -124,7 +125,7 @@ def test_deduplicate_progress_callback() -> None:
         DatasetSample(id="2", prompt="p1"),
         DatasetSample(id="3", prompt="p2"),
     ]
-    mock_output = ("hello", [], "")
+    mock_output = ("hello", [], "", TokenUsage())
     progress_calls: list[tuple[int, int]] = []
 
     def on_progress(done: int, total: int) -> None:

--- a/tests/test_multi_target.py
+++ b/tests/test_multi_target.py
@@ -15,6 +15,7 @@ from xpyd_acc.batch_compare import (
     compute_report,
     run_multi_batch,
 )
+from xpyd_acc.cost import TokenUsage
 
 
 def _make_sample_result(
@@ -161,10 +162,10 @@ class TestRunMultiBatch:
             nonlocal call_count
             call_count += 1
             if "base" in url:
-                return "baseline output", [], ""
+                return "baseline output", [], "", TokenUsage()
             if "t1" in url:
-                return "baseline output", [], ""  # matches
-            return "different output", [], ""  # diverges
+                return "baseline output", [], "", TokenUsage()  # matches
+            return "different output", [], "", TokenUsage()  # diverges
 
         with patch("xpyd_acc.batch_compare._collect_output", side_effect=mock_collect):
             report = await run_multi_batch(
@@ -188,7 +189,7 @@ class TestRunMultiBatch:
         ]
 
         async def mock_collect(url, prompt, **kwargs):
-            return "output", [], ""
+            return "output", [], "", TokenUsage()
 
         progress_calls: list[tuple[int, int]] = []
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -97,7 +97,7 @@ class TestCollectOutputRequestId:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            text, lp, returned_rid = await _collect_output(
+            text, lp, returned_rid, _usage = await _collect_output(
                 "http://test:8000", "hello",
                 request_id=rid,
             )
@@ -131,7 +131,7 @@ class TestCollectOutputRequestId:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            text, lp, returned_rid = await _collect_output(
+            text, lp, returned_rid, _usage = await _collect_output(
                 "http://test:8000", "hello",
                 request_id=None,
             )

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from xpyd_acc.batch_compare import DatasetSample
+from xpyd_acc.cost import TokenUsage
 from xpyd_acc.snapshot import (
     Snapshot,
     SnapshotSample,
@@ -146,7 +147,7 @@ class TestCaptureSnapshot:
         async def mock_collect(url, prompt, **kwargs):
             nonlocal call_count
             call_count += 1
-            return (f"reply-{prompt}", [{"token": "r", "logprob": -0.1}], "")
+            return (f"reply-{prompt}", [{"token": "r", "logprob": -0.1}], "", TokenUsage())
 
         with patch("xpyd_acc.snapshot._collect_output", side_effect=mock_collect):
             snap = await capture_snapshot(
@@ -167,7 +168,7 @@ class TestCaptureSnapshot:
         progress_calls = []
 
         async def mock_collect(url, prompt, **kwargs):
-            return ("out", [], "")
+            return ("out", [], "", TokenUsage())
 
         with patch("xpyd_acc.snapshot._collect_output", side_effect=mock_collect):
             await capture_snapshot(


### PR DESCRIPTION
## Summary
Integrates the existing `cost.py` module (M59) into the batch comparison pipeline so users can see token usage and estimated costs after a batch run.

## Changes
- `_collect_output()` now extracts and returns `TokenUsage` from API responses
- `BatchReport` and `MultiTargetBatchReport` gain `usage: UsageSummary | None` field
- `format_report()` displays token usage summary when available
- `to_json()` includes usage data; `load_report()` round-trips it
- `to_markdown()` includes a Token Usage table section
- CLI flags: `--input-price`, `--output-price` (USD per 1M tokens)
- TOML config: `[cost]` section with `input_price_per_m`, `output_price_per_m`
- `config_validate` recognizes the new `[cost]` section
- Starter config template includes commented `[cost]` section

## Tests
- 17 new tests in `test_cost_integration.py`
- Updated existing tests (`test_batch_compare`, `test_deduplicate`, `test_multi_target`, `test_request_id`, `test_snapshot`) for 4-tuple return from `_collect_output`
- All 803 tests pass

Closes #129