### PR TITLE
feat: add output truncation detection (M61)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -524,3 +524,17 @@
 - `load_report()` round-trips usage data
 - `MultiTargetBatchReport` also tracks aggregate usage
 - 17 tests covering integration, round-trip, config, CLI flags
+
+## M61: Output Truncation Detection ✅
+- `_collect_output()` extracts and returns `finish_reason` from API responses
+- `SampleResult` has `baseline_finish_reason` and `target_finish_reason` fields
+- `BatchReport` has `truncated_count` field (samples where either finish_reason is "length")
+- `compute_report()` counts truncated samples automatically
+- `format_report()` shows truncated count with ⚠️ when non-zero
+- `to_json()` includes `finish_reason` per result and `truncated_count` in report
+- `to_markdown()` shows truncation summary and flags truncated divergent samples
+- `load_report()` deserializes truncation fields; backward-compatible with v1 reports
+- Report schema version bumped to 2
+- CLI `--warn-truncated <float>` flag: exit 2 if truncated ratio exceeds threshold
+- TOML config: `[batch] warn_truncated = 0.1`
+- 18 tests covering detection, classification, JSON round-trip, backward compat, formatting

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -19,7 +19,7 @@ from xpyd_acc.response_validate import validate_chat_response
 logger = get_logger("batch_compare")
 
 # Schema version for JSON report serialisation.  Bump when the report shape changes.
-REPORT_SCHEMA_VERSION = 1
+REPORT_SCHEMA_VERSION = 2
 
 
 @dataclass
@@ -49,6 +49,8 @@ class SampleResult:
     context_length: int  # number of prompt tokens (approximated)
     # Map of role to UUID, e.g. {"baseline": "...", "target": "..."}
     request_ids: dict[str, str] = field(default_factory=dict)
+    baseline_finish_reason: str | None = None
+    target_finish_reason: str | None = None
 
     def is_divergent(self) -> bool:
         """Whether this sample diverged."""
@@ -80,6 +82,8 @@ class BatchReport:
     confidence_level: float | None = None
     # Token usage and cost tracking
     usage: UsageSummary | None = None
+    # Truncation tracking
+    truncated_count: int = 0
 
     def to_markdown(self, *, max_divergent_samples: int = 10) -> str:
         """Serialize the report to a Markdown string."""
@@ -104,6 +108,7 @@ class BatchReport:
             "divergence_ci_lower": self.divergence_ci_lower,
             "divergence_ci_upper": self.divergence_ci_upper,
             "confidence_level": self.confidence_level,
+            "truncated_count": self.truncated_count,
             "usage": self.usage.to_dict() if self.usage is not None else None,
             "results": [
                 {
@@ -119,6 +124,8 @@ class BatchReport:
                     "classification": r.classification,
                     "context_length": r.context_length,
                     "request_ids": r.request_ids,
+                    "baseline_finish_reason": r.baseline_finish_reason,
+                    "target_finish_reason": r.target_finish_reason,
                 }
                 for r in self.results
             ],
@@ -162,6 +169,8 @@ def load_report(path: str | Path) -> BatchReport:
                 classification=r.get("classification", "unknown"),
                 context_length=r.get("context_length", 0),
                 request_ids=r.get("request_ids", {}),
+                baseline_finish_reason=r.get("baseline_finish_reason"),
+                target_finish_reason=r.get("target_finish_reason"),
             )
         )
 
@@ -194,6 +203,7 @@ def load_report(path: str | Path) -> BatchReport:
         divergence_ci_upper=data.get("divergence_ci_upper"),
         confidence_level=data.get("confidence_level"),
         usage=usage,
+        truncated_count=data.get("truncated_count", 0),
     )
 
 
