### PR TITLE
feat(env): add XPYD_ACC_MAX_TOKENS and XPYD_ACC_CONCURRENCY env vars

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -551,3 +551,11 @@
 - Rich terminal output with consistency summary
 - `reproducibility.py` module with `run_reproducibility()` async function
 - 18 tests covering single/dual endpoint, metrics, edge cases, JSON export, CLI integration
+
+## M63: Environment Variable Support for Max Tokens & Concurrency ✅
+- `XPYD_ACC_MAX_TOKENS` environment variable for default max tokens
+- `XPYD_ACC_CONCURRENCY` environment variable for default concurrency
+- Priority chain: CLI flags > env vars > config file > defaults
+- `EnvDefaults` extended with `max_tokens` and `concurrency` fields
+- CLI applies env values before hardcoded defaults
+- 4 new tests covering env var read and unset behavior

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -769,6 +769,10 @@ def main(argv: list[str] | None = None) -> None:
         args.timeout = env.timeout
     if env.rate_limit is not None and hasattr(args, "rate_limit") and args.rate_limit is None:
         args.rate_limit = env.rate_limit
+    if env.max_tokens is not None and hasattr(args, "max_tokens") and args.max_tokens is None:
+        args.max_tokens = env.max_tokens
+    if env.concurrency is not None and hasattr(args, "concurrency") and args.concurrency is None:
+        args.concurrency = env.concurrency
 
     # Apply hardcoded defaults for any remaining None values
     _FINAL_DEFAULTS: dict[str, object] = {

--- a/src/xpyd_acc/env.py
+++ b/src/xpyd_acc/env.py
@@ -15,6 +15,8 @@ ENV_TOP_P = "XPYD_ACC_TOP_P"
 ENV_SEED = "XPYD_ACC_SEED"
 ENV_TIMEOUT = "XPYD_ACC_TIMEOUT"
 ENV_RATE_LIMIT = "XPYD_ACC_RATE_LIMIT"
+ENV_MAX_TOKENS = "XPYD_ACC_MAX_TOKENS"
+ENV_CONCURRENCY = "XPYD_ACC_CONCURRENCY"
 
 
 @dataclass
@@ -30,6 +32,8 @@ class EnvDefaults:
     seed: int | None = None
     timeout: float | None = None
     rate_limit: float | None = None
+    max_tokens: int | None = None
+    concurrency: int | None = None
 
 
 def get_env_defaults() -> EnvDefaults:
@@ -43,6 +47,8 @@ def get_env_defaults() -> EnvDefaults:
     seed_str = os.environ.get(ENV_SEED) or None
     timeout_str = os.environ.get(ENV_TIMEOUT) or None
     rate_limit_str = os.environ.get(ENV_RATE_LIMIT) or None
+    max_tokens_str = os.environ.get(ENV_MAX_TOKENS) or None
+    concurrency_str = os.environ.get(ENV_CONCURRENCY) or None
 
     return EnvDefaults(
         api_key=os.environ.get(ENV_API_KEY) or None,
@@ -54,6 +60,8 @@ def get_env_defaults() -> EnvDefaults:
         seed=int(seed_str) if seed_str is not None else None,
         timeout=float(timeout_str) if timeout_str is not None else None,
         rate_limit=float(rate_limit_str) if rate_limit_str is not None else None,
+        max_tokens=int(max_tokens_str) if max_tokens_str is not None else None,
+        concurrency=int(concurrency_str) if concurrency_str is not None else None,
     )
 
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -8,6 +8,8 @@ from unittest.mock import patch
 from xpyd_acc.env import (
     ENV_API_KEY,
     ENV_BASELINE_URL,
+    ENV_CONCURRENCY,
+    ENV_MAX_TOKENS,
     ENV_MODEL,
     ENV_TARGET_URL,
     ENV_TIMEOUT,
@@ -114,3 +116,29 @@ class TestCliEnvIntegration:
         with patch.dict(os.environ, {}, clear=True):
             defaults = get_env_defaults()
         assert defaults.timeout is None
+
+    def test_max_tokens_env_var(self) -> None:
+        """Verify XPYD_ACC_MAX_TOKENS env var is read correctly."""
+        env = {ENV_MAX_TOKENS: "128"}
+        with patch.dict(os.environ, env, clear=True):
+            defaults = get_env_defaults()
+        assert defaults.max_tokens == 128
+
+    def test_max_tokens_env_var_not_set(self) -> None:
+        """Verify max_tokens is None when env var not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            defaults = get_env_defaults()
+        assert defaults.max_tokens is None
+
+    def test_concurrency_env_var(self) -> None:
+        """Verify XPYD_ACC_CONCURRENCY env var is read correctly."""
+        env = {ENV_CONCURRENCY: "10"}
+        with patch.dict(os.environ, env, clear=True):
+            defaults = get_env_defaults()
+        assert defaults.concurrency == 10
+
+    def test_concurrency_env_var_not_set(self) -> None:
+        """Verify concurrency is None when env var not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            defaults = get_env_defaults()
+        assert defaults.concurrency is None


### PR DESCRIPTION
## Summary
Add environment variable support for the two remaining CLI flags that lacked it: `--max-tokens` and `--concurrency`.

### Changes
- **`env.py`**: Added `ENV_MAX_TOKENS`, `ENV_CONCURRENCY` constants; extended `EnvDefaults` with `max_tokens` and `concurrency` fields; parsing in `get_env_defaults()`
- **`cli.py`**: Apply env defaults for `max_tokens` and `concurrency` before hardcoded defaults
- **`tests/test_env.py`**: 4 new tests for read/unset behavior of both env vars
- **`ROADMAP.md`**: Added M63 milestone entry

### Priority Chain
CLI flags > env vars > TOML config > hardcoded defaults

Closes #135