### PR TITLE
feat(retry): add retry statistics reporting (M66)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -582,3 +582,16 @@
 - CLI flags `--checkpoint` and `--checkpoint-clear` wired through to `run_batch()`
 - Results maintained in original sample order regardless of resume
 - 12 tests covering resume, skip, mismatch discard, clear, cleanup, ordering
+
+## M66: Retry Statistics Reporting ✅
+- `retry_async()` returns `RetryResult(value, attempts)` instead of bare value
+- `RetryStats` dataclass: total_requests, total_retries, max_retries_single, retried_request_count
+- `RetryStats.record(result)` aggregates individual `RetryResult` instances
+- `RetryStats.to_dict()` / `from_dict()` for serialization round-trip
+- `BatchReport.retry_stats` field (optional, backward compatible)
+- `format_report()` shows retry summary when retries occurred
+- `to_json()` / `to_markdown()` include retry stats
+- `load_report()` round-trips retry stats; old reports without field load fine
+- All callers updated: batch_compare, logprobs, notify, reproducibility
+- Fixed pre-existing bug: reproducibility.py used retry_async as decorator
+- 25 tests: RetryResult, RetryStats aggregation, serialization, report integration, format, round-trip

--- a/src/xpyd_acc/batch_compare.py
+++ b/src/xpyd_acc/batch_compare.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 from xpyd_acc.cost import TokenUsage, UsageSummary, extract_usage, format_usage_summary
 from xpyd_acc.log import get_logger
 from xpyd_acc.response_validate import validate_chat_response
+from xpyd_acc.retry import RetryResult, RetryStats
 
 logger = get_logger("batch_compare")
 
@@ -84,6 +85,8 @@ class BatchReport:
     usage: UsageSummary | None = None
     # Truncation tracking
     truncated_count: int = 0
+    # Retry statistics
+    retry_stats: RetryStats | None = None
 
     def to_markdown(self, *, max_divergent_samples: int = 10) -> str:
         """Serialize the report to a Markdown string."""
@@ -110,6 +113,7 @@ class BatchReport:
             "confidence_level": self.confidence_level,
             "truncated_count": self.truncated_count,
             "usage": self.usage.to_dict() if self.usage is not None else None,
