### PR TITLE
feat: M70 — Output Entropy Analysis

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -632,3 +632,15 @@
 - Rich terminal output with clear verdict
 - `ab_test.py` module: `ABTestResult`, `run_ab_test()`, `format_ab_test()`
 - 26 tests: Fisher exact, chi-square, A/B test logic, JSON export, CLI integration
+
+## M70: Output Entropy Analysis ✅
+- `entropy.py` module: per-token Shannon entropy from top-K logprob distributions
+- `token_entropy()`, `sequence_entropy()`, `entropy_stats()`, `entropy_at_divergence()`
+- `EntropyStats` and `EntropyComparison` dataclasses with `to_dict()` serialization
+- CLI: `xpyd-acc entropy --baseline-logprobs <path> [--target-logprobs <path>]`
+- `--divergence-index <int>` for focused analysis at divergence point with context window
+- `--context-window <int>` configurable (default 5)
+- `--json <path>` export
+- Rich terminal formatting for stats and comparison
+- Handles edge cases: empty, single token, non-normalized logprobs
+- 22 tests covering computation, edge cases, formatting, file I/O, CLI integration

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -383,6 +383,26 @@ def main(argv: list[str] | None = None) -> None:
     csweep.add_argument("--json", dest="json_path", default=None, help="Export results as JSON")
     _add_sampling_args(csweep)
 
+    # entropy
+    ent = sub.add_parser("entropy", help="Analyze output entropy from logprob files")
+    ent.add_argument(
+        "--baseline-logprobs", required=True,
+        help="Path to baseline logprobs JSON file",
+    )
+    ent.add_argument(
+        "--target-logprobs", default=None,
+        help="Path to target logprobs JSON file (optional, for comparison)",
+    )
+    ent.add_argument(
+        "--divergence-index", type=int, default=None,
+        help="Token index of divergence for focused analysis",
+    )
+    ent.add_argument(
+        "--context-window", type=int, default=5,
+        help="Context window around divergence point (default: 5)",
+    )
+    ent.add_argument("--json", dest="json_path", default=None, help="Export results as JSON")
+
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
     kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
@@ -887,6 +907,8 @@ def main(argv: list[str] | None = None) -> None:
         _run_ab_test(args)
     elif args.command == "concurrency-sweep":
         asyncio.run(_run_concurrency_sweep(args))
