### PR TITLE
feat: M71 — Output Length Bias Detection

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -644,3 +644,16 @@
 - Rich terminal formatting for stats and comparison
 - Handles edge cases: empty, single token, non-normalized logprobs
 - 22 tests covering computation, edge cases, formatting, file I/O, CLI integration
+
+## M71: Output Length Bias Detection ✅
+- `length_bias.py` module: detect systematic output length differences between baseline and target
+- `SampleLength` and `LengthBiasResult` dataclasses with `to_dict()` serialization
+- Per-sample: baseline_length, target_length, length_diff, length_ratio
+- Paired t-test for statistical significance of length bias
+- Classification: shorter_bias, longer_bias, no_bias
+- CLI: `xpyd-acc length-bias --report <path>`
+- `--alpha <float>` significance level (default 0.05)
+- `--json <path>` export
+- Exit 1 if significant bias detected (CI-friendly)
+- Rich terminal output with summary and distribution breakdown
+- 28 tests covering t-test, analysis, formatting, file I/O, CLI integration

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -403,6 +403,14 @@ def main(argv: list[str] | None = None) -> None:
     )
     ent.add_argument("--json", dest="json_path", default=None, help="Export results as JSON")
 
+    # length-bias
+    lbias = sub.add_parser("length-bias", help="Detect output length bias in batch reports")
+    lbias.add_argument("--report", required=True, help="Path to batch report JSON file")
+    lbias.add_argument(
+        "--alpha", type=float, default=0.05, help="Significance level (default: 0.05)",
+    )
+    lbias.add_argument("--json", dest="json_path", default=None, help="Export results as JSON")
+
     kv = sub.add_parser("check-kv", help="Check KV cache numerical accuracy")
     kv.add_argument("--baseline", required=True, help="Path to baseline KV cache (.npz)")
     kv.add_argument("--target", required=True, help="Path to target KV cache (.npz)")
@@ -909,6 +917,8 @@ def main(argv: list[str] | None = None) -> None:
         asyncio.run(_run_concurrency_sweep(args))
     elif args.command == "entropy":
         _run_entropy(args)
+    elif args.command == "length-bias":
+        _run_length_bias(args)
     else:
         print(f"xpyd-acc {args.command} — not yet implemented")
 
@@ -2927,3 +2937,26 @@ def _run_entropy(args: argparse.Namespace) -> None:
     if args.json_path:
         Path(args.json_path).write_text(json.dumps(output, indent=2))
         print(f"\nExported to {args.json_path}")
+
+
+def _run_length_bias(args: argparse.Namespace) -> None:
+    """Run output length bias analysis on a batch report."""
+    import json
+    from pathlib import Path
+
+    from xpyd_acc.length_bias import (
+        analyze_length_bias,
+        format_length_bias,
+        load_report_file,
+    )
+
+    report = load_report_file(args.report)
+    result = analyze_length_bias(report, alpha=args.alpha)
+    print(format_length_bias(result))
+
+    if args.json_path:
+        Path(args.json_path).write_text(json.dumps(result.to_dict(), indent=2))
+        print(f"\nExported to {args.json_path}")
+
+    if result.classification != "no_bias":
+        raise SystemExit(1)