@@ -344,7 +354,7 @@ async def _collect_output(
 ) -> tuple[str, list[dict[str, Any]], str]:
     """Send prompt to an OpenAI-compatible endpoint, return (text, logprobs_list, request_id).
 
-    Returns a tuple of (generated_text, logprobs_per_token, request_id, token_usage).
+    Returns a tuple of (generated_text, logprobs_per_token, request_id, token_usage, finish_reason).
     Each logprob entry has: {"token": str, "logprob": float, "top_logprobs": [...]}.
 
     Args:
@@ -363,7 +373,7 @@ async def _collect_output(
     if cache is not None:
         entry = cache.get(url, model, prompt, sp_dict)
         if entry is not None:
-            return entry.text, entry.logprobs, entry.request_id, TokenUsage()
+            return entry.text, entry.logprobs, entry.request_id, TokenUsage(), None
 
     payload: dict[str, Any] = {
         "model": model,
@@ -380,7 +390,7 @@ async def _collect_output(
         headers["X-Request-ID"] = rid
         logger.debug("Request ID %s for %s", rid, url)
 
-    async def _do_request() -> tuple[str, list[dict[str, Any]], str, TokenUsage]:
+    async def _do_request() -> tuple[str, list[dict[str, Any]], str, TokenUsage, str | None]:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(
                 f"{url}/v1/chat/completions", json=payload, headers=headers,
@@ -393,9 +403,10 @@ async def _collect_output(
         text = choice["message"]["content"]
         logprobs_content = choice.get("logprobs", {}).get("content", [])
         usage = extract_usage(data)
-        return text, logprobs_content, rid, usage
+        finish_reason = choice.get("finish_reason")
+        return text, logprobs_content, rid, usage, finish_reason
 
-    text, logprobs_list, out_rid, usage = await retry_async(
+    text, logprobs_list, out_rid, usage, finish_reason = await retry_async(
         _do_request, retries=retries, base_delay=retry_delay,
     )
 
@@ -403,7 +414,7 @@ async def _collect_output(
     if cache is not None:
         cache.put(url, model, prompt, text, logprobs_list, out_rid, sp_dict)
 
-    return text, logprobs_list, out_rid, usage
+    return text, logprobs_list, out_rid, usage, finish_reason
 
 
 async def run_batch(
@@ -467,6 +478,7 @@ async def run_batch(
         str, list[dict[str, Any]], str,
         str, list[dict[str, Any]], str,
         TokenUsage, TokenUsage,
+        str | None, str | None,
     ]:
         """Collect outputs from both endpoints for a single prompt."""
         b_rid = str(uuid.uuid4()) if enable_request_ids else ""
@@ -474,7 +486,7 @@ async def run_batch(
         async with semaphore:
             if rate_limiter is not None:
                 await rate_limiter.acquire()
-            baseline_text, baseline_lp, b_rid_out, b_usage = await _collect_output(
+            baseline_text, baseline_lp, b_rid_out, b_usage, b_finish = await _collect_output(
                 baseline_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -485,7 +497,7 @@ async def run_batch(
             )
             if rate_limiter is not None:
                 await rate_limiter.acquire()
-            target_text, target_lp, t_rid_out, t_usage = await _collect_output(
+            target_text, target_lp, t_rid_out, t_usage, t_finish = await _collect_output(
                 target_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -498,6 +510,7 @@ async def run_batch(
             baseline_text, baseline_lp, b_rid_out,
             target_text, target_lp, t_rid_out,
             b_usage, t_usage,
+            b_finish, t_finish,
         )
 
     def _build_result(
@@ -508,6 +521,8 @@ async def run_batch(
         target_text: str,
         target_lp: list[dict[str, Any]],
         t_rid_out: str,
+        baseline_finish_reason: str | None = None,
+        target_finish_reason: str | None = None,
     ) -> SampleResult:
         """Build a SampleResult from collected outputs."""
         b_tokens = _tokenize(baseline_text)
@@ -555,12 +570,15 @@ async def run_batch(
             classification=classification,
             context_length=ctx_len,
             request_ids=req_ids,
+            baseline_finish_reason=baseline_finish_reason,
+            target_finish_reason=target_finish_reason,
         )
 
     _PairResult = tuple[
         str, list[dict[str, Any]], str,
         str, list[dict[str, Any]], str,
         TokenUsage, TokenUsage,
+        str | None, str | None,
     ]
 
     if deduplicate:
@@ -589,8 +607,11 @@ async def run_batch(
         # Build results in original sample order
         all_results: list[SampleResult] = []
         for sample in samples:
-            bt, blp, brid, tt, tlp, trid, _bu, _tu = prompt_to_pair[sample.prompt]
-            all_results.append(_build_result(sample, bt, blp, brid, tt, tlp, trid))
+            bt, blp, brid, tt, tlp, trid, _bu, _tu, bfin, tfin = prompt_to_pair[sample.prompt]
+            all_results.append(_build_result(
+                sample, bt, blp, brid, tt, tlp, trid,
+                baseline_finish_reason=bfin, target_finish_reason=tfin,
+            ))
         results = all_results
 
         report = compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
@@ -598,8 +619,12 @@ async def run_batch(
         return report
 
     async def process_sample(sample: DatasetSample) -> tuple[SampleResult, TokenUsage, TokenUsage]:
-        bt, blp, brid, tt, tlp, trid, b_usage, t_usage = await _collect_pair(sample.prompt)
-        return _build_result(sample, bt, blp, brid, tt, tlp, trid), b_usage, t_usage
+        pair = await _collect_pair(sample.prompt)
+        bt, blp, brid, tt, tlp, trid, b_usage, t_usage, b_fin, t_fin = pair
+        return _build_result(
+            sample, bt, blp, brid, tt, tlp, trid,
+            baseline_finish_reason=b_fin, target_finish_reason=t_fin,
+        ), b_usage, t_usage
 
     total = len(samples)
     usage_summary = UsageSummary()
@@ -675,6 +700,12 @@ def compute_report(
             buckets[bucket]["divergent"] += 1
     report.divergence_by_context_length = buckets
 
+    # Count truncated samples (where either finish_reason is "length")
+    report.truncated_count = sum(
+        1 for r in results
+        if r.baseline_finish_reason == "length" or r.target_finish_reason == "length"
+    )
+
     return report
 
 
@@ -740,6 +771,9 @@ def format_report(report: BatchReport) -> str:
         f"Divergent: {report.divergent_samples} ({report.divergence_rate:.1%})",
     ]
 
+    if report.truncated_count > 0:
+        lines.append(f"Truncated: {report.truncated_count} ⚠️")
+
     if report.divergence_ci_lower is not None and report.divergence_ci_upper is not None:
         lines.append(
             f"  {report.confidence_level:.0%} CI: "
@@ -803,6 +837,8 @@ def _to_markdown(report: BatchReport, *, max_divergent_samples: int = 10) -> str
     lines.append(f"| Matches | {report.match_samples} |")
     lines.append(f"| Divergent | {report.divergent_samples} |")
     lines.append(f"| Divergence rate | {report.divergence_rate:.1%} |")
+    if report.truncated_count > 0:
+        lines.append(f"| Truncated samples ⚠️ | {report.truncated_count} |")
     if report.divergence_ci_lower is not None and report.divergence_ci_upper is not None:
         lines.append(
             f"| {report.confidence_level:.0%} CI | "
@@ -858,6 +894,8 @@ def _to_markdown(report: BatchReport, *, max_divergent_samples: int = 10) -> str
                 lines.append(f"### Sample {r.sample_id}")
                 lines.append("")
                 lines.append(f"- **Classification:** {r.classification}")
+                if r.baseline_finish_reason == "length" or r.target_finish_reason == "length":
+                    lines.append("- **⚠️ Truncated output detected**")
                 lines.append(
                     f"- **First divergence at token:** {r.first_divergence_index}"
                 )
@@ -1029,7 +1067,7 @@ async def run_multi_batch(
 
     async def collect_baseline(sample: DatasetSample) -> tuple[str, str, list[dict[str, Any]]]:
         async with semaphore:
-            text, lp, _rid, b_usage = await _collect_output(
+            text, lp, _rid, b_usage, _finish = await _collect_output(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -1054,7 +1092,7 @@ async def run_multi_batch(
     ) -> SampleResult:
         nonlocal completed
         async with semaphore:
-            target_text, target_lp, _rid, t_usage = await _collect_output(
+            target_text, target_lp, _rid, t_usage, _t_finish = await _collect_output(
                 target_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -230,6 +230,10 @@ def main(argv: list[str] | None = None) -> None:
         help="Disable response caching entirely",
     )
     bc.add_argument(
+        "--warn-truncated", type=float, default=None,
+        help="Warn (exit 2) if truncated sample ratio exceeds this threshold (0.0–1.0)",
+    )
+    bc.add_argument(
         "--cache-ttl", type=float, default=None,
         help="Cache entry TTL in seconds (default: 3600)",
     )
@@ -1180,6 +1184,9 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         # Send webhook notification if configured
         await _maybe_send_webhook(args, report)
 
+        # Check truncation threshold
+        _check_truncation_threshold(args, report)
+
         fail_threshold = _resolve_fail_threshold(args, getattr(args, "_config", None))
         if fail_threshold is not None:
             # When confidence is enabled, use CI lower bound for threshold check
@@ -1287,6 +1294,37 @@ def _maybe_apply_confidence(
         from xpyd_acc.batch_compare import apply_confidence
         level = getattr(args, "confidence_level", 0.95)
         apply_confidence(report, level)
+
+
+def _check_truncation_threshold(
+    args: argparse.Namespace,
+    report: object,
+) -> None:
+    """Check if truncated sample ratio exceeds --warn-truncated threshold.
+
+    Exits with code 2 if the threshold is exceeded.
+    """
+    warn_truncated = getattr(args, "warn_truncated", None)
+    if warn_truncated is None:
+        return
+
+    total = getattr(report, "total_samples", 0)
+    truncated = getattr(report, "truncated_count", 0)
+    if total == 0:
+        return
+
+    ratio = truncated / total
+    if ratio > warn_truncated:
+        print(
+            f"\n⚠ TRUNCATION WARNING: {truncated}/{total} samples truncated "
+            f"({ratio:.1%}) exceeds threshold {warn_truncated:.1%}",
+        )
+        sys.exit(2)
+    elif truncated > 0:
+        print(
+            f"\nTruncation: {truncated}/{total} samples ({ratio:.1%}) "
+            f"within threshold {warn_truncated:.1%}",
+        )
 
 
 def _resolve_fail_threshold(

--- a/src/xpyd_acc/config.py
+++ b/src/xpyd_acc/config.py
@@ -60,6 +60,7 @@ class BatchConfig:
     cache_ttl: float | None = None
     confidence: bool = False
     confidence_level: float = 0.95
+    warn_truncated: float | None = None
 
 
 @dataclass
@@ -210,6 +211,7 @@ def merge_cli_args(config: AppConfig, args: dict[str, Any], command: str) -> dic
             "deduplicate": config.batch.deduplicate,
             "cache_dir": config.batch.cache_dir,
             "cache_ttl": config.batch.cache_ttl,
+            "warn_truncated": config.batch.warn_truncated,
         }
         for key, config_val in batch_map.items():
             if key in merged and merged[key] is None and config_val is not None:

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -339,7 +339,7 @@ class TestOnProgressCallback:
             DatasetSample(id="2", prompt="test"),
         ]
 
-        mock_output = ("response text", [], "", TokenUsage())
+        mock_output = ("response text", [], "", TokenUsage(), "stop")
 
         progress_calls: list[tuple[int, int]] = []
 
@@ -373,7 +373,7 @@ class TestOnProgressCallback:
         from xpyd_acc.cost import TokenUsage
 
         samples = [DatasetSample(id="0", prompt="hello")]
-        mock_output = ("response", [], "", TokenUsage())
+        mock_output = ("response", [], "", TokenUsage(), "stop")
 
         with patch("xpyd_acc.batch_compare._collect_output", new_callable=AsyncMock) as mock_co:
             mock_co.return_value = mock_output

--- a/tests/test_cost_integration.py
+++ b/tests/test_cost_integration.py
@@ -208,8 +208,9 @@ class TestCollectOutputReturnsUsage:
                 [],
                 "rid-123",
                 TokenUsage(prompt_tokens=10, completion_tokens=5),
+                "stop",
             )
-            text, lp, rid, usage = await _collect_output(
+            text, lp, rid, usage, finish = await _collect_output(
                 "http://fake", "test prompt",
                 skip_validation=True,
             )

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -17,7 +17,7 @@ def test_deduplicate_reduces_api_calls() -> None:
         DatasetSample(id="3", prompt="What is 3+3?"),
         DatasetSample(id="4", prompt="What is 2+2?"),  # duplicate
     ]
-    mock_output = ("hello world", [], "", TokenUsage())
+    mock_output = ("hello world", [], "", TokenUsage(), "stop")
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -45,7 +45,7 @@ def test_no_deduplicate_sends_all_calls() -> None:
         DatasetSample(id="2", prompt="What is 2+2?"),
         DatasetSample(id="3", prompt="What is 3+3?"),
     ]
-    mock_output = ("hello world", [], "", TokenUsage())
+    mock_output = ("hello world", [], "", TokenUsage(), "stop")
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -72,7 +72,7 @@ def test_deduplicate_no_duplicates() -> None:
         DatasetSample(id="2", prompt="What is 3+3?"),
         DatasetSample(id="3", prompt="What is 4+4?"),
     ]
-    mock_output = ("hello world", [], "", TokenUsage())
+    mock_output = ("hello world", [], "", TokenUsage(), "stop")
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -99,7 +99,7 @@ def test_deduplicate_preserves_sample_ids() -> None:
         DatasetSample(id="b", prompt="prompt1"),
         DatasetSample(id="c", prompt="prompt2"),
     ]
-    mock_output = ("hello world", [], "", TokenUsage())
+    mock_output = ("hello world", [], "", TokenUsage(), "stop")
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -125,7 +125,7 @@ def test_deduplicate_progress_callback() -> None:
         DatasetSample(id="2", prompt="p1"),
         DatasetSample(id="3", prompt="p2"),
     ]
-    mock_output = ("hello", [], "", TokenUsage())
+    mock_output = ("hello", [], "", TokenUsage(), "stop")
     progress_calls: list[tuple[int, int]] = []
 
     def on_progress(done: int, total: int) -> None:

--- a/tests/test_multi_target.py
+++ b/tests/test_multi_target.py
@@ -162,10 +162,10 @@ class TestRunMultiBatch:
             nonlocal call_count
             call_count += 1
             if "base" in url:
-                return "baseline output", [], "", TokenUsage()
+                return "baseline output", [], "", TokenUsage(), "stop"
             if "t1" in url:
-                return "baseline output", [], "", TokenUsage()  # matches
-            return "different output", [], "", TokenUsage()  # diverges
+                return "baseline output", [], "", TokenUsage(), "stop"  # matches
+            return "different output", [], "", TokenUsage(), "stop"  # diverges
 
         with patch("xpyd_acc.batch_compare._collect_output", side_effect=mock_collect):
             report = await run_multi_batch(
@@ -189,7 +189,7 @@ class TestRunMultiBatch:
         ]
 
         async def mock_collect(url, prompt, **kwargs):
-            return "output", [], "", TokenUsage()
+            return "output", [], "", TokenUsage(), "stop"
 
         progress_calls: list[tuple[int, int]] = []
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -97,7 +97,7 @@ class TestCollectOutputRequestId:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            text, lp, returned_rid, _usage = await _collect_output(
+            text, lp, returned_rid, _usage, _finish = await _collect_output(
                 "http://test:8000", "hello",
                 request_id=rid,
             )
@@ -131,7 +131,7 @@ class TestCollectOutputRequestId:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            text, lp, returned_rid, _usage = await _collect_output(
+            text, lp, returned_rid, _usage, _finish = await _collect_output(
                 "http://test:8000", "hello",
                 request_id=None,
             )

--- a/tests/test_truncation.py
+++ b/tests/test_truncation.py
@@ -1,0 +1,229 @@
+"""Tests for M61: Output Truncation Detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from xpyd_acc.batch_compare import (
+    SampleResult,
+    compute_report,
+    export_markdown,
+    format_report,
+    load_report,
+)
+
+
+def _make_result(
+    sample_id: str = "0",
+    exact_match: bool = True,
+    baseline_finish_reason: str | None = "stop",
+    target_finish_reason: str | None = "stop",
+) -> SampleResult:
+    """Helper to create a SampleResult with finish_reason fields."""
+    return SampleResult(
+        sample_id=sample_id,
+        prompt="test prompt",
+        baseline_output="hello world",
+        target_output="hello world" if exact_match else "hello earth",
+        exact_match=exact_match,
+        first_divergence_index=None if exact_match else 1,
+        baseline_logprob_at_divergence=None,
+        target_logprob_at_divergence=None,
+        logprob_gap=None,
+        classification="match" if exact_match else "unknown",
+        context_length=2,
+        baseline_finish_reason=baseline_finish_reason,
+        target_finish_reason=target_finish_reason,
+    )
+
+
+class TestSampleResultFinishReason:
+    """Tests for finish_reason fields on SampleResult."""
+
+    def test_default_none(self) -> None:
+        r = SampleResult(
+            sample_id="0", prompt="p", baseline_output="a", target_output="a",
+            exact_match=True, first_divergence_index=None,
+            baseline_logprob_at_divergence=None, target_logprob_at_divergence=None,
+            logprob_gap=None, classification="match", context_length=1,
+        )
+        assert r.baseline_finish_reason is None
+        assert r.target_finish_reason is None
+
+    def test_set_finish_reason(self) -> None:
+        r = _make_result(baseline_finish_reason="length", target_finish_reason="stop")
+        assert r.baseline_finish_reason == "length"
+        assert r.target_finish_reason == "stop"
+
+    def test_both_length(self) -> None:
+        r = _make_result(baseline_finish_reason="length", target_finish_reason="length")
+        assert r.baseline_finish_reason == "length"
+        assert r.target_finish_reason == "length"
+
+
+class TestBatchReportTruncatedCount:
+    """Tests for truncated_count in BatchReport."""
+
+    def test_no_truncation(self) -> None:
+        results = [_make_result(sample_id=str(i)) for i in range(3)]
+        report = compute_report(results)
+        assert report.truncated_count == 0
+
+    def test_baseline_truncated(self) -> None:
+        results = [
+            _make_result(sample_id="0", baseline_finish_reason="length"),
+            _make_result(sample_id="1"),
+        ]
+        report = compute_report(results)
+        assert report.truncated_count == 1
+
+    def test_target_truncated(self) -> None:
+        results = [
+            _make_result(sample_id="0", target_finish_reason="length"),
+            _make_result(sample_id="1"),
+        ]
+        report = compute_report(results)
+        assert report.truncated_count == 1
+
+    def test_both_truncated_counts_once(self) -> None:
+        """A sample with both sides truncated counts as one truncated sample."""
+        results = [
+            _make_result(
+                sample_id="0",
+                baseline_finish_reason="length",
+                target_finish_reason="length",
+            ),
+        ]
+        report = compute_report(results)
+        assert report.truncated_count == 1
+
+    def test_multiple_truncated(self) -> None:
+        results = [
+            _make_result(sample_id="0", baseline_finish_reason="length"),
+            _make_result(sample_id="1", target_finish_reason="length"),
+            _make_result(sample_id="2"),
+        ]
+        report = compute_report(results)
+        assert report.truncated_count == 2
+
+    def test_none_finish_reason_not_truncated(self) -> None:
+        results = [
+            _make_result(sample_id="0", baseline_finish_reason=None, target_finish_reason=None),
+        ]
+        report = compute_report(results)
+        assert report.truncated_count == 0
+
+
+class TestJsonSerialisation:
+    """Tests for JSON round-trip with truncation fields."""
+
+    def test_to_json_includes_truncation(self) -> None:
+        results = [
+            _make_result(sample_id="0", baseline_finish_reason="length"),
+        ]
+        report = compute_report(results)
+        data = json.loads(report.to_json())
+        assert data["truncated_count"] == 1
+        assert data["results"][0]["baseline_finish_reason"] == "length"
+        assert data["results"][0]["target_finish_reason"] == "stop"
+
+    def test_load_report_round_trip(self, tmp_path: Path) -> None:
+        results = [
+            _make_result(sample_id="0", target_finish_reason="length"),
+            _make_result(sample_id="1"),
+        ]
+        report = compute_report(results)
+        path = tmp_path / "report.json"
+        path.write_text(report.to_json())
+
+        loaded = load_report(path)
+        assert loaded.truncated_count == 1
+        assert loaded.results[0].target_finish_reason == "length"
+        assert loaded.results[1].target_finish_reason == "stop"
+
+    def test_load_report_backward_compat(self, tmp_path: Path) -> None:
+        """Reports without truncation fields load with defaults."""
+        data = {
+            "schema_version": 1,
+            "total_samples": 1,
+            "divergent_samples": 0,
+            "match_samples": 1,
+            "divergence_rate": 0.0,
+            "results": [{
+                "sample_id": "0",
+                "prompt": "p",
+                "baseline_output": "a",
+                "target_output": "a",
+                "exact_match": True,
+                "classification": "match",
+                "context_length": 1,
+            }],
+        }
+        path = tmp_path / "old_report.json"
+        path.write_text(json.dumps(data))
+        loaded = load_report(path)
+        assert loaded.truncated_count == 0
+        assert loaded.results[0].baseline_finish_reason is None
+        assert loaded.results[0].target_finish_reason is None
+
+
+class TestFormatReport:
+    """Tests for truncation in formatted output."""
+
+    def test_format_report_shows_truncated(self) -> None:
+        results = [
+            _make_result(sample_id="0", baseline_finish_reason="length"),
+            _make_result(sample_id="1"),
+        ]
+        report = compute_report(results)
+        text = format_report(report)
+        assert "Truncated: 1" in text
+        assert "⚠️" in text
+
+    def test_format_report_no_truncation_no_line(self) -> None:
+        results = [_make_result(sample_id="0")]
+        report = compute_report(results)
+        text = format_report(report)
+        assert "Truncated" not in text
+
+
+class TestMarkdownExport:
+    """Tests for truncation info in Markdown export."""
+
+    def test_markdown_includes_truncation(self) -> None:
+        results = [
+            _make_result(
+                sample_id="0", exact_match=False,
+                baseline_finish_reason="length",
+            ),
+        ]
+        report = compute_report(results)
+        md = export_markdown(report)
+        assert "Truncated samples" in md
+        assert "⚠️" in md
+
+    def test_markdown_divergent_sample_truncation_flag(self) -> None:
+        results = [
+            _make_result(
+                sample_id="0", exact_match=False,
+                target_finish_reason="length",
+            ),
+        ]
+        report = compute_report(results)
+        md = export_markdown(report)
+        assert "Truncated output detected" in md
+
+
+class TestSchemaVersion:
+    """Tests for schema version bump."""
+
+    def test_schema_version_is_2(self) -> None:
+        from xpyd_acc.batch_compare import REPORT_SCHEMA_VERSION
+        assert REPORT_SCHEMA_VERSION == 2
+
+    def test_to_json_has_schema_version_2(self) -> None:
+        results = [_make_result()]
+        report = compute_report(results)
+        data = json.loads(report.to_json())
+        assert data["schema_version"] == 2


### PR DESCRIPTION
## M61: Output Truncation Detection

### Changes
- `_collect_output()` extracts and returns `finish_reason` from API responses
- `SampleResult` gains `baseline_finish_reason` and `target_finish_reason` fields
- `BatchReport` gains `truncated_count` field (samples where either finish_reason is "length")
- `compute_report()` counts truncated samples automatically
- `format_report()` shows truncated count with ⚠️ when non-zero
- `to_json()` includes `finish_reason` per result and `truncated_count` in report
- `to_markdown()` shows truncation summary and flags truncated divergent samples
- `load_report()` backward-compatible with v1 schema reports
- Report schema version bumped to 2
- CLI `--warn-truncated <float>` flag: exit 2 if truncated ratio exceeds threshold
- TOML config: `[batch] warn_truncated` support
- 18 new tests covering detection, classification, JSON round-trip, backward compat, formatting
- All 821 existing tests pass

Closes #131