### PR TITLE
docs: add deliverables — guide, iteration record, diagnostic script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ xpyd-acc check-kv \
   --kv-dump-b transfer_kv.npz
 ```
 
+## Documentation
+
+- **[User Guide](docs/guide.md)** — installation, subcommand reference, step-by-step diagnostic flow, and results interpretation
+- **[Current Iteration](docs/iterations/current.md)** — M72 milestone status, features, known limitations, and roadmap
+- **[Diagnostic Script](scripts/run_diagnose.sh)** — one-shot `bash scripts/run_diagnose.sh <aggregated_url> <pd_url>`
+
 ## License
 
 TBD

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,181 @@
+# xPyD-acc User Guide
+
+Complete guide for using xPyD-acc to diagnose accuracy issues in PD (Prefill/Decode) disaggregated LLM inference.
+
+## Installation
+
+```bash
+pip install xpyd-acc
+```
+
+For development:
+
+```bash
+git clone https://github.com/xPyD-hub/xPyD-acc.git
+cd xPyD-acc
+pip install -e ".[dev]"
+```
+
+Requirements: Python ≥ 3.10.
+
+## Core Subcommands
+
+### Diagnostic Pipeline
+
+| Command | Description |
+|---|---|
+| `diagnose` | Run the full diagnostic pipeline (healthcheck → compare → report) |
+| `healthcheck` | Check endpoint availability and basic API compatibility |
+| `compare-output` | Compare text outputs between baseline (aggregated) and target (PD) endpoints |
+| `compare-logprobs` | Compare per-token log-probabilities between two endpoints |
+| `check-kv` | Check KV cache numerical accuracy between two `.npz` dumps |
+| `report` | Generate an HTML report from batch comparison JSON results |
+
+### Batch & Analysis
+
+| Command | Description |
+|---|---|
+| `batch-compare` | Run comparison across a dataset of prompts |
+| `entropy` | Analyze output entropy distribution from logprob data |
+| `length-bias` | Detect systematic output length differences in batch reports |
+| `sensitivity` | Prompt sensitivity analysis — test how small prompt changes affect divergence |
+| `regression` | Detect regressions between two batch runs |
+| `diff` | Side-by-side comparison of two batch reports |
+| `ab-test` | A/B test divergence rates from two batch reports |
+| `aggregate` | Aggregate multiple batch run reports |
+
+### Exploration & Debugging
+
+| Command | Description |
+|---|---|
+| `compare-streaming` | Compare SSE streaming outputs token-by-token |
+| `detect` | Auto-detect xPyD endpoint type (aggregated vs prefill vs decode) |
+| `bisect` | Binary search for minimum context length causing divergence |
+| `snapshot` | Capture baseline outputs as a reference snapshot |
+| `fingerprint` | Model fingerprinting via deterministic probes |
+| `reproducibility` | Multi-run consistency measurement |
+| `explain` | Deep-dive analysis of a single divergent sample |
+| `cluster` | Cluster divergent samples by divergence pattern |
+| `filter` | Filter samples from a batch report |
+| `annotate` | Add notes and labels to batch report samples |
+| `summary` | Compact summary of a batch report |
+| `benchmark` | Benchmark endpoint latency |
+| `watch` | Continuous divergence monitoring |
+
+### Utilities
+
+| Command | Description |
+|---|---|
+| `init` | Generate a starter `xpyd-acc.toml` config file |
+| `config validate` | Validate a TOML config file |
+| `cache clear` | Remove all cached responses |
+| `cache stats` | Show cache statistics |
+| `history save/list/trend/purge` | Result history & trend tracking |
+| `dataset-stats` | Analyze dataset characteristics before batch comparison |
+| `profiles` | List available named profiles (e.g., greedy, stochastic) |
+| `completion` | Generate shell completion script |
+
+## Step-by-Step Diagnostic Flow
+
+The recommended diagnostic workflow isolates accuracy issues stage by stage.
+
+### Step 1: Healthcheck — Confirm Endpoints Are Reachable
+
+```bash
+xpyd-acc healthcheck --url http://aggregated:8000
+xpyd-acc healthcheck --url http://pd-endpoint:8001
+```
+
+Verifies that both endpoints respond correctly and expose a compatible API. Fix any connectivity or auth issues before proceeding.
+
+### Step 2: Compare Output — Baseline vs PD
+
+```bash
+xpyd-acc compare-output \
+  --baseline http://aggregated:8000 \
+  --target http://pd-endpoint:8001 \
+  --prompt "The quick brown fox jumps over the lazy dog" \
+  --max-tokens 128
+```
+
+Sends the same prompt to both endpoints and compares the generated text. This is the first signal — if outputs match, PD disaggregation is likely accurate for this prompt.
+
+For broader coverage, use `batch-compare` with a dataset:
+
+```bash
+xpyd-acc batch-compare \
+  --baseline http://aggregated:8000 \
+  --target http://pd-endpoint:8001 \
+  --dataset prompts.jsonl \
+  --output results.json
+```
+
+### Step 3: Compare Logprobs — Token-Level Precision
+
+```bash
+xpyd-acc compare-logprobs \
+  --baseline http://aggregated:8000 \
+  --target http://pd-endpoint:8001 \
+  --prompt "Hello world" \
+  --top-k 10
+```
+
+Compares per-token log-probabilities. Even when final text matches, logprob divergence can reveal hidden precision issues that surface under different prompts or longer contexts.
+
+### Step 4: Check KV Cache — Numerical Accuracy
+
+```bash
+xpyd-acc check-kv \
+  --kv-dump-a baseline_kv.npz \
+  --kv-dump-b transfer_kv.npz
+```
+
+Directly compares KV cache tensors (requires `.npz` dumps from both modes). This isolates whether the KV transfer step introduces numerical drift.
+
+### Step 5: Report — Generate Diagnostic Report
+
+```bash
+xpyd-acc report --input results.json --output report.html
+```
+
+Generates a comprehensive HTML report from batch comparison results, including divergence statistics, per-sample details, and visualizations.
+
+## Interpreting Results
+
+### Key Metrics
+
+| Metric | What It Means |
+|---|---|
+| **Divergence Rate** | Fraction of samples where PD output differs from baseline. 0% = perfect match. >5% warrants investigation. |
+| **Token Accuracy** | Fraction of generated tokens that match between baseline and target at each position. Lower accuracy at later positions may indicate KV cache drift. |
+| **Entropy** | Shannon entropy of the output distribution. Higher entropy = more uncertainty. A significant entropy gap between modes suggests the model's confidence is affected by disaggregation. |
+| **Max Logprob Difference** | Largest absolute difference in log-probability for the top token at any position. Values >0.1 are notable; >1.0 indicates a serious precision issue. |
+| **KV MSE (Mean Squared Error)** | Numerical difference between KV cache tensors. Values near 0 are ideal. Increasing MSE across layers points to accumulating precision loss. |
+| **Length Bias** | Systematic difference in output length between modes. Positive = PD generates longer outputs; negative = shorter. |
+
+### Quick Decision Guide
+
+- **All metrics green** → PD disaggregation is accurate; safe to deploy.
+- **High divergence rate, low KV MSE** → Issue is likely in decode-stage sampling, not KV transfer.
+- **High KV MSE, high divergence** → KV transfer is the root cause. Check serialization format, quantization, and memory alignment.
+- **Divergence increases with context length** → Use `bisect` to find the critical length. Likely a position encoding or attention mask issue.
+- **Entropy gap but text matches** → Latent precision issue. May surface with different prompts or temperatures. Monitor with `watch`.
+
+## Global Options
+
+All subcommands support these flags:
+
+```
+-v / --verbose      Increase verbosity (-v for INFO, -vv for DEBUG)
+-q / --quiet        Quiet mode (ERROR level only)
+--config FILE       Path to TOML config file (auto-discovers xpyd-acc.toml in cwd)
+```
+
+Sampling-related subcommands also accept:
+
+```
+--profile NAME      Named profile (e.g., greedy, stochastic)
+--temperature F     Sampling temperature (0 = greedy)
+--top-p F           Nucleus sampling top-p
+--seed N            Random seed for reproducibility
+```

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -1,0 +1,41 @@
+# Current Iteration — M72
+
+## Milestone
+
+**M72** — Feature-complete diagnostic toolkit with batch analysis, reporting, and CI integration support.
+
+## Main Features
+
+- **Full diagnostic pipeline** (`diagnose`) — automated healthcheck → compare → report flow
+- **Output comparison** — text-level and logprob-level comparison between aggregated and PD endpoints
+- **KV cache analysis** — direct numerical comparison of KV cache tensors (`.npz`)
+- **Batch comparison** — dataset-driven testing with JSONL input
+- **HTML reporting** — rich report generation from batch results
+- **Streaming comparison** — SSE token-by-token diff
+- **Entropy & length-bias analysis** — statistical detection of distribution shifts
+- **Prompt sensitivity analysis** — measure divergence stability under prompt perturbations
+- **Regression detection** — compare two batch runs to catch accuracy regressions
+- **Bisect** — binary search for minimum context length triggering divergence
+- **Fingerprinting & reproducibility** — model identity verification and multi-run consistency
+- **History & trends** — save, list, and trend divergence rates over time
+- **Caching** — response cache to avoid redundant API calls during iteration
+- **Configuration** — TOML-based config with validation, profiles, and `init` scaffolding
+- **Shell completion** — auto-generated completions for bash/zsh/fish
+
+## Known Limitations
+
+- No native support for multi-model comparison (single model per run)
+- KV cache dump (`.npz`) must be obtained externally; xPyD-acc does not trigger dumps itself
+- HTML report does not support real-time / streaming updates
+- `watch` mode does not persist state across restarts
+- No built-in authentication beyond API key pass-through
+- Dataset format limited to JSONL (no CSV or Parquet support yet)
+
+## Next Steps
+
+- Add Parquet / CSV dataset support
+- Native KV dump triggering via xPyD control plane API
+- Interactive HTML report with filtering and drill-down
+- CI/CD integration examples (GitHub Actions, GitLab CI)
+- Multi-model and multi-version comparison in a single run
+- Prometheus / OpenTelemetry metrics export for `watch` mode

--- a/scripts/run_diagnose.sh
+++ b/scripts/run_diagnose.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# run_diagnose.sh — One-shot diagnostic: healthcheck → compare-output → compare-logprobs → report
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <aggregated_url> <pd_url> [--prompt TEXT] [--output-dir DIR]"
+  echo
+  echo "Arguments:"
+  echo "  aggregated_url   Aggregated (baseline) endpoint URL"
+  echo "  pd_url           PD disaggregated endpoint URL"
+  echo
+  echo "Options:"
+  echo "  --prompt TEXT     Prompt to use (default: built-in test prompt)"
+  echo "  --output-dir DIR  Output directory (default: ./diagnose-output)"
+  exit 1
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+fi
+
+AGGREGATED_URL="$1"
+PD_URL="$2"
+shift 2
+
+PROMPT="The quick brown fox jumps over the lazy dog. Explain the history of this phrase."
+OUTPUT_DIR="./diagnose-output"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prompt) PROMPT="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+mkdir -p "$OUTPUT_DIR"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BATCH_OUTPUT="$OUTPUT_DIR/batch_${TIMESTAMP}.json"
+REPORT_OUTPUT="$OUTPUT_DIR/report_${TIMESTAMP}.html"
+
+echo "=== xPyD-acc Diagnostic Run ==="
+echo "Aggregated: $AGGREGATED_URL"
+echo "PD Target:  $PD_URL"
+echo "Timestamp:  $TIMESTAMP"
+echo
+
+# Step 1: Healthcheck
+echo "[Step 1/4] Healthcheck — verifying endpoints..."
+xpyd-acc healthcheck --url "$AGGREGATED_URL"
+xpyd-acc healthcheck --url "$PD_URL"
+echo "✓ Both endpoints healthy."
+echo
+
+# Step 2: Compare output
+echo "[Step 2/4] Compare output — text-level comparison..."
+xpyd-acc compare-output \
+  --baseline "$AGGREGATED_URL" \
+  --target "$PD_URL" \
+  --prompt "$PROMPT" \
+  --max-tokens 128
+echo
+
+# Step 3: Compare logprobs
+echo "[Step 3/4] Compare logprobs — token-level precision..."
+xpyd-acc compare-logprobs \
+  --baseline "$AGGREGATED_URL" \
+  --target "$PD_URL" \
+  --prompt "$PROMPT" \
+  --top-k 10
+echo
+
+# Step 4: Generate report
+echo "[Step 4/4] Generating report..."
+# Run a quick batch comparison to produce JSON, then generate HTML report
+xpyd-acc batch-compare \
+  --baseline "$AGGREGATED_URL" \
+  --target "$PD_URL" \
+  --dataset <(echo "{\"prompt\": \"$PROMPT\"}") \
+  --output "$BATCH_OUTPUT" 2>/dev/null || true
+
+if [[ -f "$BATCH_OUTPUT" ]]; then
+  xpyd-acc report --input "$BATCH_OUTPUT" --output "$REPORT_OUTPUT"
+  echo
+  echo "=== Diagnostic Complete ==="
+  echo "Batch results: $BATCH_OUTPUT"
+  echo "HTML report:   $REPORT_OUTPUT"
+else
+  echo
+  echo "=== Diagnostic Complete (no batch output) ==="
+  echo "Individual comparisons above show the results."
+  echo "To generate a full HTML report, run batch-compare with a dataset file."
+fi


### PR DESCRIPTION
## What

Add project deliverables:

- **docs/guide.md** — Complete user guide: installation, all subcommands, step-by-step diagnostic flow (healthcheck → compare-output → compare-logprobs → check-kv → report), and results interpretation
- **docs/iterations/current.md** — M72 milestone status, feature list, known limitations, next steps
- **scripts/run_diagnose.sh** — One-shot diagnostic script accepting aggregated and PD endpoint URLs
- **README.md** — Added Documentation section linking to the above

## Why

Project needs complete documentation and tooling for users to get started quickly.