### PR TITLE
feat: M68 — Endpoint A/B Testing with Statistical Significance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -607,3 +607,15 @@
 - `run_batch()` and `run_multi_batch()` forward custom headers
 - CLI `batch-compare` resolves and passes headers through full chain
 - 18 tests: parsing, env var, priority chain, merging, integration, CLI flag
+
+## M68: Endpoint A/B Testing with Statistical Significance ✅
+- `xpyd-acc ab-test --report-a <path> --report-b <path>` compares divergence rates
+- Fisher's exact test (pure Python, no scipy) for statistical significance
+- Chi-square test with Yates' correction as secondary test
+- Effect size via odds ratio and 95% confidence interval for rate difference
+- `--alpha <float>` flag (default 0.05) for significance level
+- `--json <path>` export of full test results
+- Exit code: 0 if no significant difference, 1 if significant (CI-friendly)
+- Rich terminal output with clear verdict
+- `ab_test.py` module: `ABTestResult`, `run_ab_test()`, `format_ab_test()`
+- 26 tests: Fisher exact, chi-square, A/B test logic, JSON export, CLI integration

--- a/src/xpyd_acc/ab_test.py
+++ b/src/xpyd_acc/ab_test.py
@@ -1,0 +1,291 @@
+"""A/B testing for comparing divergence rates between two batch reports.
+
+Performs Fisher's exact test and chi-square test to determine whether the
+difference in divergence rates between two target endpoints is statistically
+significant.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+@dataclass
+class ABTestResult:
+    """Result of an A/B test comparing two batch reports."""
+
+    # Report A stats
+    report_a_total: int
+    report_a_divergent: int
+    report_a_rate: float
+
+    # Report B stats
+    report_b_total: int
+    report_b_divergent: int
+    report_b_rate: float
+
+    # Rate difference
+    rate_difference: float  # B - A
+    rate_difference_ci_lower: float
+    rate_difference_ci_upper: float
+
+    # Statistical tests
+    fisher_p_value: float
+    chi_square_statistic: float
+    chi_square_p_value: float
+    odds_ratio: float | None  # None if undefined (zero cell)
+
+    # Verdict
+    alpha: float
+    significant: bool  # True if p < alpha
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        return json.dumps(asdict(self), indent=2)
+
+    def save_json(self, path: str | Path) -> None:
+        """Write JSON to file."""
+        Path(path).write_text(self.to_json(), encoding="utf-8")
+
+
+def _log_factorial(n: int) -> float:
+    """Compute log(n!) using Stirling's approximation for large n."""
+    if n <= 1:
+        return 0.0
+    return sum(math.log(i) for i in range(2, n + 1))
+
+
+def _hypergeometric_log_pmf(k: int, n: int, K: int, N: int) -> float:
+    """Log probability mass function of hypergeometric distribution.
+
+    P(X=k) = C(K,k) * C(N-K, n-k) / C(N, n)
+    """
+    return (
+        _log_comb(K, k)
+        + _log_comb(N - K, n - k)
+        - _log_comb(N, n)
+    )
+
+
+def _log_comb(n: int, k: int) -> float:
+    """Log of binomial coefficient C(n, k)."""
+    if k < 0 or k > n:
+        return -math.inf
+    return _log_factorial(n) - _log_factorial(k) - _log_factorial(n - k)
+
+
+def fisher_exact_two_sided(a: int, b: int, c: int, d: int) -> float:
+    """Two-sided Fisher's exact test for a 2x2 contingency table.
+
+    Table:
+        [[a, b],
+         [c, d]]
+
+    Returns p-value.
+    """
+    n = a + b + c + d
+    row1 = a + b
+    col1 = a + c
+
+    # Log probability of observed table
+    log_p_observed = _hypergeometric_log_pmf(a, row1, col1, n)
+
+    # Sum probabilities of all tables with P <= P(observed)
+    total_p = 0.0
+    min_a = max(0, row1 + col1 - n)
+    max_a = min(row1, col1)
+
+    for a_i in range(min_a, max_a + 1):
+        log_p_i = _hypergeometric_log_pmf(a_i, row1, col1, n)
+        if log_p_i <= log_p_observed + 1e-10:  # small tolerance for floating point
+            total_p += math.exp(log_p_i)
+
+    return min(total_p, 1.0)
+
+
+def chi_square_test(a: int, b: int, c: int, d: int) -> tuple[float, float]:
+    """Chi-square test with Yates' correction for a 2x2 table.
+
+    Returns (chi_square_statistic, p_value).
+    """
+    n = a + b + c + d
+    if n == 0:
+        return 0.0, 1.0
+
+    row1 = a + b
+    row2 = c + d
+    col1 = a + c
+    col2 = b + d
+
+    # Check for zero marginals
+    if row1 == 0 or row2 == 0 or col1 == 0 or col2 == 0:
+        return 0.0, 1.0
+
+    # Yates' correction
+    numerator = (abs(a * d - b * c) - n / 2) ** 2 * n
+    denominator = row1 * row2 * col1 * col2
+
+    if denominator == 0:
+        return 0.0, 1.0
+
+    chi2 = numerator / denominator
+    chi2 = max(chi2, 0.0)
+
+    # p-value from chi-square distribution with 1 df
+    p_value = _chi2_sf(chi2, 1)
+    return chi2, p_value
+
+
+def _chi2_sf(x: float, df: int) -> float:
+    """Survival function (1 - CDF) of chi-square distribution.
+
+    Uses the regularized incomplete gamma function for df=1.
+    """
+    if x <= 0:
+        return 1.0
+    if df == 1:
+        # For df=1: P(X > x) = 2 * (1 - Phi(sqrt(x))) = erfc(sqrt(x/2))
+        return math.erfc(math.sqrt(x / 2))
+    # General case via incomplete gamma (not needed for our use case)
+    return math.erfc(math.sqrt(x / 2))
+
+
+def _rate_difference_ci(
+    n1: int, x1: int, n2: int, x2: int, confidence: float = 0.95,
+) -> tuple[float, float]:
+    """Wald confidence interval for the difference of two proportions (p2 - p1)."""
+    if n1 == 0 or n2 == 0:
+        return -1.0, 1.0
+
+    p1 = x1 / n1
+    p2 = x2 / n2
+    diff = p2 - p1
+
+    z = _normal_quantile((1 + confidence) / 2)
+    se = math.sqrt(p1 * (1 - p1) / n1 + p2 * (1 - p2) / n2)
+
+    lower = max(diff - z * se, -1.0)
+    upper = min(diff + z * se, 1.0)
+    return lower, upper
+
+
+def _normal_quantile(p: float) -> float:
+    """Approximate quantile of the standard normal distribution.
+
+    Uses Abramowitz and Stegun approximation 26.2.23.
+    """
+    if p <= 0 or p >= 1:
+        return 0.0
+    if p < 0.5:
+        return -_normal_quantile(1 - p)
+    t = math.sqrt(-2 * math.log(1 - p))
+    c0, c1, c2 = 2.515517, 0.802853, 0.010328
+    d1, d2, d3 = 1.432788, 0.189269, 0.001308
+    return t - (c0 + c1 * t + c2 * t * t) / (1 + d1 * t + d2 * t * t + d3 * t * t * t)
+
+
+def run_ab_test(
+    report_a_total: int,
+    report_a_divergent: int,
+    report_b_total: int,
+    report_b_divergent: int,
+    alpha: float = 0.05,
+) -> ABTestResult:
+    """Run A/B test comparing divergence rates from two batch reports.
+
+    Args:
+        report_a_total: Total samples in report A.
+        report_a_divergent: Divergent samples in report A.
+        report_b_total: Total samples in report B.
+        report_b_divergent: Divergent samples in report B.
+        alpha: Significance level (default 0.05).
+
+    Returns:
+        ABTestResult with test statistics and verdict.
+    """
+    rate_a = report_a_divergent / report_a_total if report_a_total > 0 else 0.0
+    rate_b = report_b_divergent / report_b_total if report_b_total > 0 else 0.0
+
+    # 2x2 contingency table:
+    # [[a_match, a_div], [b_match, b_div]]
+    a_match = report_a_total - report_a_divergent
+    a_div = report_a_divergent
+    b_match = report_b_total - report_b_divergent
+    b_div = report_b_divergent
+
+    # Fisher's exact test
+    fisher_p = fisher_exact_two_sided(a_match, a_div, b_match, b_div)
+
+    # Chi-square test
+    chi2_stat, chi2_p = chi_square_test(a_match, a_div, b_match, b_div)
+
+    # Odds ratio
+    if a_div > 0 and b_match > 0:
+        odds_ratio: float | None = (a_match * b_div) / (a_div * b_match)
+    elif a_div == 0 and b_div == 0:
+        odds_ratio = 1.0
+    else:
+        odds_ratio = None
+
+    # CI for rate difference
+    ci_lower, ci_upper = _rate_difference_ci(
+        report_a_total, report_a_divergent,
+        report_b_total, report_b_divergent,
+    )
+
+    # Use Fisher p-value for significance decision
+    significant = fisher_p < alpha
+
+    return ABTestResult(
+        report_a_total=report_a_total,
+        report_a_divergent=report_a_divergent,
+        report_a_rate=round(rate_a, 6),
+        report_b_total=report_b_total,
+        report_b_divergent=report_b_divergent,
+        report_b_rate=round(rate_b, 6),
+        rate_difference=round(rate_b - rate_a, 6),
+        rate_difference_ci_lower=round(ci_lower, 6),
+        rate_difference_ci_upper=round(ci_upper, 6),
+        fisher_p_value=round(fisher_p, 6),
+        chi_square_statistic=round(chi2_stat, 6),
+        chi_square_p_value=round(chi2_p, 6),
+        odds_ratio=round(odds_ratio, 6) if odds_ratio is not None else None,
+        alpha=alpha,
+        significant=significant,
+    )
+
+
+def format_ab_test(result: ABTestResult) -> str:
+    """Format A/B test result as rich terminal text."""
+    lines = [
+        "=== A/B Test: Divergence Rate Comparison ===",
+        "",
+        f"  Report A: {result.report_a_divergent}/{result.report_a_total} "
+        f"divergent ({result.report_a_rate:.2%})",
+        f"  Report B: {result.report_b_divergent}/{result.report_b_total} "
+        f"divergent ({result.report_b_rate:.2%})",
+        "",
+        f"  Rate difference (B - A): {result.rate_difference:+.4f} "
+        f"[{result.rate_difference_ci_lower:+.4f}, {result.rate_difference_ci_upper:+.4f}]",
+    ]
+    if result.odds_ratio is not None:
+        lines.append(f"  Odds ratio: {result.odds_ratio:.4f}")
+    else:
+        lines.append("  Odds ratio: undefined (zero cell)")
+    lines.extend([
+        "",
+        f"  Fisher's exact p-value: {result.fisher_p_value:.6f}",
+        f"  Chi-square statistic:   {result.chi_square_statistic:.4f}  "
+        f"(p = {result.chi_square_p_value:.6f})",
+        "",
+        f"  Alpha: {result.alpha}",
+    ])
+    if result.significant:
+        lines.append("  ❌ SIGNIFICANT DIFFERENCE — divergence rates differ (p < alpha)")
+    else:
+        lines.append("  ✅ NO SIGNIFICANT DIFFERENCE — divergence rates are compatible (p ≥ alpha)")
+
+    return "\n".join(lines)

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -347,6 +347,19 @@ def main(argv: list[str] | None = None) -> None:
         help="Export diff result as JSON",
     )
 
