### PR TITLE
feat(M73): Multi-Model Comparison in Single Batch Run

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -669,3 +669,13 @@
 - Sampling params support (--temperature, --top-p, --seed, --profile)
 - `sensitivity.py` module: `generate_perturbations()`, `run_sensitivity()`, `SensitivityResult`, `format_sensitivity()`
 - 22 tests covering perturbation generation, classification, analysis, formatting, JSON export, CLI integration
+
+## M73: Multi-Model Comparison in Single Batch Run
+- `batch-compare --model m1 --model m2 --baseline ... --target ... --dataset ...`
+- Run same dataset against each model via existing `run_batch()`
+- `MultiModelBatchReport` with per-model `BatchReport` and `CrossModelSummary`
+- Cross-model analysis: systematic (all models diverge), model-specific, all-match
+- JSON and Markdown export with per-model breakdowns
+- Terminal formatting with per-model pass/fail indicators
+- `multi_model.py` module: `run_multi_model()`, `compute_cross_model_summary()`, `format_multi_model_report()`
+- 15 tests covering dataclasses, cross-model summary, serialization, async runs

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -1,41 +1,39 @@
-# Current Iteration — M72
+# Current Iteration — M73
 
 ## Milestone
 
-**M72** — Feature-complete diagnostic toolkit with batch analysis, reporting, and CI integration support.
+**M73** — Multi-Model Comparison in Single Batch Run
 
-## Main Features
+## What Was Done
 
-- **Full diagnostic pipeline** (`diagnose`) — automated healthcheck → compare → report flow
-- **Output comparison** — text-level and logprob-level comparison between aggregated and PD endpoints
-- **KV cache analysis** — direct numerical comparison of KV cache tensors (`.npz`)
-- **Batch comparison** — dataset-driven testing with JSONL input
-- **HTML reporting** — rich report generation from batch results
-- **Streaming comparison** — SSE token-by-token diff
-- **Entropy & length-bias analysis** — statistical detection of distribution shifts
-- **Prompt sensitivity analysis** — measure divergence stability under prompt perturbations
-- **Regression detection** — compare two batch runs to catch accuracy regressions
-- **Bisect** — binary search for minimum context length triggering divergence
-- **Fingerprinting & reproducibility** — model identity verification and multi-run consistency
-- **History & trends** — save, list, and trend divergence rates over time
-- **Caching** — response cache to avoid redundant API calls during iteration
-- **Configuration** — TOML-based config with validation, profiles, and `init` scaffolding
-- **Shell completion** — auto-generated completions for bash/zsh/fish
+Added `multi_model.py` module enabling `batch-compare` to accept multiple `--model` flags
+and run the same dataset against each model, producing a `MultiModelBatchReport` with:
 
-## Known Limitations
+- Per-model `BatchReport` (reuses existing `run_batch()`)
+- Cross-model analysis: systematic divergences (all models), model-specific, all-match
+- JSON and Markdown export with per-model breakdowns
+- Terminal formatting with per-model pass/fail indicators
 
-- No native support for multi-model comparison (single model per run)
-- KV cache dump (`.npz`) must be obtained externally; xPyD-acc does not trigger dumps itself
-- HTML report does not support real-time / streaming updates
-- `watch` mode does not persist state across restarts
-- No built-in authentication beyond API key pass-through
-- Dataset format limited to JSONL (no CSV or Parquet support yet)
+### Files Changed
 
-## Next Steps
+- **`src/xpyd_acc/multi_model.py`** (new): `MultiModelBatchReport`, `CrossModelSummary`,
+  `compute_cross_model_summary()`, `format_multi_model_report()`, `run_multi_model()`
+- **`src/xpyd_acc/cli.py`**: `--model` changed to `action="append"` for repeatable flag;
+  multi-model branch added in `_run_batch_compare()` with JSON/Markdown export and exit code
+- **`tests/test_multi_model.py`** (new): 15 tests covering dataclasses, cross-model summary,
+  report serialization, formatting, and async `run_multi_model()` with mocked `run_batch`
 