+            "retry_stats": self.retry_stats.to_dict() if self.retry_stats is not None else None,
             "results": [
                 {
                     "sample_id": r.sample_id,
@@ -204,6 +208,7 @@ def load_report(path: str | Path) -> BatchReport:
         confidence_level=data.get("confidence_level"),
         usage=usage,
         truncated_count=data.get("truncated_count", 0),
+        retry_stats=RetryStats.from_dict(data["retry_stats"]) if data.get("retry_stats") else None,
     )
 
 
@@ -373,7 +378,7 @@ async def _collect_output(
     if cache is not None:
         entry = cache.get(url, model, prompt, sp_dict)
         if entry is not None:
-            return entry.text, entry.logprobs, entry.request_id, TokenUsage(), None
+            return entry.text, entry.logprobs, entry.request_id, TokenUsage(), None, 1
 
     payload: dict[str, Any] = {
         "model": model,
@@ -406,15 +411,16 @@ async def _collect_output(
         finish_reason = choice.get("finish_reason")
         return text, logprobs_content, rid, usage, finish_reason
 
-    text, logprobs_list, out_rid, usage, finish_reason = await retry_async(
+    retry_result = await retry_async(
         _do_request, retries=retries, base_delay=retry_delay,
     )
+    text, logprobs_list, out_rid, usage, finish_reason = retry_result.value
 
     # Store in cache
     if cache is not None:
         cache.put(url, model, prompt, text, logprobs_list, out_rid, sp_dict)
 
-    return text, logprobs_list, out_rid, usage, finish_reason
+    return text, logprobs_list, out_rid, usage, finish_reason, retry_result.attempts
 
 
 async def run_batch(
@@ -533,7 +539,10 @@ async def run_batch(
         async with semaphore:
             if rate_limiter is not None:
                 await rate_limiter.acquire()
-            baseline_text, baseline_lp, b_rid_out, b_usage, b_finish = await _collect_output(
+            (
+                baseline_text, baseline_lp, b_rid_out,
+                b_usage, b_finish, b_attempts,
+            ) = await _collect_output(
                 baseline_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -544,7 +553,10 @@ async def run_batch(
             )
             if rate_limiter is not None:
                 await rate_limiter.acquire()
-            target_text, target_lp, t_rid_out, t_usage, t_finish = await _collect_output(
+            (
+                target_text, target_lp, t_rid_out,
+                t_usage, t_finish, t_attempts,
+            ) = await _collect_output(
                 target_url, prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -558,6 +570,7 @@ async def run_batch(
             target_text, target_lp, t_rid_out,
             b_usage, t_usage,
             b_finish, t_finish,
+            b_attempts, t_attempts,
         )
 
     def _build_result(
@@ -632,12 +645,19 @@ async def run_batch(
         # Send unique prompts only, then fan out results
         total = len(unique_prompts)
         usage_summary = UsageSummary()
+        retry_stats_dedup = RetryStats()
 
         async def _tracked_unique(prompt: str) -> _PairResult:
             nonlocal completed
             result = await _collect_pair(prompt)
             usage_summary.add(result[6])  # baseline usage
             usage_summary.add(result[7])  # target usage
+            retry_stats_dedup.record(
+                RetryResult(value=None, attempts=result[10]),
+            )  # baseline
+            retry_stats_dedup.record(
+                RetryResult(value=None, attempts=result[11]),
+            )  # target
             completed += 1
             if on_progress is not None:
                 on_progress(completed, total)
@@ -654,7 +674,10 @@ async def run_batch(
         # Build results in original sample order
         all_results: list[SampleResult] = []
         for sample in samples:
-            bt, blp, brid, tt, tlp, trid, _bu, _tu, bfin, tfin = prompt_to_pair[sample.prompt]
+            (
+                bt, blp, brid, tt, tlp, trid,
+                _bu, _tu, bfin, tfin, _ba, _ta,
+            ) = prompt_to_pair[sample.prompt]
             all_results.append(_build_result(
                 sample, bt, blp, brid, tt, tlp, trid,
                 baseline_finish_reason=bfin, target_finish_reason=tfin,
@@ -663,15 +686,18 @@ async def run_batch(
 
         report = compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
         report.usage = usage_summary
+        report.retry_stats = retry_stats_dedup
         return report
 
-    async def process_sample(sample: DatasetSample) -> tuple[SampleResult, TokenUsage, TokenUsage]:
+    async def process_sample(
+        sample: DatasetSample,
+    ) -> tuple[SampleResult, TokenUsage, TokenUsage, int, int]:
         pair = await _collect_pair(sample.prompt)
-        bt, blp, brid, tt, tlp, trid, b_usage, t_usage, b_fin, t_fin = pair
+        bt, blp, brid, tt, tlp, trid, b_usage, t_usage, b_fin, t_fin, b_att, t_att = pair
         return _build_result(
             sample, bt, blp, brid, tt, tlp, trid,
             baseline_finish_reason=b_fin, target_finish_reason=t_fin,
-        ), b_usage, t_usage
+        ), b_usage, t_usage, b_att, t_att
 
     total = len(samples)
     usage_summary = UsageSummary()
@@ -685,7 +711,9 @@ async def run_batch(
         )
         completed = len(resumed_results)
 
-    async def _tracked_sample(sample: DatasetSample) -> tuple[SampleResult, TokenUsage, TokenUsage]:
+    async def _tracked_sample(
+        sample: DatasetSample,
+    ) -> tuple[SampleResult, TokenUsage, TokenUsage, int, int]:
         nonlocal completed
         result_tuple = await process_sample(sample)
         completed += 1
@@ -707,11 +735,14 @@ async def run_batch(
             results.append(resumed_results[s.id])
         # pending results added below in order
     # Now add freshly computed results
+    retry_stats = RetryStats()
     pending_results = []
-    for sr, b_u, t_u in raw_results:
+    for sr, b_u, t_u, b_att, t_att in raw_results:
         pending_results.append(sr)
         usage_summary.add(b_u)
         usage_summary.add(t_u)
+        retry_stats.record(RetryResult(value=None, attempts=b_att))
+        retry_stats.record(RetryResult(value=None, attempts=t_att))
 
     # Rebuild results in original sample order
     pending_map = {sr.sample_id: sr for sr in pending_results}
@@ -731,6 +762,7 @@ async def run_batch(
 
     report = compute_report(results, logprob_gap_threshold=logprob_gap_threshold)
     report.usage = usage_summary
+    report.retry_stats = retry_stats
     return report
 
 
@@ -898,6 +930,15 @@ def format_report(report: BatchReport) -> str:
         lines.append("")
         lines.append(format_usage_summary(report.usage))
 
+    if report.retry_stats is not None and report.retry_stats.total_retries > 0:
+        rs = report.retry_stats
+        lines.append("")
+        lines.append("--- Retry Statistics ---")
+        lines.append(f"  Total requests:     {rs.total_requests}")
+        lines.append(f"  Retried requests:   {rs.retried_request_count}")
+        lines.append(f"  Total retries:      {rs.total_retries}")
+        lines.append(f"  Max retries (single): {rs.max_retries_single}")
+
     return "\n".join(lines)
 
 
@@ -1004,6 +1045,18 @@ def _to_markdown(report: BatchReport, *, max_divergent_samples: int = 10) -> str
         lines.append(f"| Total tokens | {report.usage.total_tokens:,} |")
         if report.usage.estimated_cost_usd is not None:
             lines.append(f"| Estimated cost | ${report.usage.estimated_cost_usd:.4f} |")
+        lines.append("")
+
+    if report.retry_stats is not None and report.retry_stats.total_retries > 0:
+        rs = report.retry_stats
+        lines.append("## Retry Statistics")
+        lines.append("")
+        lines.append("| Metric | Value |")
+        lines.append("|--------|-------|")
+        lines.append(f"| Total requests | {rs.total_requests} |")
+        lines.append(f"| Retried requests | {rs.retried_request_count} |")
+        lines.append(f"| Total retries | {rs.total_retries} |")
+        lines.append(f"| Max retries (single) | {rs.max_retries_single} |")
         lines.append("")
 
     return "\n".join(lines)
@@ -1151,7 +1204,7 @@ async def run_multi_batch(
 
     async def collect_baseline(sample: DatasetSample) -> tuple[str, str, list[dict[str, Any]]]:
         async with semaphore:
-            text, lp, _rid, b_usage, _finish = await _collect_output(
+            text, lp, _rid, b_usage, _finish, _att = await _collect_output(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,
@@ -1176,7 +1229,7 @@ async def run_multi_batch(
     ) -> SampleResult:
         nonlocal completed
         async with semaphore:
-            target_text, target_lp, _rid, t_usage, _t_finish = await _collect_output(
+            target_text, target_lp, _rid, t_usage, _t_finish, _t_att = await _collect_output(
                 target_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,

--- a/src/xpyd_acc/logprobs.py
+++ b/src/xpyd_acc/logprobs.py
@@ -92,7 +92,8 @@ class LogprobsCollector:
                 resp.raise_for_status()
                 return resp.json()
 
-        data = await retry_async(_do_request, retries=retries, base_delay=retry_delay)
+        result = await retry_async(_do_request, retries=retries, base_delay=retry_delay)
+        data = result.value
         if not skip_validation:
             validate_chat_response(data, require_logprobs=True)
         return self._parse_response(data)

--- a/src/xpyd_acc/notify.py
+++ b/src/xpyd_acc/notify.py
@@ -71,7 +71,8 @@ async def send_webhook(
             return True
 
     try:
-        return await retry_async(_do_post, retries=retries, base_delay=retry_delay)
+        result = await retry_async(_do_post, retries=retries, base_delay=retry_delay)
+        return result.value
     except Exception:
         logger.error("Webhook delivery failed after %d retries", retries)
         return False

--- a/src/xpyd_acc/reproducibility.py
+++ b/src/xpyd_acc/reproducibility.py
@@ -139,7 +139,6 @@ async def _collect_outputs(
         if seed is not None:
             body["seed"] = seed
 
-        @retry_async(retries=retries, base_delay=retry_delay)
         async def _do_request() -> str:
             async with httpx.AsyncClient(timeout=timeout) as client:
                 resp = await client.post(
@@ -151,7 +150,8 @@ async def _collect_outputs(
                 data = resp.json()
                 return data["choices"][0]["message"]["content"]
 
-        return await _do_request()
+        result = await retry_async(_do_request, retries=retries, base_delay=retry_delay)
+        return result.value
 
     tasks = [_single_request() for _ in range(runs)]
     outputs = await asyncio.gather(*tasks)

--- a/src/xpyd_acc/retry.py
+++ b/src/xpyd_acc/retry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import random
+from dataclasses import dataclass
 from typing import Any, Callable, TypeVar
 
 import httpx
@@ -27,13 +28,60 @@ class RetriesExhausted(Exception):
         super().__init__(f"All {attempts} attempts failed. Last error: {last_error}")
 
 
+@dataclass
+class RetryResult:
+    """Wrapper returned by :func:`retry_async` containing the value and attempt metadata."""
+
+    value: Any
+    attempts: int  # 1 means succeeded on first try (no retries)
+
+
+@dataclass
+class RetryStats:
+    """Aggregate retry statistics across multiple requests."""
+
+    total_requests: int = 0
+    total_retries: int = 0  # sum of (attempts - 1) across all requests
+    max_retries_single: int = 0  # highest (attempts - 1) for a single request
+    retried_request_count: int = 0  # how many requests needed at least one retry
+
+    def record(self, result: RetryResult) -> None:
+        """Record a single :class:`RetryResult`."""
+        retries = result.attempts - 1
+        self.total_requests += 1
+        self.total_retries += retries
+        if retries > self.max_retries_single:
+            self.max_retries_single = retries
+        if retries > 0:
+            self.retried_request_count += 1
+
+    def to_dict(self) -> dict[str, int]:
+        """Serialize to a plain dictionary."""
+        return {
+            "total_requests": self.total_requests,
+            "total_retries": self.total_retries,
+            "max_retries_single": self.max_retries_single,
+            "retried_request_count": self.retried_request_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RetryStats:
+        """Deserialize from a dictionary."""
+        return cls(
+            total_requests=data.get("total_requests", 0),
+            total_retries=data.get("total_retries", 0),
+            max_retries_single=data.get("max_retries_single", 0),
+            retried_request_count=data.get("retried_request_count", 0),
+        )
+
+
 async def retry_async(
     func: Callable[..., Any],
     *args: Any,
     retries: int = 3,
     base_delay: float = 1.0,
     **kwargs: Any,
-) -> Any:
+) -> RetryResult:
     """Call *func* with retries on transient HTTP errors.
 
     Retries on:
@@ -50,7 +98,8 @@ async def retry_async(
         *args, **kwargs: Forwarded to *func*.
 
     Returns:
-        The return value of *func*.
+        A :class:`RetryResult` containing the return value and the number of
+        attempts made.
 
     Raises:
         RetriesExhausted: If all attempts fail.
@@ -62,7 +111,8 @@ async def retry_async(
 
     for attempt in range(retries):
         try:
-            return await func(*args, **kwargs)
+            value = await func(*args, **kwargs)
+            return RetryResult(value=value, attempts=attempt + 1)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code not in RETRYABLE_STATUS_CODES:
                 raise

--- a/src/xpyd_acc/snapshot.py
+++ b/src/xpyd_acc/snapshot.py
@@ -80,7 +80,7 @@ async def capture_snapshot(
     async def _capture_one(sample: DatasetSample) -> SnapshotSample:
         nonlocal completed
         async with semaphore:
-            text, logprobs, _rid, _usage = await _collect_output(
+            text, logprobs, _rid, _usage, *_rest = await _collect_output(
                 baseline_url, sample.prompt, model=model,
                 max_tokens=max_tokens, api_key=api_key,
                 retries=retries, retry_delay=retry_delay,

--- a/tests/test_batch_compare.py
+++ b/tests/test_batch_compare.py
@@ -339,7 +339,7 @@ class TestOnProgressCallback:
             DatasetSample(id="2", prompt="test"),
         ]
 
-        mock_output = ("response text", [], "", TokenUsage(), "stop")
+        mock_output = ("response text", [], "", TokenUsage(), "stop", 1)
 
         progress_calls: list[tuple[int, int]] = []
 
@@ -373,7 +373,7 @@ class TestOnProgressCallback:
         from xpyd_acc.cost import TokenUsage
 
         samples = [DatasetSample(id="0", prompt="hello")]
-        mock_output = ("response", [], "", TokenUsage(), "stop")
+        mock_output = ("response", [], "", TokenUsage(), "stop", 1)
 
         with patch("xpyd_acc.batch_compare._collect_output", new_callable=AsyncMock) as mock_co:
             mock_co.return_value = mock_output

--- a/tests/test_checkpoint_integration.py
+++ b/tests/test_checkpoint_integration.py
@@ -27,7 +27,7 @@ def _samples(n: int = 3) -> list[DatasetSample]:
 def _fake_collect_output(text: str = "hello"):
     """Return an AsyncMock that simulates _collect_output."""
     async def _mock(*args, **kwargs):
-        return text, [], "", TokenUsage(0, 0), "stop"  # text, logprobs, rid, usage, finish
+        return text, [], "", TokenUsage(0, 0), "stop", 1  # text, logprobs, rid, usage, finish
     return _mock
 
 
@@ -179,7 +179,7 @@ class TestCheckpointIntegration:
         async def _mock(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            return "output", [], "", TokenUsage(0, 0), "stop"
+            return "output", [], "", TokenUsage(0, 0), "stop", 1
 
         mock_collect.side_effect = _mock
         cp_path = tmp_path / "cp.json"

--- a/tests/test_cost_integration.py
+++ b/tests/test_cost_integration.py
@@ -201,18 +201,23 @@ class TestCollectOutputReturnsUsage:
     @pytest.mark.asyncio
     async def test_collect_output_returns_usage(self):
         from xpyd_acc.batch_compare import _collect_output
+        from xpyd_acc.retry import RetryResult
 
         with patch("xpyd_acc.retry.retry_async") as mock_retry:
-            mock_retry.return_value = (
-                "hello",
-                [],
-                "rid-123",
-                TokenUsage(prompt_tokens=10, completion_tokens=5),
-                "stop",
+            mock_retry.return_value = RetryResult(
+                value=(
+                    "hello",
+                    [],
+                    "rid-123",
+                    TokenUsage(prompt_tokens=10, completion_tokens=5),
+                    "stop",
+                ),
+                attempts=1,
             )
-            text, lp, rid, usage, finish = await _collect_output(
+            text, lp, rid, usage, finish, attempts = await _collect_output(
                 "http://fake", "test prompt",
                 skip_validation=True,
             )
             assert usage.prompt_tokens == 10
             assert usage.completion_tokens == 5
+            assert attempts == 1

--- a/tests/test_deduplicate.py
+++ b/tests/test_deduplicate.py
@@ -17,7 +17,7 @@ def test_deduplicate_reduces_api_calls() -> None:
         DatasetSample(id="3", prompt="What is 3+3?"),
         DatasetSample(id="4", prompt="What is 2+2?"),  # duplicate
     ]
-    mock_output = ("hello world", [], "", TokenUsage(), "stop")
+    mock_output = ("hello world", [], "", TokenUsage(), "stop", 1)
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -45,7 +45,7 @@ def test_no_deduplicate_sends_all_calls() -> None:
         DatasetSample(id="2", prompt="What is 2+2?"),
         DatasetSample(id="3", prompt="What is 3+3?"),
     ]
-    mock_output = ("hello world", [], "", TokenUsage(), "stop")
+    mock_output = ("hello world", [], "", TokenUsage(), "stop", 1)
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -72,7 +72,7 @@ def test_deduplicate_no_duplicates() -> None:
         DatasetSample(id="2", prompt="What is 3+3?"),
         DatasetSample(id="3", prompt="What is 4+4?"),
     ]
-    mock_output = ("hello world", [], "", TokenUsage(), "stop")
+    mock_output = ("hello world", [], "", TokenUsage(), "stop", 1)
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -99,7 +99,7 @@ def test_deduplicate_preserves_sample_ids() -> None:
         DatasetSample(id="b", prompt="prompt1"),
         DatasetSample(id="c", prompt="prompt2"),
     ]
-    mock_output = ("hello world", [], "", TokenUsage(), "stop")
+    mock_output = ("hello world", [], "", TokenUsage(), "stop", 1)
 
     with patch(
         "xpyd_acc.batch_compare._collect_output",
@@ -125,7 +125,7 @@ def test_deduplicate_progress_callback() -> None:
         DatasetSample(id="2", prompt="p1"),
         DatasetSample(id="3", prompt="p2"),
     ]
-    mock_output = ("hello", [], "", TokenUsage(), "stop")
+    mock_output = ("hello", [], "", TokenUsage(), "stop", 1)
     progress_calls: list[tuple[int, int]] = []
 
     def on_progress(done: int, total: int) -> None:

--- a/tests/test_multi_target.py
+++ b/tests/test_multi_target.py
@@ -162,10 +162,10 @@ class TestRunMultiBatch:
             nonlocal call_count
             call_count += 1
             if "base" in url:
-                return "baseline output", [], "", TokenUsage(), "stop"
+                return "baseline output", [], "", TokenUsage(), "stop", 1
             if "t1" in url:
-                return "baseline output", [], "", TokenUsage(), "stop"  # matches
-            return "different output", [], "", TokenUsage(), "stop"  # diverges
+                return "baseline output", [], "", TokenUsage(), "stop", 1  # matches
+            return "different output", [], "", TokenUsage(), "stop", 1  # diverges
 
         with patch("xpyd_acc.batch_compare._collect_output", side_effect=mock_collect):
             report = await run_multi_batch(
@@ -189,7 +189,7 @@ class TestRunMultiBatch:
         ]
 
         async def mock_collect(url, prompt, **kwargs):
-            return "output", [], "", TokenUsage(), "stop"
+            return "output", [], "", TokenUsage(), "stop", 1
 
         progress_calls: list[tuple[int, int]] = []
 

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -14,6 +14,7 @@ from xpyd_acc.notify import (
     resolve_webhook_config,
     send_webhook,
 )
+from xpyd_acc.retry import RetryResult
 
 
 def _make_payload(*, divergence: bool = True) -> WebhookPayload:
@@ -139,7 +140,7 @@ class TestSendWebhook:
         mock_response.raise_for_status = lambda: None
 
         with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
-            mock_retry.return_value = True
+            mock_retry.return_value = RetryResult(value=True, attempts=1)
             result = await send_webhook(config, payload)
             assert result is True
             mock_retry.assert_called_once()
@@ -150,7 +151,7 @@ class TestSendWebhook:
         payload = _make_payload(divergence=True)
 
         with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
-            mock_retry.return_value = True
+            mock_retry.return_value = RetryResult(value=True, attempts=1)
             result = await send_webhook(config, payload)
             assert result is True
 
@@ -163,7 +164,7 @@ class TestSendWebhook:
         payload = _make_payload()
 
         with patch("xpyd_acc.notify.retry_async", new_callable=AsyncMock) as mock_retry:
-            mock_retry.return_value = True
+            mock_retry.return_value = RetryResult(value=True, attempts=1)
             result = await send_webhook(config, payload)
             assert result is True
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -97,7 +97,7 @@ class TestCollectOutputRequestId:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            text, lp, returned_rid, _usage, _finish = await _collect_output(
+            text, lp, returned_rid, _usage, _finish, _att = await _collect_output(
                 "http://test:8000", "hello",
                 request_id=rid,
             )
@@ -131,7 +131,7 @@ class TestCollectOutputRequestId:
             mock_client.__aexit__ = AsyncMock(return_value=False)
             mock_client_cls.return_value = mock_client
 
-            text, lp, returned_rid, _usage, _finish = await _collect_output(
+            text, lp, returned_rid, _usage, _finish, _att = await _collect_output(
                 "http://test:8000", "hello",
                 request_id=None,
             )

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 
-from xpyd_acc.retry import RETRYABLE_STATUS_CODES, RetriesExhausted, retry_async
+from xpyd_acc.retry import (
+    RETRYABLE_STATUS_CODES,
+    RetriesExhausted,
+    RetryResult,
+    RetryStats,
+    retry_async,
+)
 
 
 def _make_error(status: int) -> httpx.HTTPStatusError:
@@ -28,7 +34,9 @@ def _make_error_with_retry_after(
 async def test_retry_succeeds_first_try() -> None:
     func = AsyncMock(return_value="ok")
     result = await retry_async(func, retries=3, base_delay=0.01)
-    assert result == "ok"
+    assert isinstance(result, RetryResult)
+    assert result.value == "ok"
+    assert result.attempts == 1
     assert func.call_count == 1
 
 
@@ -36,7 +44,8 @@ async def test_retry_succeeds_first_try() -> None:
 async def test_retry_succeeds_after_transient_timeout() -> None:
     func = AsyncMock(side_effect=[httpx.TimeoutException("timeout"), "ok"])
     result = await retry_async(func, retries=3, base_delay=0.01)
-    assert result == "ok"
+    assert result.value == "ok"
+    assert result.attempts == 2
     assert func.call_count == 2
 
 
@@ -44,7 +53,8 @@ async def test_retry_succeeds_after_transient_timeout() -> None:
 async def test_retry_succeeds_after_connect_error() -> None:
     func = AsyncMock(side_effect=[httpx.ConnectError("refused"), "ok"])
     result = await retry_async(func, retries=3, base_delay=0.01)
-    assert result == "ok"
+    assert result.value == "ok"
+    assert result.attempts == 2
     assert func.call_count == 2
 
 
@@ -52,7 +62,8 @@ async def test_retry_succeeds_after_connect_error() -> None:
 async def test_retry_on_429_status() -> None:
     func = AsyncMock(side_effect=[_make_error(429), "ok"])
     result = await retry_async(func, retries=3, base_delay=0.01)
-    assert result == "ok"
+    assert result.value == "ok"
+    assert result.attempts == 2
     assert func.call_count == 2
 
 
@@ -60,7 +71,7 @@ async def test_retry_on_429_status() -> None:
 async def test_retry_on_502_status() -> None:
     func = AsyncMock(side_effect=[_make_error(502), "ok"])
     result = await retry_async(func, retries=3, base_delay=0.01)
-    assert result == "ok"
+    assert result.value == "ok"
 
 
 @pytest.mark.asyncio
@@ -86,7 +97,8 @@ async def test_retry_respects_retry_after_header() -> None:
     func = AsyncMock(side_effect=[err, "ok"])
     # large base_delay proves Retry-After overrides backoff
     result = await retry_async(func, retries=3, base_delay=100.0)
-    assert result == "ok"
+    assert result.value == "ok"
+    assert result.attempts == 2
     assert func.call_count == 2
 
 
@@ -97,3 +109,77 @@ async def test_retryable_status_codes_coverage() -> None:
     assert 503 in RETRYABLE_STATUS_CODES
     assert 504 in RETRYABLE_STATUS_CODES
     assert 400 not in RETRYABLE_STATUS_CODES
+
+
+# --- RetryResult tests ---
+
+
+def test_retry_result_fields() -> None:
+    r = RetryResult(value="hello", attempts=3)
+    assert r.value == "hello"
+    assert r.attempts == 3
+
+
+# --- RetryStats tests ---
+
+
+def test_retry_stats_record_no_retries() -> None:
+    stats = RetryStats()
+    stats.record(RetryResult(value=None, attempts=1))
+    stats.record(RetryResult(value=None, attempts=1))
+    assert stats.total_requests == 2
+    assert stats.total_retries == 0
+    assert stats.max_retries_single == 0
+    assert stats.retried_request_count == 0
+
+
+def test_retry_stats_record_with_retries() -> None:
+    stats = RetryStats()
+    stats.record(RetryResult(value=None, attempts=1))
+    stats.record(RetryResult(value=None, attempts=3))  # 2 retries
+    stats.record(RetryResult(value=None, attempts=2))  # 1 retry
+    assert stats.total_requests == 3
+    assert stats.total_retries == 3  # 0 + 2 + 1
+    assert stats.max_retries_single == 2
+    assert stats.retried_request_count == 2
+
+
+def test_retry_stats_to_dict() -> None:
+    stats = RetryStats(
+        total_requests=5, total_retries=3,
+        max_retries_single=2, retried_request_count=2,
+    )
+    d = stats.to_dict()
+    assert d == {
+        "total_requests": 5,
+        "total_retries": 3,
+        "max_retries_single": 2,
+        "retried_request_count": 2,
+    }
+
+
+def test_retry_stats_from_dict() -> None:
+    d = {
+        "total_requests": 10, "total_retries": 4,
+        "max_retries_single": 3, "retried_request_count": 2,
+    }
+    stats = RetryStats.from_dict(d)
+    assert stats.total_requests == 10
+    assert stats.total_retries == 4
+    assert stats.max_retries_single == 3
+    assert stats.retried_request_count == 2
+
+
+def test_retry_stats_from_dict_defaults() -> None:
+    stats = RetryStats.from_dict({})
+    assert stats.total_requests == 0
+    assert stats.total_retries == 0
+
+
+def test_retry_stats_round_trip() -> None:
+    original = RetryStats(
+        total_requests=7, total_retries=2,
+        max_retries_single=1, retried_request_count=2,
+    )
+    restored = RetryStats.from_dict(original.to_dict())
+    assert restored == original

--- a/tests/test_retry_stats_integration.py
+++ b/tests/test_retry_stats_integration.py
@@ -1,0 +1,111 @@
+"""Tests for M66: Retry Statistics Reporting integration."""
+
+from __future__ import annotations
+
+import json
+
+from xpyd_acc.batch_compare import (
+    SampleResult,
+    compute_report,
+    format_report,
+    load_report,
+)
+from xpyd_acc.retry import RetryStats
+
+
+def _make_sample(sid: str, match: bool) -> SampleResult:
+    return SampleResult(
+        sample_id=sid,
+        prompt="test",
+        baseline_output="a",
+        target_output="a" if match else "b",
+        exact_match=match,
+        first_divergence_index=None if match else 0,
+        baseline_logprob_at_divergence=None,
+        target_logprob_at_divergence=None,
+        logprob_gap=None if match else 0.5,
+        classification="match" if match else "likely_bug",
+        context_length=10,
+    )
+
+
+class TestRetryStatsInReport:
+    def test_report_includes_retry_stats_in_json(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        report.retry_stats = RetryStats(
+            total_requests=4, total_retries=2,
+            max_retries_single=2, retried_request_count=1,
+        )
+        data = json.loads(report.to_json())
+        assert data["retry_stats"] is not None
+        assert data["retry_stats"]["total_requests"] == 4
+        assert data["retry_stats"]["total_retries"] == 2
+        assert data["retry_stats"]["max_retries_single"] == 2
+        assert data["retry_stats"]["retried_request_count"] == 1
+
+    def test_report_no_retry_stats_json(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        data = json.loads(report.to_json())
+        assert data["retry_stats"] is None
+
+    def test_report_round_trip_with_retry_stats(self, tmp_path) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        report.retry_stats = RetryStats(
+            total_requests=6, total_retries=3,
+            max_retries_single=2, retried_request_count=2,
+        )
+        path = tmp_path / "report.json"
+        path.write_text(report.to_json())
+        loaded = load_report(str(path))
+        assert loaded.retry_stats is not None
+        assert loaded.retry_stats.total_requests == 6
+        assert loaded.retry_stats.total_retries == 3
+        assert loaded.retry_stats.max_retries_single == 2
+        assert loaded.retry_stats.retried_request_count == 2
+
+    def test_load_report_without_retry_stats_backward_compat(self, tmp_path) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        data = json.loads(report.to_json())
+        del data["retry_stats"]
+        path = tmp_path / "report.json"
+        path.write_text(json.dumps(data))
+        loaded = load_report(str(path))
+        assert loaded.retry_stats is None
+
+    def test_format_report_with_retries(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        report.retry_stats = RetryStats(
+            total_requests=10, total_retries=5,
+            max_retries_single=3, retried_request_count=3,
+        )
+        text = format_report(report)
+        assert "Retry Statistics" in text
+        assert "Total requests:     10" in text
+        assert "Total retries:      5" in text
+
+    def test_format_report_no_retries_suppressed(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        report.retry_stats = RetryStats(total_requests=4, total_retries=0)
+        text = format_report(report)
+        assert "Retry Statistics" not in text
+
+    def test_format_report_none_retry_stats(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        text = format_report(report)
+        assert "Retry Statistics" not in text
+
+    def test_markdown_includes_retry_stats(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        report.retry_stats = RetryStats(
+            total_requests=8, total_retries=3,
+            max_retries_single=2, retried_request_count=2,
+        )
+        md = report.to_markdown()
+        assert "## Retry Statistics" in md
+        assert "Total retries | 3" in md
+
+    def test_markdown_no_retries_suppressed(self) -> None:
+        report = compute_report([_make_sample("s1", True)])
+        report.retry_stats = RetryStats(total_requests=4, total_retries=0)
+        md = report.to_markdown()
+        assert "Retry Statistics" not in md


### PR DESCRIPTION
## Summary

Adds retry statistics tracking and reporting to batch comparison runs.

### Changes
- `retry_async()` now returns `RetryResult(value, attempts)` instead of bare value
- `RetryStats` dataclass aggregates retry metrics across all requests
- `BatchReport.retry_stats` field with full JSON/Markdown/terminal output support
- All callers updated: batch_compare, logprobs, notify, reproducibility, snapshot
- Fixed pre-existing bug: `reproducibility.py` incorrectly used `retry_async` as decorator
- Backward compatible: old reports without `retry_stats` load fine

### Tests
- 25 new/updated tests covering RetryResult, RetryStats aggregation, serialization round-trip, report formatting
- All 894 tests pass

Closes #141