--- a/src/xpyd_acc/length_bias.py
+++ b/src/xpyd_acc/length_bias.py
@@ -1,0 +1,220 @@
+"""Output length bias detection for batch comparison reports."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SampleLength:
+    """Length data for a single sample."""
+
+    sample_id: str
+    baseline_length: int
+    target_length: int
+    length_diff: int  # target - baseline
+    length_ratio: float  # target / baseline (0.0 if baseline is 0)
+
+
+@dataclass
+class LengthBiasResult:
+    """Aggregate length bias analysis result."""
+
+    sample_count: int
+    mean_baseline_length: float
+    mean_target_length: float
+    mean_diff: float
+    median_diff: float
+    stdev_diff: float
+    t_statistic: float
+    p_value: float
+    classification: str  # "shorter_bias", "longer_bias", "no_bias"
+    alpha: float
+    samples: list[SampleLength] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sample_count": self.sample_count,
+            "mean_baseline_length": self.mean_baseline_length,
+            "mean_target_length": self.mean_target_length,
+            "mean_diff": self.mean_diff,
+            "median_diff": self.median_diff,
+            "stdev_diff": self.stdev_diff,
+            "t_statistic": self.t_statistic,
+            "p_value": self.p_value,
+            "classification": self.classification,
+            "alpha": self.alpha,
+            "samples": [
+                {
+                    "sample_id": s.sample_id,
+                    "baseline_length": s.baseline_length,
+                    "target_length": s.target_length,
+                    "length_diff": s.length_diff,
+                    "length_ratio": s.length_ratio,
+                }
+                for s in self.samples
+            ],
+        }
+
+
+def _paired_t_test(diffs: list[int]) -> tuple[float, float]:
+    """Paired t-test for mean difference from zero.
+
+    Returns (t_statistic, p_value). Uses two-tailed test.
+    For n < 2, returns (0.0, 1.0).
+    """
+    n = len(diffs)
+    if n < 2:
+        return 0.0, 1.0
+
+    mean_d = statistics.mean(diffs)
+    stdev_d = statistics.stdev(diffs)
+    if stdev_d == 0:
+        # All diffs identical — if mean is 0, no bias; if non-zero, p → 0
+        if mean_d == 0:
+            return 0.0, 1.0
+        return float("inf") if mean_d > 0 else float("-inf"), 0.0
+
+    t_stat = mean_d / (stdev_d / math.sqrt(n))
+    # Approximate p-value using normal distribution for large n
+    # For small n this is an approximation (proper would use t-distribution)
+    p_value = 2.0 * _normal_cdf(-abs(t_stat))
+    return t_stat, p_value
+
+
+def _normal_cdf(x: float) -> float:
+    """Approximate standard normal CDF using error function."""
+    return 0.5 * (1.0 + math.erf(x / math.sqrt(2.0)))
+
+
+def analyze_length_bias(
+    report: dict[str, Any],
+    alpha: float = 0.05,
+) -> LengthBiasResult:
+    """Analyze output length bias from a batch comparison report.
+
+    Parameters
+    ----------
+    report : dict
+        Deserialized batch comparison report JSON.
+    alpha : float
+        Significance level for the t-test.
+
+    Returns
+    -------
+    LengthBiasResult
+        Analysis results with per-sample data and classification.
+    """
+    results = report.get("results", [])
+    samples: list[SampleLength] = []
+
+    for r in results:
+        bl_out = r.get("baseline_output", "") or ""
+        tg_out = r.get("target_output", "") or ""
+        bl_len = len(bl_out)
+        tg_len = len(tg_out)
+        diff = tg_len - bl_len
+        ratio = tg_len / bl_len if bl_len > 0 else 0.0
+        samples.append(
+            SampleLength(
+                sample_id=r.get("sample_id", ""),
+                baseline_length=bl_len,
+                target_length=tg_len,
+                length_diff=diff,
+                length_ratio=ratio,
+            )
+        )
+
+    if not samples:
+        return LengthBiasResult(
+            sample_count=0,
+            mean_baseline_length=0.0,
+            mean_target_length=0.0,
+            mean_diff=0.0,
+            median_diff=0.0,
+            stdev_diff=0.0,
+            t_statistic=0.0,
+            p_value=1.0,
+            classification="no_bias",
+            alpha=alpha,
+            samples=[],
+        )
+
+    bl_lengths = [s.baseline_length for s in samples]
+    tg_lengths = [s.target_length for s in samples]
+    diffs = [s.length_diff for s in samples]
+
+    mean_bl = statistics.mean(bl_lengths)
+    mean_tg = statistics.mean(tg_lengths)
+    mean_diff = statistics.mean(diffs)
+    median_diff = statistics.median(diffs)
+    stdev_diff = statistics.stdev(diffs) if len(diffs) >= 2 else 0.0
+
+    t_stat, p_val = _paired_t_test(diffs)
+
+    if p_val < alpha:
+        classification = "shorter_bias" if mean_diff < 0 else "longer_bias"
+    else:
+        classification = "no_bias"
+
+    return LengthBiasResult(
+        sample_count=len(samples),
+        mean_baseline_length=mean_bl,
+        mean_target_length=mean_tg,
+        mean_diff=mean_diff,
+        median_diff=median_diff,
+        stdev_diff=stdev_diff,
+        t_statistic=t_stat,
+        p_value=p_val,
+        classification=classification,
+        alpha=alpha,
+        samples=samples,
+    )
+
+
+def format_length_bias(result: LengthBiasResult) -> str:
+    """Format length bias result for terminal display."""
+    lines = [
+        "Output Length Bias Analysis",
+        "=" * 50,
+        f"  Samples:              {result.sample_count}",
+        f"  Mean baseline length: {result.mean_baseline_length:.1f}",
+        f"  Mean target length:   {result.mean_target_length:.1f}",
+        f"  Mean diff (T-B):      {result.mean_diff:+.1f}",
+        f"  Median diff:          {result.median_diff:+.1f}",
+        f"  Stdev diff:           {result.stdev_diff:.1f}",
+        f"  t-statistic:          {result.t_statistic:.4f}",
+        f"  p-value:              {result.p_value:.6f}",
+        f"  Alpha:                {result.alpha}",
+        "",
+    ]
+
+    if result.classification == "no_bias":
+        lines.append("  ✅ No significant length bias detected")
+    elif result.classification == "shorter_bias":
+        lines.append("  ⚠️  Significant SHORTER bias in target outputs")
+    else:
+        lines.append("  ⚠️  Significant LONGER bias in target outputs")
+
+    # Distribution summary
+    if result.samples:
+        shorter = sum(1 for s in result.samples if s.length_diff < 0)
+        equal = sum(1 for s in result.samples if s.length_diff == 0)
+        longer = sum(1 for s in result.samples if s.length_diff > 0)
+        lines.append("")
+        lines.append("  Distribution:")
+        lines.append(f"    Shorter: {shorter} ({100*shorter/len(result.samples):.1f}%)")
+        lines.append(f"    Equal:   {equal} ({100*equal/len(result.samples):.1f}%)")
+        lines.append(f"    Longer:  {longer} ({100*longer/len(result.samples):.1f}%)")
+
+    return "\n".join(lines)
+
+
+def load_report_file(path: str) -> dict[str, Any]:
+    """Load a batch report JSON file."""
+    with open(path) as f:
+        return json.load(f)

--- a/tests/test_length_bias.py
+++ b/tests/test_length_bias.py
@@ -1,0 +1,329 @@
+"""Tests for output length bias detection module."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import pytest
+
+from xpyd_acc.length_bias import (
+    LengthBiasResult,
+    SampleLength,
+    _normal_cdf,
+    _paired_t_test,
+    analyze_length_bias,
+    format_length_bias,
+    load_report_file,
+)
+
+# ---------------------------------------------------------------------------
+# _paired_t_test
+# ---------------------------------------------------------------------------
+
+
+def test_paired_t_test_no_samples():
+    t, p = _paired_t_test([])
+    assert t == 0.0
+    assert p == 1.0
+
+
+def test_paired_t_test_one_sample():
+    t, p = _paired_t_test([5])
+    assert t == 0.0
+    assert p == 1.0
+
+
+def test_paired_t_test_no_diff():
+    t, p = _paired_t_test([0, 0, 0, 0])
+    assert t == 0.0
+    assert p == 1.0
+
+
+def test_paired_t_test_all_same_nonzero():
+    t, p = _paired_t_test([10, 10, 10, 10])
+    assert math.isinf(t)
+    assert p == 0.0
+
+
+def test_paired_t_test_significant():
+    # Large consistent positive diffs → significant
+    diffs = [100, 110, 90, 105, 95, 102, 98, 108, 92, 103]
+    t, p = _paired_t_test(diffs)
+    assert t > 0
+    assert p < 0.001
+
+
+def test_paired_t_test_not_significant():
+    # Small mixed diffs → not significant
+    diffs = [1, -1, 2, -2, 1, -1, 0, 0]
+    t, p = _paired_t_test(diffs)
+    assert p > 0.1
+
+
+# ---------------------------------------------------------------------------
+# _normal_cdf
+# ---------------------------------------------------------------------------
+
+
+def test_normal_cdf_zero():
+    assert abs(_normal_cdf(0) - 0.5) < 1e-9
+
+
+def test_normal_cdf_large_positive():
+    assert _normal_cdf(5.0) > 0.999
+
+
+def test_normal_cdf_large_negative():
+    assert _normal_cdf(-5.0) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# analyze_length_bias
+# ---------------------------------------------------------------------------
+
+
+def _make_report(pairs: list[tuple[str, str]]) -> dict:
+    """Create a minimal report from (baseline_output, target_output) pairs."""
+    return {
+        "results": [
+            {
+                "sample_id": f"s{i}",
+                "baseline_output": bl,
+                "target_output": tg,
+            }
+            for i, (bl, tg) in enumerate(pairs)
+        ]
+    }
+
+
+def test_analyze_empty_report():
+    result = analyze_length_bias({"results": []})
+    assert result.sample_count == 0
+    assert result.classification == "no_bias"
+
+
+def test_analyze_no_bias():
+    pairs = [("hello", "world"), ("foo", "bar"), ("abc", "xyz")]
+    result = analyze_length_bias(_make_report(pairs))
+    assert result.sample_count == 3
+    assert result.classification == "no_bias"
+
+
+def test_analyze_shorter_bias():
+    # Target consistently shorter
+    pairs = [("a" * 100, "b" * 20)] * 20
+    result = analyze_length_bias(_make_report(pairs))
+    assert result.classification == "shorter_bias"
+    assert result.mean_diff < 0
+    assert result.p_value < 0.05
+
+
+def test_analyze_longer_bias():
+    # Target consistently longer
+    pairs = [("b" * 20, "a" * 100)] * 20
+    result = analyze_length_bias(_make_report(pairs))
+    assert result.classification == "longer_bias"
+    assert result.mean_diff > 0
+    assert result.p_value < 0.05
+
+
+def test_analyze_equal_lengths():
+    pairs = [("abc", "xyz"), ("de", "fg"), ("h", "i")]
+    result = analyze_length_bias(_make_report(pairs))
+    assert result.mean_diff == 0.0
+    assert result.classification == "no_bias"
+
+
+def test_analyze_empty_outputs():
+    pairs = [("", ""), ("", "")]
+    result = analyze_length_bias(_make_report(pairs))
+    assert result.sample_count == 2
+    assert result.mean_diff == 0.0
+    for s in result.samples:
+        assert s.length_ratio == 0.0
+
+
+def test_analyze_missing_output_fields():
+    report = {"results": [{"sample_id": "s0"}]}
+    result = analyze_length_bias(report)
+    assert result.sample_count == 1
+    assert result.samples[0].baseline_length == 0
+
+
+def test_analyze_custom_alpha():
+    # With very high alpha, even small diffs might be "significant"
+    pairs = [("ab", "abc"), ("ab", "abc"), ("ab", "abc")]
+    result = analyze_length_bias(_make_report(pairs), alpha=0.99)
+    assert result.alpha == 0.99
+
+
+# ---------------------------------------------------------------------------
+# SampleLength
+# ---------------------------------------------------------------------------
+
+
+def test_sample_length_fields():
+    s = SampleLength(
+        sample_id="s0",
+        baseline_length=100,
+        target_length=80,
+        length_diff=-20,
+        length_ratio=0.8,
+    )
+    assert s.length_diff == -20
+    assert s.length_ratio == 0.8
+
+
+# ---------------------------------------------------------------------------
+# LengthBiasResult.to_dict
+# ---------------------------------------------------------------------------
+
+
+def test_result_to_dict():
+    result = LengthBiasResult(
+        sample_count=2,
+        mean_baseline_length=50.0,
+        mean_target_length=30.0,
+        mean_diff=-20.0,
+        median_diff=-20.0,
+        stdev_diff=0.0,
+        t_statistic=-5.0,
+        p_value=0.001,
+        classification="shorter_bias",
+        alpha=0.05,
+        samples=[
+            SampleLength("s0", 50, 30, -20, 0.6),
+        ],
+    )
+    d = result.to_dict()
+    assert d["classification"] == "shorter_bias"
+    assert len(d["samples"]) == 1
+    assert d["samples"][0]["length_diff"] == -20
+
+
+# ---------------------------------------------------------------------------
+# format_length_bias
+# ---------------------------------------------------------------------------
+
+
+def test_format_no_bias():
+    result = LengthBiasResult(
+        sample_count=5, mean_baseline_length=50.0, mean_target_length=50.0,
+        mean_diff=0.0, median_diff=0.0, stdev_diff=0.0,
+        t_statistic=0.0, p_value=1.0, classification="no_bias", alpha=0.05,
+    )
+    text = format_length_bias(result)
+    assert "No significant" in text
+
+
+def test_format_shorter_bias():
+    result = LengthBiasResult(
+        sample_count=10, mean_baseline_length=100.0, mean_target_length=60.0,
+        mean_diff=-40.0, median_diff=-40.0, stdev_diff=5.0,
+        t_statistic=-8.0, p_value=0.0001, classification="shorter_bias", alpha=0.05,
+        samples=[SampleLength(f"s{i}", 100, 60, -40, 0.6) for i in range(10)],
+    )
+    text = format_length_bias(result)
+    assert "SHORTER" in text
+    assert "Distribution" in text
+
+
+def test_format_longer_bias():
+    result = LengthBiasResult(
+        sample_count=5, mean_baseline_length=50.0, mean_target_length=90.0,
+        mean_diff=40.0, median_diff=40.0, stdev_diff=3.0,
+        t_statistic=10.0, p_value=0.0001, classification="longer_bias", alpha=0.05,
+        samples=[SampleLength(f"s{i}", 50, 90, 40, 1.8) for i in range(5)],
+    )
+    text = format_length_bias(result)
+    assert "LONGER" in text
+
+
+# ---------------------------------------------------------------------------
+# load_report_file
+# ---------------------------------------------------------------------------
+
+
+def test_load_report_file(tmp_path: Path):
+    report = {"results": [{"sample_id": "s0", "baseline_output": "hi", "target_output": "hey"}]}
+    f = tmp_path / "report.json"
+    f.write_text(json.dumps(report))
+    loaded = load_report_file(str(f))
+    assert loaded["results"][0]["sample_id"] == "s0"
+
+
+def test_load_report_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_report_file("/nonexistent/path.json")
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_length_bias_help(capsys):
+    from xpyd_acc.cli import main
+
+    with pytest.raises(SystemExit) as exc:
+        main(["length-bias", "--help"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "length-bias" in captured.out or "report" in captured.out
+
+
+def test_cli_length_bias_basic(tmp_path: Path, capsys):
+    from xpyd_acc.cli import main
+
+    # Equal-length outputs → no bias → exit 0
+    report = {
+        "results": [
+            {"sample_id": "s0", "baseline_output": "hello", "target_output": "world"},
+            {"sample_id": "s1", "baseline_output": "foo", "target_output": "bar"},
+        ]
+    }
+    f = tmp_path / "report.json"
+    f.write_text(json.dumps(report))
+
+    main(["length-bias", "--report", str(f)])
+    captured = capsys.readouterr()
+    assert "Length Bias" in captured.out
+
+
+def test_cli_length_bias_json_export(tmp_path: Path, capsys):
+    from xpyd_acc.cli import main
+
+    # Equal-length outputs → no bias → exit 0
+    report = {
+        "results": [
+            {"sample_id": f"s{i}", "baseline_output": "abcde", "target_output": "vwxyz"}
+            for i in range(10)
+        ]
+    }
+    f = tmp_path / "report.json"
+    f.write_text(json.dumps(report))
+    out = tmp_path / "result.json"
+
+    main(["length-bias", "--report", str(f), "--json", str(out)])
+    result = json.loads(out.read_text())
+    assert "classification" in result
+    assert "samples" in result
+
+
+def test_cli_length_bias_exit_code_on_bias(tmp_path: Path):
+    from xpyd_acc.cli import main
+
+    report = {
+        "results": [
+            {"sample_id": f"s{i}", "baseline_output": "a" * 200, "target_output": "b" * 10}
+            for i in range(30)
+        ]
+    }
+    f = tmp_path / "report.json"
+    f.write_text(json.dumps(report))
+
+    with pytest.raises(SystemExit) as exc:
+        main(["length-bias", "--report", str(f)])
+    assert exc.value.code == 1


### PR DESCRIPTION
## Summary
Detect systematic output length differences between baseline and target endpoints using paired t-test.

## Changes
- New `length_bias.py` module: `SampleLength`, `LengthBiasResult`, `analyze_length_bias()`, `format_length_bias()`
- Paired t-test with normal approximation for statistical significance
- Classification: shorter_bias, longer_bias, no_bias
- CLI subcommand: `xpyd-acc length-bias --report <path>`
- Flags: `--alpha`, `--json`
- Exit 1 if significant bias detected (CI-friendly)
- ROADMAP.md updated with M71
- 28 tests

Closes #151