+    elif args.command == "entropy":
+        _run_entropy(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -2864,3 +2886,44 @@ async def _run_concurrency_sweep(args: argparse.Namespace) -> None:
 
     if result.any_divergence:
         raise SystemExit(1)
+
+
+def _run_entropy(args: argparse.Namespace) -> None:
+    """Run entropy analysis on logprob files."""
+    import json
+    from pathlib import Path
+
+    from xpyd_acc.entropy import (
+        entropy_at_divergence,
+        entropy_stats,
+        format_entropy_comparison,
+        format_entropy_stats,
+        load_logprobs_file,
+        sequence_entropy,
+    )
+
+    baseline_lp = load_logprobs_file(args.baseline_logprobs)
+    bl_entropies = sequence_entropy(baseline_lp)
+    bl_stats = entropy_stats(bl_entropies)
+
+    output: dict = {"baseline_stats": bl_stats.to_dict()}
+    print("Baseline " + format_entropy_stats(bl_stats))
+
+    if args.target_logprobs:
+        target_lp = load_logprobs_file(args.target_logprobs)
+        tg_entropies = sequence_entropy(target_lp)
+        tg_stats = entropy_stats(tg_entropies)
+        output["target_stats"] = tg_stats.to_dict()
+        print("\nTarget " + format_entropy_stats(tg_stats))
+
+        if args.divergence_index is not None:
+            comp = entropy_at_divergence(
+                baseline_lp, target_lp, args.divergence_index,
+                context_window=args.context_window,
+            )
+            output["comparison"] = comp.to_dict()
+            print("\n" + format_entropy_comparison(comp))
+
+    if args.json_path:
+        Path(args.json_path).write_text(json.dumps(output, indent=2))
+        print(f"\nExported to {args.json_path}")

--- a/src/xpyd_acc/entropy.py
+++ b/src/xpyd_acc/entropy.py
@@ -1,0 +1,215 @@
+"""Output entropy analysis for divergence characterization."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class EntropyStats:
+    """Summary statistics for a sequence of entropy values."""
+
+    min: float
+    max: float
+    mean: float
+    median: float
+    p95: float
+    count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "min": self.min,
+            "max": self.max,
+            "mean": self.mean,
+            "median": self.median,
+            "p95": self.p95,
+            "count": self.count,
+        }
+
+
+@dataclass
+class EntropyComparison:
+    """Entropy comparison at and around a divergence point."""
+
+    divergence_index: int
+    baseline_entropy: float
+    target_entropy: float
+    delta: float
+    context_baseline: list[float] = field(default_factory=list)
+    context_target: list[float] = field(default_factory=list)
+    context_start: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "divergence_index": self.divergence_index,
+            "baseline_entropy": self.baseline_entropy,
+            "target_entropy": self.target_entropy,
+            "delta": self.delta,
+            "context_baseline": self.context_baseline,
+            "context_target": self.context_target,
+            "context_start": self.context_start,
+        }
+
+
+def token_entropy(logprobs: dict[str, float]) -> float:
+    """Compute Shannon entropy (in nats) from a top-K logprob dict.
+
+    Parameters
+    ----------
+    logprobs : dict[str, float]
+        Mapping of token string to log-probability (natural log).
+
+    Returns
+    -------
+    float
+        Shannon entropy. Returns 0.0 for empty or single-token dicts.
+    """
+    if len(logprobs) <= 1:
+        return 0.0
+
+    probs = [math.exp(lp) for lp in logprobs.values()]
+    total = sum(probs)
+    if total <= 0:
+        return 0.0
+
+    entropy = 0.0
+    for p in probs:
+        p_norm = p / total
+        if p_norm > 0:
+            entropy -= p_norm * math.log(p_norm)
+    return entropy
+
+
+def sequence_entropy(token_logprobs: list[dict[str, float]]) -> list[float]:
+    """Compute per-position entropy for a sequence of logprob dicts."""
+    return [token_entropy(lp) for lp in token_logprobs]
+
+
+def entropy_stats(entropies: list[float]) -> EntropyStats:
+    """Compute summary statistics for a list of entropy values.
+
+    Parameters
+    ----------
+    entropies : list[float]
+        Per-position entropy values.
+
+    Returns
+    -------
+    EntropyStats
+        Summary statistics. For empty list, all values are 0.0.
+    """
+    if not entropies:
+        return EntropyStats(min=0.0, max=0.0, mean=0.0, median=0.0, p95=0.0, count=0)
+
+    sorted_e = sorted(entropies)
+    n = len(sorted_e)
+    p95_idx = min(int(n * 0.95), n - 1)
+
+    return EntropyStats(
+        min=sorted_e[0],
+        max=sorted_e[-1],
+        mean=statistics.mean(sorted_e),
+        median=statistics.median(sorted_e),
+        p95=sorted_e[p95_idx],
+        count=n,
+    )
+
+
+def entropy_at_divergence(
+    baseline_logprobs: list[dict[str, float]],
+    target_logprobs: list[dict[str, float]],
+    divergence_index: int,
+    context_window: int = 5,
+) -> EntropyComparison:
+    """Compare entropy at and around a divergence point.
+
+    Parameters
+    ----------
+    baseline_logprobs : list[dict[str, float]]
+        Per-position top-K logprobs from baseline.
+    target_logprobs : list[dict[str, float]]
+        Per-position top-K logprobs from target.
+    divergence_index : int
+        Token index where divergence was detected.
+    context_window : int
+        Number of positions before and after to include.
+
+    Returns
+    -------
+    EntropyComparison
+        Entropy data at the divergence point with context.
+    """
+    if divergence_index < len(baseline_logprobs):
+        bl_entropy = token_entropy(baseline_logprobs[divergence_index])
+    else:
+        bl_entropy = 0.0
+    if divergence_index < len(target_logprobs):
+        tg_entropy = token_entropy(target_logprobs[divergence_index])
+    else:
+        tg_entropy = 0.0
+
+    start = max(0, divergence_index - context_window)
+    end_bl = min(len(baseline_logprobs), divergence_index + context_window + 1)
+    end_tg = min(len(target_logprobs), divergence_index + context_window + 1)
+
+    ctx_bl = [token_entropy(baseline_logprobs[i]) for i in range(start, end_bl)]
+    ctx_tg = [token_entropy(target_logprobs[i]) for i in range(start, end_tg)]
+
+    return EntropyComparison(
+        divergence_index=divergence_index,
+        baseline_entropy=bl_entropy,
+        target_entropy=tg_entropy,
+        delta=tg_entropy - bl_entropy,
+        context_baseline=ctx_bl,
+        context_target=ctx_tg,
+        context_start=start,
+    )
+
+
+def format_entropy_stats(stats: EntropyStats) -> str:
+    """Format entropy stats for terminal display."""
+    lines = [
+        "Entropy Statistics",
+        "=" * 40,
+        f"  Count:  {stats.count}",
+        f"  Min:    {stats.min:.4f}",
+        f"  Max:    {stats.max:.4f}",
+        f"  Mean:   {stats.mean:.4f}",
+        f"  Median: {stats.median:.4f}",
+        f"  P95:    {stats.p95:.4f}",
+    ]
+    return "\n".join(lines)
+
+
+def format_entropy_comparison(comp: EntropyComparison) -> str:
+    """Format entropy comparison for terminal display."""
+    ctx_end = comp.context_start + len(comp.context_baseline) - 1
+    lines = [
+        f"Entropy at divergence (index {comp.divergence_index})",
+        "=" * 50,
+        f"  Baseline entropy: {comp.baseline_entropy:.4f}",
+        f"  Target entropy:   {comp.target_entropy:.4f}",
+        f"  Delta (T-B):      {comp.delta:+.4f}",
+        "",
+        f"Context window (positions {comp.context_start}–{ctx_end}):",
+        f"  Baseline: {[round(e, 4) for e in comp.context_baseline]}",
+        f"  Target:   {[round(e, 4) for e in comp.context_target]}",
+    ]
+    return "\n".join(lines)
+
+
+def load_logprobs_file(path: str) -> list[dict[str, float]]:
+    """Load logprobs from a JSON file.
+
+    Expected format: list of dicts, each mapping token string to logprob float.
+    """
+    with open(path) as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        msg = f"Expected JSON array, got {type(data).__name__}"
+        raise ValueError(msg)
+    return data

--- a/tests/test_entropy.py
+++ b/tests/test_entropy.py
@@ -1,0 +1,256 @@
+"""Tests for entropy analysis module."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.entropy import (
+    EntropyComparison,
+    EntropyStats,
+    entropy_at_divergence,
+    entropy_stats,
+    format_entropy_comparison,
+    format_entropy_stats,
+    load_logprobs_file,
+    sequence_entropy,
+    token_entropy,
+)
+
+# ---------------------------------------------------------------------------
+# token_entropy tests
+# ---------------------------------------------------------------------------
+
+
+def test_token_entropy_empty():
+    assert token_entropy({}) == 0.0
+
+
+def test_token_entropy_single_token():
+    assert token_entropy({"hello": -0.1}) == 0.0
+
+
+def test_token_entropy_uniform_two():
+    """Two equally likely tokens → ln(2)."""
+    lp = math.log(0.5)
+    ent = token_entropy({"a": lp, "b": lp})
+    assert abs(ent - math.log(2)) < 1e-9
+
+
+def test_token_entropy_skewed():
+    """One dominant token → low entropy."""
+    lp_high = math.log(0.99)
+    lp_low = math.log(0.01)
+    ent = token_entropy({"a": lp_high, "b": lp_low})
+    assert ent < math.log(2)
+    assert ent > 0.0
+
+
+def test_token_entropy_three_uniform():
+    lp = math.log(1.0 / 3.0)
+    ent = token_entropy({"a": lp, "b": lp, "c": lp})
+    assert abs(ent - math.log(3)) < 1e-9
+
+
+def test_token_entropy_normalizes():
+    """Logprobs that don't sum to 1 are normalized."""
+    ent = token_entropy({"a": -1.0, "b": -1.0})
+    # Both equal → should still be ln(2)
+    assert abs(ent - math.log(2)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# sequence_entropy tests
+# ---------------------------------------------------------------------------
+
+
+def test_sequence_entropy_empty():
+    assert sequence_entropy([]) == []
+
+
+def test_sequence_entropy_basic():
+    lps = [
+        {"a": math.log(0.5), "b": math.log(0.5)},
+        {"a": math.log(0.9), "b": math.log(0.1)},
+    ]
+    result = sequence_entropy(lps)
+    assert len(result) == 2
+    assert abs(result[0] - math.log(2)) < 1e-9
+    assert result[1] < result[0]
+
+
+# ---------------------------------------------------------------------------
+# entropy_stats tests
+# ---------------------------------------------------------------------------
+
+
+def test_entropy_stats_empty():
+    stats = entropy_stats([])
+    assert stats.count == 0
+    assert stats.mean == 0.0
+
+
+def test_entropy_stats_single():
+    stats = entropy_stats([1.5])
+    assert stats.count == 1
+    assert stats.min == 1.5
+    assert stats.max == 1.5
+    assert stats.mean == 1.5
+
+
+def test_entropy_stats_multiple():
+    vals = [0.1, 0.5, 0.3, 0.9, 0.2]
+    stats = entropy_stats(vals)
+    assert stats.count == 5
+    assert stats.min == 0.1
+    assert stats.max == 0.9
+
+
+def test_entropy_stats_to_dict():
+    stats = EntropyStats(min=0.1, max=0.9, mean=0.5, median=0.4, p95=0.8, count=10)
+    d = stats.to_dict()
+    assert d["count"] == 10
+    assert d["min"] == 0.1
+
+
+# ---------------------------------------------------------------------------
+# entropy_at_divergence tests
+# ---------------------------------------------------------------------------
+
+
+def test_entropy_at_divergence_basic():
+    bl = [{"a": math.log(0.5), "b": math.log(0.5)}] * 10
+    tg = [{"a": math.log(0.9), "b": math.log(0.1)}] * 10
+    comp = entropy_at_divergence(bl, tg, 5, context_window=2)
+    assert comp.divergence_index == 5
+    assert comp.baseline_entropy > comp.target_entropy
+    assert comp.delta < 0
+    assert comp.context_start == 3
+    assert len(comp.context_baseline) == 5  # positions 3,4,5,6,7
+
+
+def test_entropy_at_divergence_start():
+    bl = [{"a": math.log(0.5), "b": math.log(0.5)}] * 3
+    tg = [{"a": math.log(0.5), "b": math.log(0.5)}] * 3
+    comp = entropy_at_divergence(bl, tg, 0, context_window=5)
+    assert comp.context_start == 0
+    assert len(comp.context_baseline) == 3
+
+
+def test_entropy_comparison_to_dict():
+    comp = EntropyComparison(
+        divergence_index=5,
+        baseline_entropy=0.5,
+        target_entropy=0.3,
+        delta=-0.2,
+        context_baseline=[0.5, 0.5, 0.5],
+        context_target=[0.3, 0.3, 0.3],
+        context_start=3,
+    )
+    d = comp.to_dict()
+    assert d["divergence_index"] == 5
+    assert d["delta"] == -0.2
+
+
+# ---------------------------------------------------------------------------
+# Format tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_entropy_stats():
+    stats = EntropyStats(min=0.1, max=0.9, mean=0.5, median=0.4, p95=0.8, count=10)
+    text = format_entropy_stats(stats)
+    assert "0.1000" in text
+    assert "Count" in text
+
+
+def test_format_entropy_comparison():
+    comp = EntropyComparison(
+        divergence_index=5, baseline_entropy=0.5, target_entropy=0.3,
+        delta=-0.2, context_baseline=[0.5], context_target=[0.3],
+        context_start=5,
+    )
+    text = format_entropy_comparison(comp)
+    assert "index 5" in text
+    assert "Delta" in text
+
+
+# ---------------------------------------------------------------------------
+# File loading tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_logprobs_file(tmp_path: Path):
+    data = [{"a": -0.5, "b": -1.2}, {"c": -0.1}]
+    f = tmp_path / "lp.json"
+    f.write_text(json.dumps(data))
+    loaded = load_logprobs_file(str(f))
+    assert len(loaded) == 2
+    assert loaded[0]["a"] == -0.5
+
+
+def test_load_logprobs_file_invalid(tmp_path: Path):
+    f = tmp_path / "bad.json"
+    f.write_text('{"not": "a list"}')
+    with pytest.raises(ValueError, match="Expected JSON array"):
+        load_logprobs_file(str(f))
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_entropy_help(capsys):
+    from xpyd_acc.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["entropy", "--help"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "entropy" in captured.out or "baseline-logprobs" in captured.out
+
+
+def test_cli_entropy_baseline_only(tmp_path: Path, capsys):
+    from xpyd_acc.cli import main
+
+    data = [{"a": math.log(0.5), "b": math.log(0.5)}] * 5
+    f = tmp_path / "bl.json"
+    f.write_text(json.dumps(data))
+
+    main(["entropy", "--baseline-logprobs", str(f)])
+    captured = capsys.readouterr()
+    assert "Entropy Statistics" in captured.out
+
+
+def test_cli_entropy_with_target_and_json(tmp_path: Path, capsys):
+    from xpyd_acc.cli import main
+
+    bl = [{"a": math.log(0.5), "b": math.log(0.5)}] * 5
+    tg = [{"a": math.log(0.9), "b": math.log(0.1)}] * 5
+    bf = tmp_path / "bl.json"
+    tf = tmp_path / "tg.json"
+    bf.write_text(json.dumps(bl))
+    tf.write_text(json.dumps(tg))
+
+    out = tmp_path / "result.json"
+    main([
+        "entropy",
+        "--baseline-logprobs", str(bf),
+        "--target-logprobs", str(tf),
+        "--divergence-index", "2",
+        "--json", str(out),
+    ])
+
+    captured = capsys.readouterr()
+    assert "Baseline" in captured.out
+    assert "Target" in captured.out
+    assert "divergence" in captured.out.lower()
+
+    result = json.loads(out.read_text())
+    assert "baseline_stats" in result
+    assert "target_stats" in result
+    assert "comparison" in result


### PR DESCRIPTION
## Summary
Per-token Shannon entropy analysis from top-K logprob distributions for richer divergence characterization.

## Changes
- New `entropy.py` module: `token_entropy()`, `sequence_entropy()`, `entropy_stats()`, `entropy_at_divergence()`
- `EntropyStats` and `EntropyComparison` dataclasses with serialization
- CLI subcommand: `xpyd-acc entropy --baseline-logprobs <path> [--target-logprobs <path>]`
- Flags: `--divergence-index`, `--context-window`, `--json`
- ROADMAP.md updated with M70
- 22 tests

Closes #149