-- Add Parquet / CSV dataset support
-- Native KV dump triggering via xPyD control plane API
-- Interactive HTML report with filtering and drill-down
-- CI/CD integration examples (GitHub Actions, GitLab CI)
-- Multi-model and multi-version comparison in a single run
-- Prometheus / OpenTelemetry metrics export for `watch` mode
+### Tests
+
+15 tests all passing:
+- `CrossModelSummary` serialization
+- `compute_cross_model_summary` for all-match, systematic, model-specific, empty, single-model
+- `MultiModelBatchReport` JSON round-trip, Markdown generation
+- `format_multi_model_report` terminal output
+- `run_multi_model` with callback, backward compat, parameter forwarding, mixed results
+
+## Iteration History
+
+| # | Date | Task | Result | Reviewer Comments |
+|---|------|------|--------|-------------------|
+| 1 | 2026-04-06 | M73: Multi-Model Comparison | ⏳ pending review | — |

--- a/src/xpyd_acc/cli.py
+++ b/src/xpyd_acc/cli.py
@@ -127,7 +127,10 @@ def main(argv: list[str] | None = None) -> None:
         help="Use saved snapshot as baseline (mutually exclusive with --baseline)",
     )
     bc.add_argument("--dataset", required=True, help="Path to JSONL dataset file")
-    bc.add_argument("--model", default=None, help="Model name (default: default)")
+    bc.add_argument(
+        "--model", default=None, action="append",
+        help="Model name (repeatable for multi-model comparison; default: default)",
+    )
     bc.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
     bc.add_argument("--api-key", default=None, help="API key for endpoints")
     bc.add_argument(
@@ -1185,14 +1188,50 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             cli_headers=cli_hdrs, env_headers=env_hdrs, config_headers=cfg_hdrs,
         ) or None
 
+        # Normalize model list: --model can be repeated for multi-model
+        model_list: list[str] = args.model if args.model else ["default"]
+        is_multi_model = len(model_list) > 1
+        single_model = model_list[0]
+
         is_multi = len(target_urls) > 1
 