+    # ab-test
+    ab = sub.add_parser("ab-test", help="A/B test divergence rates from two batch reports")
+    ab.add_argument("--report-a", required=True, help="Path to first batch report JSON")
+    ab.add_argument("--report-b", required=True, help="Path to second batch report JSON")
+    ab.add_argument(
+        "--alpha", type=float, default=0.05,
+        help="Significance level (default: 0.05)",
+    )
+    ab.add_argument(
+        "--json", dest="json_path", default=None,
+        help="Export A/B test result as JSON",
+    )
+
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
     kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
@@ -847,6 +860,8 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_bisect(args))
     elif args.command == "dataset-stats":
         _run_dataset_stats(args)
+    elif args.command == "ab-test":
+        _run_ab_test(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -1880,6 +1895,32 @@ def _run_diff(args: argparse.Namespace) -> None:
         print(f"\nDiff result exported to {args.json_path}")
 
     sys.exit(1 if result.regressions > 0 else 0)
+
+
+def _run_ab_test(args: argparse.Namespace) -> None:
+    """Run A/B test comparing divergence rates from two batch reports."""
+    import json as json_mod
+    from pathlib import Path
+
+    from xpyd_acc.ab_test import format_ab_test, run_ab_test
+
+    report_a = json_mod.loads(Path(args.report_a).read_text(encoding="utf-8"))
+    report_b = json_mod.loads(Path(args.report_b).read_text(encoding="utf-8"))
+
+    result = run_ab_test(
+        report_a_total=report_a["total_samples"],
+        report_a_divergent=report_a["divergent_samples"],
+        report_b_total=report_b["total_samples"],
+        report_b_divergent=report_b["divergent_samples"],
+        alpha=args.alpha,
+    )
+    print(format_ab_test(result))
+
+    if getattr(args, "json_path", None):
+        result.save_json(args.json_path)
+        print(f"\nA/B test result exported to {args.json_path}")
+
+    sys.exit(1 if result.significant else 0)
 
 
 def _run_aggregate(args: argparse.Namespace) -> None:

--- a/tests/test_ab_test.py
+++ b/tests/test_ab_test.py
@@ -1,0 +1,223 @@
+"""Tests for the ab_test module — A/B testing for divergence rates."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.ab_test import (
+    chi_square_test,
+    fisher_exact_two_sided,
+    format_ab_test,
+    run_ab_test,
+)
+
+
+class TestFisherExact:
+    """Tests for Fisher's exact test implementation."""
+
+    def test_identical_tables(self):
+        """Identical proportions should give p ≈ 1."""
+        p = fisher_exact_two_sided(50, 50, 50, 50)
+        assert p > 0.9
+
+    def test_extreme_difference(self):
+        """Completely different proportions should give small p."""
+        p = fisher_exact_two_sided(100, 0, 0, 100)
+        assert p < 0.001
+
+    def test_known_table(self):
+        """Verify against a known 2x2 table."""
+        # Classic tea-tasting example-like table
+        p = fisher_exact_two_sided(8, 2, 1, 9)
+        assert p < 0.05
+
+    def test_symmetric(self):
+        """Swapping rows shouldn't change p-value."""
+        p1 = fisher_exact_two_sided(10, 5, 3, 12)
+        p2 = fisher_exact_two_sided(3, 12, 10, 5)
+        assert abs(p1 - p2) < 1e-10
+
+    def test_zero_cell(self):
+        """Should handle zero cells gracefully."""
+        p = fisher_exact_two_sided(0, 10, 10, 0)
+        assert p < 0.001
+
+    def test_single_sample(self):
+        """Edge case: single sample per group."""
+        p = fisher_exact_two_sided(1, 0, 0, 1)
+        assert 0 <= p <= 1.0
+
+
+class TestChiSquare:
+    """Tests for chi-square test implementation."""
+
+    def test_identical(self):
+        stat, p = chi_square_test(50, 50, 50, 50)
+        assert p > 0.8
+        assert stat < 0.5
+
+    def test_extreme(self):
+        stat, p = chi_square_test(100, 0, 0, 100)
+        assert p < 0.001
+        assert stat > 10
+
+    def test_zero_marginal(self):
+        stat, p = chi_square_test(0, 0, 10, 10)
+        assert stat == 0.0
+        assert p == 1.0
+
+    def test_all_zero(self):
+        stat, p = chi_square_test(0, 0, 0, 0)
+        assert stat == 0.0
+        assert p == 1.0
+
+
+class TestRunABTest:
+    """Tests for the main run_ab_test function."""
+
+    def test_no_difference(self):
+        result = run_ab_test(100, 10, 100, 10)
+        assert not result.significant
+        assert result.rate_difference == 0.0
+
+    def test_large_difference(self):
+        result = run_ab_test(100, 5, 100, 50)
+        assert result.significant
+        assert result.rate_difference > 0
+
+    def test_report_rates(self):
+        result = run_ab_test(200, 20, 200, 40)
+        assert result.report_a_rate == pytest.approx(0.1, abs=0.001)
+        assert result.report_b_rate == pytest.approx(0.2, abs=0.001)
+
+    def test_custom_alpha(self):
+        """Marginal case: significant at 0.10 but not at 0.01."""
+        result_loose = run_ab_test(50, 5, 50, 12, alpha=0.10)
+        result_strict = run_ab_test(50, 5, 50, 12, alpha=0.001)
+        # Both should return valid results
+        assert isinstance(result_loose.significant, bool)
+        assert isinstance(result_strict.significant, bool)
+
+    def test_zero_divergent(self):
+        result = run_ab_test(100, 0, 100, 0)
+        assert not result.significant
+        assert result.rate_difference == 0.0
+        assert result.odds_ratio == 1.0
+
+    def test_all_divergent(self):
+        result = run_ab_test(100, 100, 100, 100)
+        assert not result.significant
+        assert result.rate_difference == 0.0
+
+    def test_odds_ratio_undefined(self):
+        """When one group has zero divergent, odds ratio should be None."""
+        result = run_ab_test(100, 0, 100, 50)
+        assert result.odds_ratio is None
+
+    def test_ci_contains_zero_when_not_significant(self):
+        result = run_ab_test(100, 10, 100, 12)
+        assert result.rate_difference_ci_lower <= 0 <= result.rate_difference_ci_upper
+
+    def test_json_export(self, tmp_path: Path):
+        result = run_ab_test(100, 10, 100, 30)
+        out = tmp_path / "ab_result.json"
+        result.save_json(out)
+        data = json.loads(out.read_text())
+        assert data["report_a_total"] == 100
+        assert data["report_b_divergent"] == 30
+        assert "fisher_p_value" in data
+        assert "significant" in data
+
+    def test_to_json_roundtrip(self):
+        result = run_ab_test(50, 5, 50, 15)
+        data = json.loads(result.to_json())
+        assert data["alpha"] == 0.05
+
+
+class TestFormatABTest:
+    """Tests for format_ab_test."""
+
+    def test_significant_output(self):
+        result = run_ab_test(100, 5, 100, 50)
+        text = format_ab_test(result)
+        assert "SIGNIFICANT DIFFERENCE" in text
+
+    def test_not_significant_output(self):
+        result = run_ab_test(100, 10, 100, 12)
+        text = format_ab_test(result)
+        assert "NO SIGNIFICANT DIFFERENCE" in text
+
+    def test_undefined_odds(self):
+        result = run_ab_test(100, 0, 100, 50)
+        text = format_ab_test(result)
+        assert "undefined" in text
+
+
+class TestCLIIntegration:
+    """Tests for CLI ab-test subcommand."""
+
+    def test_cli_ab_test_no_sig(self, tmp_path: Path):
+        """ab-test exits 0 when no significant difference."""
+        from io import StringIO
+        from unittest.mock import patch
+
+        report_a = {"total_samples": 100, "divergent_samples": 10}
+        report_b = {"total_samples": 100, "divergent_samples": 10}
+        a_path = tmp_path / "a.json"
+        b_path = tmp_path / "b.json"
+        a_path.write_text(json.dumps(report_a))
+        b_path.write_text(json.dumps(report_b))
+
+        from xpyd_acc import cli
+
+        with (
+            pytest.raises(SystemExit) as exc_info,
+            patch("sys.stdout", new_callable=StringIO) as mock_out,
+        ):
+            cli.main(["ab-test", "--report-a", str(a_path), "--report-b", str(b_path)])
+        assert exc_info.value.code == 0
+        assert "NO SIGNIFICANT DIFFERENCE" in mock_out.getvalue()
+
+    def test_cli_ab_test_significant(self, tmp_path: Path):
+        """ab-test exits 1 when significant difference."""
+        from io import StringIO
+        from unittest.mock import patch
+
+        report_a = {"total_samples": 200, "divergent_samples": 5}
+        report_b = {"total_samples": 200, "divergent_samples": 80}
+        a_path = tmp_path / "a.json"
+        b_path = tmp_path / "b.json"
+        a_path.write_text(json.dumps(report_a))
+        b_path.write_text(json.dumps(report_b))
+
+        from xpyd_acc import cli
+
+        with (
+            pytest.raises(SystemExit) as exc_info,
+            patch("sys.stdout", new_callable=StringIO) as mock_out,
+        ):
+            cli.main(["ab-test", "--report-a", str(a_path), "--report-b", str(b_path)])
+        assert exc_info.value.code == 1
+        assert "SIGNIFICANT DIFFERENCE" in mock_out.getvalue()
+
+    def test_cli_ab_test_json_export(self, tmp_path: Path):
+        from io import StringIO
+        from unittest.mock import patch
+
+        report_a = {"total_samples": 100, "divergent_samples": 5}
+        report_b = {"total_samples": 100, "divergent_samples": 40}
+        a_path = tmp_path / "a.json"
+        b_path = tmp_path / "b.json"
+        out_path = tmp_path / "out.json"
+        a_path.write_text(json.dumps(report_a))
+        b_path.write_text(json.dumps(report_b))
+
+        from xpyd_acc import cli
+
+        with pytest.raises(SystemExit), patch("sys.stdout", new_callable=StringIO):
+            cli.main(["ab-test", "--report-a", str(a_path), "--report-b", str(b_path),
+                       "--json", str(out_path)])
+        assert out_path.exists()
+        data = json.loads(out_path.read_text())
+        assert "fisher_p_value" in data


### PR DESCRIPTION
## Summary
Add A/B testing capability to compare divergence rates from two batch reports with statistical significance testing.

## Changes
- **`ab_test.py`**: Fisher's exact test (pure Python), chi-square with Yates' correction, odds ratio, CI for rate difference
- **CLI**: `xpyd-acc ab-test --report-a <path> --report-b <path> [--alpha 0.05] [--json <path>]`
- **Exit codes**: 0 = no significant difference, 1 = significant (CI-friendly)
- **26 tests** covering math, edge cases, formatting, CLI integration
- **ROADMAP.md** updated with M68

## Testing
```
python3 -m pytest tests/test_ab_test.py -v  # 26 passed
ruff check src tests && isort --check src tests  # All passed
python3 -m pytest tests/ -x -q  # 951 passed
```

Closes #145