-        if is_multi:
+        if is_multi_model and not is_multi:
+            # Multi-model, single target
+            from xpyd_acc.multi_model import (
+                format_multi_model_report,
+                run_multi_model,
+            )
+
+            mm_report = await run_multi_model(
+                samples,
+                args.baseline,
+                target_urls[0],
+                model_list,
+                max_tokens=args.max_tokens,
+                api_key=args.api_key,
+                logprob_gap_threshold=args.logprob_gap_threshold,
+                concurrency=args.concurrency,
+                retries=args.retries,
+                retry_delay=args.retry_delay,
+                match_config=effective_match,
+                sampling_params=sampling,
+                timeout=args.timeout,
+                skip_validation=getattr(args, "skip_validation", False),
+                custom_headers=custom_headers,
+            )
+            report = None
+            multi_report = None
+        else:
+            mm_report = None
+
+        if mm_report is not None:
+            pass  # handled after finally block
+        elif is_multi:
             multi_report = await run_multi_batch(
                 samples,
                 args.baseline,
                 target_urls,
-                model=args.model,
+                model=single_model,
                 max_tokens=args.max_tokens,
                 api_key=args.api_key,
                 logprob_gap_threshold=args.logprob_gap_threshold,
@@ -1215,7 +1254,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
                 samples,
                 args.baseline,
                 target_urls[0],
-                model=args.model,
+                model=single_model,
                 max_tokens=args.max_tokens,
                 api_key=args.api_key,
                 logprob_gap_threshold=args.logprob_gap_threshold,
@@ -1247,9 +1286,31 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             print(f"\nCache: {cs.hits} hits, {cs.misses} misses ({cs.hit_rate:.0%} hit rate)")
 
     # Apply cost estimation if pricing is configured
-    _apply_cost_to_report(args, report if report is not None else multi_report)
+    cost_target = report or multi_report or mm_report
+    _apply_cost_to_report(args, cost_target)
 
-    if multi_report is not None:
+    if mm_report is not None:
+        # Multi-model mode
+        from xpyd_acc.multi_model import format_multi_model_report
+
+        print()
+        print(format_multi_model_report(mm_report))
+
+        if args.json_path:
+            from pathlib import Path
+            Path(args.json_path).write_text(mm_report.to_json())
+            print(f"\nJSON exported to {args.json_path}")
+
+        if args.markdown:
+            from pathlib import Path
+            Path(args.markdown).write_text(mm_report.to_markdown())
+            print(f"\nMarkdown exported to {args.markdown}")
+
+        # Exit 1 if any model has divergences
+        if any(r.divergent_samples > 0 for r in mm_report.per_model.values()):
+            sys.exit(1)
+
+    elif multi_report is not None:
         # Multi-target mode
         for url in target_urls:
             print(f"\n--- Target: {url} ---")

--- a/src/xpyd_acc/multi_model.py
+++ b/src/xpyd_acc/multi_model.py
@@ -1,0 +1,247 @@
+"""Multi-model comparison: run the same dataset against multiple models."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from xpyd_acc.batch_compare import BatchReport, DatasetSample, run_batch
+from xpyd_acc.log import get_logger
+
+logger = get_logger("multi_model")
+
+
+@dataclass
+class CrossModelSummary:
+    """Cross-model divergence analysis."""
+
+    # sample_id -> list of models where the sample diverged
+    per_sample_divergent_models: dict[str, list[str]] = field(default_factory=dict)
+    # Samples that diverge in ALL models (systematic issue)
+    systematic_divergent_ids: list[str] = field(default_factory=list)
+    # Samples that diverge in some but not all models (model-specific)
+    model_specific_divergent_ids: list[str] = field(default_factory=list)
+    # Samples that match in all models
+    all_match_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "per_sample_divergent_models": self.per_sample_divergent_models,
+            "systematic_divergent_count": len(self.systematic_divergent_ids),
+            "systematic_divergent_ids": self.systematic_divergent_ids,
+            "model_specific_divergent_count": len(self.model_specific_divergent_ids),
+            "model_specific_divergent_ids": self.model_specific_divergent_ids,
+            "all_match_count": len(self.all_match_ids),
+        }
+
+
+@dataclass
+class MultiModelBatchReport:
+    """Report comparing a dataset across multiple models."""
+
+    baseline_url: str
+    target_url: str
+    models: list[str]
+    per_model: dict[str, BatchReport]
+    cross_model: CrossModelSummary
+    total_samples: int
+
+    def to_json(self) -> str:
+        """Serialize to JSON string."""
+        data: dict[str, Any] = {
+            "baseline_url": self.baseline_url,
+            "target_url": self.target_url,
+            "models": self.models,
+            "total_samples": self.total_samples,
+            "per_model": {
+                model: json.loads(report.to_json())
+                for model, report in self.per_model.items()
+            },
+            "cross_model": self.cross_model.to_dict(),
+        }
+        return json.dumps(data, indent=2)
+
+    def to_markdown(self, *, max_divergent_samples: int = 10) -> str:
+        """Serialize to Markdown string."""
+        lines: list[str] = []
+        lines.append("# Multi-Model Batch Comparison Report")
+        lines.append("")
+        lines.append(f"**Baseline:** `{self.baseline_url}`")
+        lines.append(f"**Target:** `{self.target_url}`")
+        lines.append(f"**Models:** {', '.join(f'`{m}`' for m in self.models)}")
+        lines.append(f"**Total samples:** {self.total_samples}")
+        lines.append("")
+
+        # Per-model summary table
+        lines.append("## Per-Model Summary")
+        lines.append("")
+        lines.append("| Model | Matches | Divergent | Rate |")
+        lines.append("|-------|---------|-----------|------|")
+        for model in self.models:
+            r = self.per_model[model]
+            lines.append(
+                f"| `{model}` | {r.match_samples} | {r.divergent_samples} "
+                f"| {r.divergence_rate:.1%} |"
+            )
+        lines.append("")
+
+        # Cross-model summary
+        cm = self.cross_model
+        lines.append("## Cross-Model Analysis")
+        lines.append("")
+        lines.append(
+            f"- **Systematic divergences** (all models): "
+            f"{len(cm.systematic_divergent_ids)}"
+        )
+        lines.append(
+            f"- **Model-specific divergences** (some models): "
+            f"{len(cm.model_specific_divergent_ids)}"
+        )
+        lines.append(f"- **All match** (no model diverges): {len(cm.all_match_ids)}")
+        lines.append("")
+
+        # Systematic divergences detail
+        if cm.systematic_divergent_ids:
+            show = cm.systematic_divergent_ids[:max_divergent_samples]
+            lines.append("### Systematic Divergences")
+            lines.append("")
+            for sid in show:
+                lines.append(f"- `{sid}`")
+            if len(cm.systematic_divergent_ids) > max_divergent_samples:
+                lines.append(
+                    f"- ... and {len(cm.systematic_divergent_ids) - max_divergent_samples} more"
+                )
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+def compute_cross_model_summary(
+    models: list[str],
+    per_model: dict[str, BatchReport],
+) -> CrossModelSummary:
+    """Compute cross-model divergence analysis from per-model reports."""
+    # Collect all sample IDs from the first model's results
+    if not models or not per_model:
+        return CrossModelSummary()
+
+    first_report = per_model[models[0]]
+    sample_ids = [r.sample_id for r in first_report.results]
+
+    # Build per-sample divergence map
+    per_sample: dict[str, list[str]] = {}
+    for sid in sample_ids:
+        divergent_in: list[str] = []
+        for model in models:
+            report = per_model[model]
+            for result in report.results:
+                if result.sample_id == sid:
+                    if result.is_divergent():
+                        divergent_in.append(model)
+                    break
+        per_sample[sid] = divergent_in
+
+    systematic = [
+        sid for sid, divs in per_sample.items()
+        if len(divs) == len(models) and len(divs) > 0
+    ]
+    model_specific = [sid for sid, divs in per_sample.items() if 0 < len(divs) < len(models)]
+    all_match = [sid for sid, divs in per_sample.items() if len(divs) == 0]
+
+    return CrossModelSummary(
+        per_sample_divergent_models=per_sample,
+        systematic_divergent_ids=systematic,
+        model_specific_divergent_ids=model_specific,
+        all_match_ids=all_match,
+    )
+
+
+def format_multi_model_report(report: MultiModelBatchReport) -> str:
+    """Format multi-model report for terminal display."""
+    lines: list[str] = []
+    lines.append("Multi-Model Batch Comparison")
+    lines.append(f"  Baseline: {report.baseline_url}")
+    lines.append(f"  Target:   {report.target_url}")
+    lines.append(f"  Models:   {', '.join(report.models)}")
+    lines.append(f"  Samples:  {report.total_samples}")
+    lines.append("")
+
+    for model in report.models:
+        r = report.per_model[model]
+        status = "✅" if r.divergent_samples == 0 else "❌"
+        lines.append(
+            f"  {status} {model}: {r.match_samples}/{r.total_samples} match "
+            f"({r.divergence_rate:.1%} divergence)"
+        )
+
+    cm = report.cross_model
+    lines.append("")
+    lines.append(f"  Systematic (all models):  {len(cm.systematic_divergent_ids)}")
+    lines.append(f"  Model-specific:           {len(cm.model_specific_divergent_ids)}")
+    lines.append(f"  All match:                {len(cm.all_match_ids)}")
+
+    return "\n".join(lines)
+
+
+async def run_multi_model(
+    samples: list[DatasetSample],
+    baseline_url: str,
+    target_url: str,
+    models: list[str],
+    *,
+    max_tokens: int = 64,
+    api_key: str = "no-key",
+    logprob_gap_threshold: float = 0.1,
+    concurrency: int = 5,
+    retries: int = 3,
+    retry_delay: float = 1.0,
+    on_model_complete: Callable[[str, BatchReport], None] | None = None,
+    match_config: Any | None = None,
+    sampling_params: Any | None = None,
+    timeout: float = 120.0,
+    skip_validation: bool = False,
+    custom_headers: dict[str, str] | None = None,
+) -> MultiModelBatchReport:
+    """Run batch comparison for each model and produce a multi-model report.
+
+    Args:
+        models: List of model names to compare.
+        on_model_complete: Optional callback after each model completes.
+    """
+    per_model: dict[str, BatchReport] = {}
+
+    for model in models:
+        logger.info("Running batch for model: %s", model)
+        report = await run_batch(
+            samples,
+            baseline_url,
+            target_url,
+            model=model,
+            max_tokens=max_tokens,
+            api_key=api_key,
+            logprob_gap_threshold=logprob_gap_threshold,
+            concurrency=concurrency,
+            retries=retries,
+            retry_delay=retry_delay,
+            match_config=match_config,
+            sampling_params=sampling_params,
+            timeout=timeout,
+            skip_validation=skip_validation,
+            custom_headers=custom_headers,
+        )
+        per_model[model] = report
+        if on_model_complete:
+            on_model_complete(model, report)
+
+    cross_model = compute_cross_model_summary(models, per_model)
+
+    return MultiModelBatchReport(
+        baseline_url=baseline_url,
+        target_url=target_url,
+        models=models,
+        per_model=per_model,
+        cross_model=cross_model,
+        total_samples=len(samples),
+    )

--- a/tests/test_multi_model.py
+++ b/tests/test_multi_model.py
@@ -1,0 +1,260 @@
+"""Tests for multi-model comparison."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from xpyd_acc.batch_compare import BatchReport, DatasetSample, SampleResult
+from xpyd_acc.multi_model import (
+    CrossModelSummary,
+    MultiModelBatchReport,
+    compute_cross_model_summary,
+    format_multi_model_report,
+    run_multi_model,
+)
+
+
+def _make_result(sample_id: str, match: bool) -> SampleResult:
+    return SampleResult(
+        sample_id=sample_id,
+        prompt=f"prompt-{sample_id}",
+        baseline_output="out",
+        target_output="out" if match else "diff",
+        exact_match=match,
+        first_divergence_index=None if match else 0,
+        baseline_logprob_at_divergence=None,
+        target_logprob_at_divergence=None,
+        logprob_gap=None if match else 0.5,
+        classification="match" if match else "likely_bug",
+        context_length=10,
+    )
+
+
+def _make_report(results: list[SampleResult]) -> BatchReport:
+    divergent = sum(1 for r in results if r.is_divergent())
+    total = len(results)
+    return BatchReport(
+        total_samples=total,
+        divergent_samples=divergent,
+        match_samples=total - divergent,
+        divergence_rate=divergent / total if total else 0.0,
+        results=results,
+    )
+
+
+class TestCrossModelSummary:
+    def test_to_dict(self) -> None:
+        s = CrossModelSummary(
+            per_sample_divergent_models={"s1": ["m1"], "s2": ["m1", "m2"]},
+            systematic_divergent_ids=["s2"],
+            model_specific_divergent_ids=["s1"],
+            all_match_ids=[],
+        )
+        d = s.to_dict()
+        assert d["systematic_divergent_count"] == 1
+        assert d["model_specific_divergent_count"] == 1
+        assert d["all_match_count"] == 0
+
+    def test_empty(self) -> None:
+        s = CrossModelSummary()
+        d = s.to_dict()
+        assert d["systematic_divergent_count"] == 0
+
+
+class TestComputeCrossModelSummary:
+    def test_all_match(self) -> None:
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", True)])
+        r2 = _make_report([_make_result("s1", True), _make_result("s2", True)])
+        cm = compute_cross_model_summary(["m1", "m2"], {"m1": r1, "m2": r2})
+        assert cm.all_match_ids == ["s1", "s2"]
+        assert cm.systematic_divergent_ids == []
+        assert cm.model_specific_divergent_ids == []
+
+    def test_systematic_divergence(self) -> None:
+        r1 = _make_report([_make_result("s1", False), _make_result("s2", True)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", True)])
+        cm = compute_cross_model_summary(["m1", "m2"], {"m1": r1, "m2": r2})
+        assert cm.systematic_divergent_ids == ["s1"]
+        assert cm.all_match_ids == ["s2"]
+
+    def test_model_specific_divergence(self) -> None:
+        r1 = _make_report([_make_result("s1", False), _make_result("s2", True)])
+        r2 = _make_report([_make_result("s1", True), _make_result("s2", True)])
+        cm = compute_cross_model_summary(["m1", "m2"], {"m1": r1, "m2": r2})
+        assert cm.model_specific_divergent_ids == ["s1"]
+        assert cm.systematic_divergent_ids == []
+
+    def test_empty_models(self) -> None:
+        cm = compute_cross_model_summary([], {})
+        assert cm.all_match_ids == []
+
+    def test_single_model(self) -> None:
+        r1 = _make_report([_make_result("s1", False)])
+        cm = compute_cross_model_summary(["m1"], {"m1": r1})
+        assert cm.systematic_divergent_ids == ["s1"]
+        assert cm.model_specific_divergent_ids == []
+
+
+class TestMultiModelBatchReport:
+    def _make_report(self) -> MultiModelBatchReport:
+        r1 = _make_report([_make_result("s1", True), _make_result("s2", False)])
+        r2 = _make_report([_make_result("s1", False), _make_result("s2", False)])
+        cm = compute_cross_model_summary(["m1", "m2"], {"m1": r1, "m2": r2})
+        return MultiModelBatchReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            models=["m1", "m2"],
+            per_model={"m1": r1, "m2": r2},
+            cross_model=cm,
+            total_samples=2,
+        )
+
+    def test_to_json_roundtrip(self) -> None:
+        report = self._make_report()
+        data = json.loads(report.to_json())
+        assert data["models"] == ["m1", "m2"]
+        assert "m1" in data["per_model"]
+        assert "m2" in data["per_model"]
+        assert data["cross_model"]["systematic_divergent_count"] == 1
+        assert data["cross_model"]["model_specific_divergent_count"] == 1
+
+    def test_to_markdown(self) -> None:
+        report = self._make_report()
+        md = report.to_markdown()
+        assert "Multi-Model" in md
+        assert "`m1`" in md
+        assert "`m2`" in md
+        assert "Systematic" in md
+
+    def test_to_markdown_no_systematic(self) -> None:
+        r1 = _make_report([_make_result("s1", True)])
+        r2 = _make_report([_make_result("s1", True)])
+        cm = compute_cross_model_summary(["m1", "m2"], {"m1": r1, "m2": r2})
+        report = MultiModelBatchReport(
+            baseline_url="http://b",
+            target_url="http://t",
+            models=["m1", "m2"],
+            per_model={"m1": r1, "m2": r2},
+            cross_model=cm,
+            total_samples=1,
+        )
+        md = report.to_markdown()
+        assert "Systematic Divergences" not in md
+
+
+class TestFormatMultiModelReport:
+    def test_format(self) -> None:
+        r1 = _make_report([_make_result("s1", True)])
+        r2 = _make_report([_make_result("s1", False)])
+        cm = compute_cross_model_summary(["m1", "m2"], {"m1": r1, "m2": r2})
+        report = MultiModelBatchReport(
+            baseline_url="http://b",
+            target_url="http://t",
+            models=["m1", "m2"],
+            per_model={"m1": r1, "m2": r2},
+            cross_model=cm,
+            total_samples=1,
+        )
+        output = format_multi_model_report(report)
+        assert "✅ m1" in output
+        assert "❌ m2" in output
+        assert "Model-specific" in output
+
+
+class TestRunMultiModel:
+    @pytest.mark.asyncio
+    async def test_runs_each_model(self) -> None:
+        samples = [DatasetSample(id="s1", prompt="hello")]
+        mock_report = _make_report([_make_result("s1", True)])
+
+        completed_models: list[str] = []
+
+        def on_complete(model: str, report: BatchReport) -> None:
+            completed_models.append(model)
+
+        with patch("xpyd_acc.multi_model.run_batch", new_callable=AsyncMock) as mock_rb:
+            mock_rb.return_value = mock_report
+            result = await run_multi_model(
+                samples,
+                "http://b",
+                "http://t",
+                ["m1", "m2", "m3"],
+                on_model_complete=on_complete,
+            )
+
+        assert mock_rb.call_count == 3
+        assert result.models == ["m1", "m2", "m3"]
+        assert len(result.per_model) == 3
+        assert completed_models == ["m1", "m2", "m3"]
+        assert result.total_samples == 1
+
+    @pytest.mark.asyncio
+    async def test_single_model_backward_compat(self) -> None:
+        samples = [DatasetSample(id="s1", prompt="hello")]
+        mock_report = _make_report([_make_result("s1", False)])
+
+        with patch("xpyd_acc.multi_model.run_batch", new_callable=AsyncMock) as mock_rb:
+            mock_rb.return_value = mock_report
+            result = await run_multi_model(
+                samples, "http://b", "http://t", ["single-model"]
+            )
+
+        assert mock_rb.call_count == 1
+        assert result.models == ["single-model"]
+        assert result.cross_model.systematic_divergent_ids == ["s1"]
+
+    @pytest.mark.asyncio
+    async def test_passes_model_to_run_batch(self) -> None:
+        samples = [DatasetSample(id="s1", prompt="hello")]
+        mock_report = _make_report([_make_result("s1", True)])
+
+        with patch("xpyd_acc.multi_model.run_batch", new_callable=AsyncMock) as mock_rb:
+            mock_rb.return_value = mock_report
+            await run_multi_model(
+                samples, "http://b", "http://t", ["mymodel"],
+                max_tokens=128, api_key="test-key",
+            )
+
+        kw = mock_rb.call_args.kwargs
+        assert kw.get("model") == "mymodel"
+
+    @pytest.mark.asyncio
+    async def test_cross_model_with_mixed_results(self) -> None:
+        samples = [
+            DatasetSample(id="s1", prompt="p1"),
+            DatasetSample(id="s2", prompt="p2"),
+            DatasetSample(id="s3", prompt="p3"),
+        ]
+        # m1: s1 diverges, s2 diverges, s3 matches
+        report_m1 = _make_report([
+            _make_result("s1", False),
+            _make_result("s2", False),
+            _make_result("s3", True),
+        ])
+        # m2: s1 diverges, s2 matches, s3 matches
+        report_m2 = _make_report([
+            _make_result("s1", False),
+            _make_result("s2", True),
+            _make_result("s3", True),
+        ])
+
+        call_count = 0
+
+        async def fake_run_batch(samps, base, target, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if kwargs.get("model") == "m1":
+                return report_m1
+            return report_m2
+
+        with patch("xpyd_acc.multi_model.run_batch", side_effect=fake_run_batch):
+            result = await run_multi_model(
+                samples, "http://b", "http://t", ["m1", "m2"]
+            )
+
+        assert result.cross_model.systematic_divergent_ids == ["s1"]
+        assert result.cross_model.model_specific_divergent_ids == ["s2"]
+        assert result.cross_model.all_match_ids == ["s3"]


### PR DESCRIPTION
## Summary

Add multi-model comparison support to `batch-compare`. Users can now pass `--model` multiple times to compare the same dataset across different models in a single invocation.

### Changes

- **`src/xpyd_acc/multi_model.py`** (new): `MultiModelBatchReport`, `CrossModelSummary`, `compute_cross_model_summary()`, `format_multi_model_report()`, `run_multi_model()`
- **`src/xpyd_acc/cli.py`**: `--model` changed to `action="append"` for repeatable flag; multi-model branch in `_run_batch_compare()`
- **`tests/test_multi_model.py`** (new): 15 tests
- **`ROADMAP.md`**: M73 added
- **`docs/iterations/current.md`**: updated

### Cross-Model Analysis

- **Systematic divergences**: samples that diverge in ALL models (likely real bugs)
- **Model-specific divergences**: samples that diverge in some but not all models
- **All match**: samples that match across all models

Closes #158