### PR TITLE
feat(M76): report dashboard server (#165)

### DIFF
--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -98,4 +98,5 @@ Added `xpyd-acc root-cause --report <path>` CLI subcommand that analyzes batch r
 | # | Date | Task | Result | Reviewer Comments |
 |---|------|------|--------|-------------------|
 | M74 | 2026-04-05 | Divergence Root Cause Heuristics | ✅ merged | Both approved |
-| M75 | 2026-04-06 | Side-by-Side Token Diff Viewer | ⏳ PR pending | — |
+| M75 | 2026-04-06 | Side-by-Side Token Diff Viewer | ✅ merged | Both approved |
+| M76 | 2026-04-06 | Report Dashboard Server | ⏳ PR pending | — |

--- a/src/xpyd_acc/cli/__init__.py
+++ b/src/xpyd_acc/cli/__init__.py
@@ -29,7 +29,7 @@ from .benchmark import (
 )
 from .compare import _run_compare_logprobs, _run_compare_output, _run_compare_streaming
 from .config_cmd import _run_completion, _run_config, _run_init, _run_profiles
-from .data import _run_cache, _run_dataset_stats, _run_history, _run_snapshot
+from .data import _run_cache, _run_dataset_stats, _run_history, _run_serve, _run_snapshot
 from .diagnose import _run_check_kv, _run_detect, _run_diagnose, _run_healthcheck
 from .report import (
     _run_ab_test,
@@ -120,6 +120,7 @@ def main(argv: list[str] | None = None) -> None:
         "root-cause": lambda: handle_root_cause(args),
         "token-diff": lambda: handle_token_diff(args),
         "filter": lambda: _run_filter(args),
+        "serve": lambda: _run_serve(args),
         "init": lambda: _run_init(args),
         "config": lambda: _run_config(args),
         "profiles": lambda: _run_profiles(config),

--- a/src/xpyd_acc/cli/data.py
+++ b/src/xpyd_acc/cli/data.py
@@ -366,3 +366,24 @@ def _run_dataset_stats(args: argparse.Namespace) -> None:
     if args.json_path:
         report.to_json(args.json_path)
         print(f"\nExported to {args.json_path}")
+
+
+def _run_serve(args: argparse.Namespace) -> None:
+    """Launch report dashboard server."""
+    from xpyd_acc.serve import run_server
+
+    server = run_server(
+        args.report,
+        host=args.host,
+        port=args.port,
+        open_browser=args.open_browser,
+    )
+    url = f"http://{args.host}:{args.port}"
+    print(f"Dashboard server running at {url}")
+    print("Press Ctrl+C to stop")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\nServer stopped.")
+    finally:
+        server.server_close()

--- a/src/xpyd_acc/cli/parsers.py
+++ b/src/xpyd_acc/cli/parsers.py
@@ -45,6 +45,7 @@ def register_all(sub: argparse._SubParsersAction) -> None:
     _register_reproducibility(sub)
     _register_dataset_stats(sub)
     _register_cache(sub)
+    _register_serve(sub)
 def _register_compare(sub):
     lp = sub.add_parser("compare-logprobs", help="Compare logprobs between two endpoints")
     lp.add_argument("--baseline", required=True, help="Baseline endpoint URL")
@@ -518,4 +519,15 @@ def _register_token_diff(sub):
     td_cmd.add_argument(
         "--json", dest="td_json", default=None,
         help="Export diff as JSON",
+    )
+
+
+def _register_serve(sub):
+    sv = sub.add_parser("serve", help="Launch interactive report dashboard server")
+    sv.add_argument("--report", required=True, help="Path to batch report JSON file")
+    sv.add_argument("--port", type=int, default=8080, help="Server port (default: 8080)")
+    sv.add_argument("--host", default="localhost", help="Server host (default: localhost)")
+    sv.add_argument(
+        "--open", action="store_true", default=False, dest="open_browser",
+        help="Auto-open browser on start",
     )

--- a/src/xpyd_acc/serve.py
+++ b/src/xpyd_acc/serve.py
@@ -1,0 +1,250 @@
+"""Report Dashboard Server — local HTTP server for interactive report exploration."""
+
+from __future__ import annotations
+
+import json
+import os
+import webbrowser
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from typing import Any
+
+from xpyd_acc.batch_compare import BatchReport, load_report
+
+DASHBOARD_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>xPyD-acc Report Dashboard</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+       background: #f5f5f5; color: #333; line-height: 1.6; }
+.header { background: #1a1a2e; color: #fff; padding: 1rem 2rem; }
+.header h1 { font-size: 1.4rem; }
+.cards { display: flex; gap: 1rem; padding: 1.5rem 2rem; flex-wrap: wrap; }
+.card { background: #fff; border-radius: 8px; padding: 1.2rem; min-width: 180px;
+        box-shadow: 0 1px 3px rgba(0,0,0,.12); flex: 1; }
+.card .label { font-size: .85rem; color: #666; }
+.card .value { font-size: 1.8rem; font-weight: 700; margin-top: .3rem; }
+.card .value.pass { color: #2e7d32; }
+.card .value.fail { color: #c62828; }
+.controls { padding: 0 2rem 1rem; display: flex; gap: 1rem; flex-wrap: wrap; }
+.controls input, .controls select { padding: .5rem .8rem; border: 1px solid #ccc;
+  border-radius: 4px; font-size: .9rem; }
+.controls input { flex: 1; min-width: 200px; }
+table { width: 100%; border-collapse: collapse; background: #fff; }
+th, td { padding: .6rem .8rem; text-align: left; border-bottom: 1px solid #eee;
+         font-size: .85rem; }
+th { background: #f9f9f9; font-weight: 600; position: sticky; top: 0; }
+.table-wrap { margin: 0 2rem 2rem; border-radius: 8px; overflow: auto;
+              max-height: 60vh; box-shadow: 0 1px 3px rgba(0,0,0,.12); }
+tr.divergent { background: #fff5f5; }
+tr:hover { background: #f0f7ff; }
+.badge { display: inline-block; padding: .15rem .5rem; border-radius: 4px;
+         font-size: .75rem; font-weight: 600; }
+.badge.match { background: #e8f5e9; color: #2e7d32; }
+.badge.likely_bug { background: #ffebee; color: #c62828; }
+.badge.likely_uncertainty { background: #fff3e0; color: #e65100; }
+.badge.unknown { background: #e3f2fd; color: #1565c0; }
+.detail { display: none; }
+.detail.open { display: table-row; }
+.detail td { background: #fafafa; padding: 1rem; }
+.detail pre { white-space: pre-wrap; word-break: break-word; font-size: .8rem;
+              max-height: 200px; overflow-y: auto; background: #f5f5f5; padding: .5rem;
+              border-radius: 4px; margin-top: .3rem; }
+.refresh-note { padding: .5rem 2rem; font-size: .75rem; color: #999; }
+</style>
+</head>
+<body>
+<div class="header"><h1>📊 xPyD-acc Report Dashboard</h1></div>
+<div id="app"></div>
+<script>
+let reportData = null;
+let lastMtime = 0;
+
+async function fetchReport() {
+  const resp = await fetch('/api/report');
+  const data = await resp.json();
+  if (data.mtime !== lastMtime) {
+    lastMtime = data.mtime;
+    reportData = data.report;
+    render();
+  }
+}
+
+function render() {
+  if (!reportData) return;
+  const r = reportData;
+  const app = document.getElementById('app');
+  const rate = (r.divergence_rate * 100).toFixed(1);
+  const rateClass = r.divergent_samples === 0 ? 'pass' : 'fail';
+
+  let html = `
+    <div class="cards">
+      <div class="card"><div class="label">Total</div>
+        <div class="value">${r.total_samples}</div></div>
+      <div class="card"><div class="label">Divergent</div>
+        <div class="value fail">${r.divergent_samples}</div></div>
+      <div class="card"><div class="label">Match</div>
+        <div class="value pass">${r.match_samples}</div></div>
+      <div class="card"><div class="label">Rate</div>
+        <div class="value ${rateClass}">${rate}%</div></div>
+    </div>
+    <div class="controls">
+      <input type="text" id="search" placeholder="Search prompt or output..." oninput="render()">
+      <select id="classFilter" onchange="render()">
+        <option value="">All classifications</option>
+        <option value="match">match</option>
+        <option value="likely_bug">likely_bug</option>
+        <option value="likely_uncertainty">likely_uncertainty</option>
+        <option value="unknown">unknown</option>
+      </select>
+    </div>
+    <div class="refresh-note">Auto-refreshes every 5 seconds</div>
+    <div class="table-wrap"><table>
+      <thead><tr><th>#</th><th>ID</th><th>Class</th>
+        <th>Div Idx</th><th>Gap</th>
+        <th>Prompt</th></tr></thead>
+      <tbody id="samples"></tbody>
+    </table></div>`;
+  app.innerHTML = html;
+
+  const search = (document.getElementById('search')?.value || '').toLowerCase();
+  const classFilter = document.getElementById('classFilter')?.value || '';
+  const tbody = document.getElementById('samples');
+  let rows = '';
+  r.results.forEach((s, i) => {
+    if (classFilter && s.classification !== classFilter) return;
+    const text = (s.prompt + ' ' + s.baseline_output + ' ' + s.target_output).toLowerCase();
+    if (search && !text.includes(search)) return;
+    const cls = s.exact_match ? '' : 'divergent';
+    const prompt = s.prompt.length > 80 ? s.prompt.slice(0, 80) + '…' : s.prompt;
+    const gap = s.logprob_gap !== null ? s.logprob_gap.toFixed(3) : '—';
+    const divIdx = s.first_divergence_index !== null ? s.first_divergence_index : '—';
+    rows += `<tr class="${cls}" onclick="toggleDetail(${i})" style="cursor:pointer">
+      <td>${i+1}</td><td>${esc(s.sample_id)}</td>
+      <td><span class="badge ${s.classification}">${s.classification}</span></td>
+      <td>${divIdx}</td><td>${gap}</td><td>${esc(prompt)}</td></tr>`;
+    rows += `<tr class="detail" id="detail-${i}"><td colspan="6">
+      <strong>Baseline:</strong><pre>${esc(s.baseline_output)}</pre>
+      <strong>Target:</strong><pre>${esc(s.target_output)}</pre>
+    </td></tr>`;
+  });
+  tbody.innerHTML = rows;
+}
+
+function toggleDetail(i) {
+  document.getElementById('detail-' + i)?.classList.toggle('open');
+}
+
+function esc(s) {
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+fetchReport();
+setInterval(fetchReport, 5000);
+</script>
+</body>
+</html>
+"""
+
+
+def render_dashboard() -> str:
+    """Return the dashboard HTML template."""
+    return DASHBOARD_TEMPLATE
+
+
+def report_to_api_dict(report: BatchReport) -> dict[str, Any]:
+    """Convert a BatchReport to a JSON-serializable dict for the API."""
+    return json.loads(report.to_json())
+
+
+class ReportHandler(SimpleHTTPRequestHandler):
+    """HTTP handler serving dashboard and report API."""
+
+    report_path: str = ""
+    _cached_report: dict[str, Any] | None = None
+    _cached_mtime: float = 0.0
+
+    def _get_report_data(self) -> dict[str, Any]:
+        """Load report, caching by mtime."""
+        try:
+            mtime = os.path.getmtime(self.report_path)
+        except OSError:
+            mtime = 0.0
+
+        if mtime != self.__class__._cached_mtime or self.__class__._cached_report is None:
+            report = load_report(self.report_path)
+            self.__class__._cached_report = report_to_api_dict(report)
+            self.__class__._cached_mtime = mtime
+
+        return {"report": self.__class__._cached_report, "mtime": self.__class__._cached_mtime}
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/" or self.path == "":
+            html = render_dashboard()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(html.encode())))
+            self.end_headers()
+            self.wfile.write(html.encode())
+        elif self.path == "/api/report":
+            try:
+                data = self._get_report_data()
+                body = json.dumps(data).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except Exception as exc:
+                err = json.dumps({"error": str(exc)}).encode()
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(err)))
+                self.end_headers()
+                self.wfile.write(err)
+        else:
+            self.send_response(404)
+            body = b"Not Found"
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Suppress default stderr logging."""
+        pass
+
+
+def create_handler(report_path: str) -> type[ReportHandler]:
+    """Create a handler class bound to a specific report path."""
+    handler = type("BoundReportHandler", (ReportHandler,), {
+        "report_path": report_path,
+        "_cached_report": None,
+        "_cached_mtime": 0.0,
+    })
+    return handler
+
+
+def run_server(
+    report_path: str,
+    *,
+    host: str = "localhost",
+    port: int = 8080,
+    open_browser: bool = False,
+) -> HTTPServer:
+    """Start the dashboard server. Returns the server instance."""
+    # Validate report exists and is loadable
+    load_report(report_path)
+
+    handler_class = create_handler(report_path)
+    server = HTTPServer((host, port), handler_class)
+
+    if open_browser:
+        webbrowser.open(f"http://{host}:{port}")
+
+    return server

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,197 @@
+"""Tests for serve module — report dashboard server."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from http.client import HTTPConnection
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from xpyd_acc.batch_compare import BatchReport, SampleResult
+from xpyd_acc.serve import (
+    create_handler,
+    render_dashboard,
+    report_to_api_dict,
+    run_server,
+)
+
+
+def _make_result(
+    sample_id: str = "s1",
+    match: bool = False,
+    classification: str = "likely_bug",
+) -> SampleResult:
+    return SampleResult(
+        sample_id=sample_id,
+        prompt="test prompt",
+        baseline_output="hello world",
+        target_output="hello earth" if not match else "hello world",
+        exact_match=match,
+        first_divergence_index=1 if not match else None,
+        baseline_logprob_at_divergence=-1.0 if not match else None,
+        target_logprob_at_divergence=-2.0 if not match else None,
+        logprob_gap=0.5 if not match else None,
+        classification="match" if match else classification,
+        context_length=10,
+    )
+
+
+def _make_report(*results: SampleResult) -> BatchReport:
+    rs = list(results) if results else [_make_result()]
+    div = sum(1 for r in rs if not r.exact_match)
+    return BatchReport(
+        total_samples=len(rs),
+        divergent_samples=div,
+        match_samples=len(rs) - div,
+        divergence_rate=div / len(rs) if rs else 0.0,
+        results=rs,
+    )
+
+
+def _write_report(path: Path, report: BatchReport | None = None) -> Path:
+    report = report or _make_report()
+    path.write_text(report.to_json())
+    return path
+
+
+class TestRenderDashboard:
+    def test_returns_html(self):
+        html = render_dashboard()
+        assert "<!DOCTYPE html>" in html
+        assert "xPyD-acc Report Dashboard" in html
+
+    def test_contains_app_div(self):
+        html = render_dashboard()
+        assert 'id="app"' in html
+
+    def test_contains_fetch_script(self):
+        html = render_dashboard()
+        assert "/api/report" in html
+        assert "fetchReport" in html
+
+
+class TestReportToApiDict:
+    def test_basic_conversion(self):
+        report = _make_report()
+        d = report_to_api_dict(report)
+        assert d["total_samples"] == 1
+        assert d["divergent_samples"] == 1
+        assert len(d["results"]) == 1
+
+    def test_results_fields(self):
+        report = _make_report()
+        d = report_to_api_dict(report)
+        r = d["results"][0]
+        assert r["sample_id"] == "s1"
+        assert r["exact_match"] is False
+        assert r["classification"] == "likely_bug"
+
+
+class TestCreateHandler:
+    def test_creates_bound_handler(self):
+        handler_cls = create_handler("/some/path.json")
+        assert handler_cls.report_path == "/some/path.json"
+
+    def test_different_paths_different_classes(self):
+        h1 = create_handler("/path1.json")
+        h2 = create_handler("/path2.json")
+        assert h1.report_path != h2.report_path
+
+
+class TestServerIntegration:
+    """Integration tests that start a real HTTP server."""
+
+    @pytest.fixture()
+    def report_file(self, tmp_path: Path) -> Path:
+        return _write_report(tmp_path / "report.json")
+
+    @pytest.fixture()
+    def server_url(self, report_file: Path):
+        """Start server on a free port, yield URL, then shut down."""
+        server = run_server(str(report_file), host="127.0.0.1", port=0)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        yield f"127.0.0.1:{port}"
+        server.shutdown()
+        server.server_close()
+
+    def test_dashboard_route(self, server_url: str):
+        conn = HTTPConnection(server_url, timeout=5)
+        conn.request("GET", "/")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        body = resp.read().decode()
+        assert "xPyD-acc Report Dashboard" in body
+        conn.close()
+
+    def test_api_report_route(self, server_url: str):
+        conn = HTTPConnection(server_url, timeout=5)
+        conn.request("GET", "/api/report")
+        resp = conn.getresponse()
+        assert resp.status == 200
+        data = json.loads(resp.read())
+        assert "report" in data
+        assert "mtime" in data
+        assert data["report"]["total_samples"] == 1
+        conn.close()
+
+    def test_404_unknown_route(self, server_url: str):
+        conn = HTTPConnection(server_url, timeout=5)
+        conn.request("GET", "/unknown")
+        resp = conn.getresponse()
+        assert resp.status == 404
+        conn.close()
+
+    def test_auto_refresh_on_file_change(self, server_url: str, report_file: Path):
+        conn = HTTPConnection(server_url, timeout=5)
+        conn.request("GET", "/api/report")
+        data1 = json.loads(conn.getresponse().read())
+        conn.close()
+
+        # Write updated report
+        new_report = _make_report(
+            _make_result("s1", match=True),
+            _make_result("s2", match=False),
+        )
+        time.sleep(0.1)  # ensure mtime changes
+        report_file.write_text(new_report.to_json())
+
+        conn = HTTPConnection(server_url, timeout=5)
+        conn.request("GET", "/api/report")
+        data2 = json.loads(conn.getresponse().read())
+        conn.close()
+
+        assert data2["report"]["total_samples"] == 2
+        assert data2["mtime"] != data1["mtime"]
+
+
+class TestRunServerValidation:
+    def test_invalid_report_path(self, tmp_path: Path):
+        with pytest.raises(Exception):
+            run_server(str(tmp_path / "nonexistent.json"))
+
+    def test_open_browser_flag(self, tmp_path: Path):
+        _write_report(tmp_path / "report.json")
+        with patch("xpyd_acc.serve.webbrowser") as mock_wb:
+            server = run_server(
+                str(tmp_path / "report.json"),
+                host="127.0.0.1",
+                port=0,
+                open_browser=True,
+            )
+            mock_wb.open.assert_called_once()
+            server.server_close()
+
+
+class TestCLIIntegration:
+    def test_serve_registered(self):
+        """Verify serve subcommand is registered in CLI."""
+        from xpyd_acc.cli import main
+        with pytest.raises(SystemExit) as exc_info:
+            main(["serve", "--help"])
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

Implements M76: Report Dashboard Server — a local HTTP server for interactive batch report exploration.

### Changes

- **`src/xpyd_acc/serve.py`**: Core server module
  - `render_dashboard()` — single-page HTML app with summary cards, sample table, filter/search
  - `ReportHandler` — serves dashboard at `/`, report JSON at `/api/report`, 404 otherwise
  - `run_server()` — starts HTTP server with port/host/open_browser options
  - Auto-refresh: caches report by mtime, client polls every 5 seconds

- **CLI integration**: `xpyd-acc serve --report <path> [--port N] [--host H] [--open]`

- **`tests/test_serve.py`**: 14 tests covering template rendering, API dict conversion, handler creation, full HTTP integration (dashboard route, API route, 404, file change detection), validation, browser open, CLI registration

### Dashboard Features
- Summary cards: total samples, divergent, match, divergence rate
- Clickable sample rows with expandable detail (baseline/target output)
- Filter by classification dropdown
- Search by prompt/output text
- Color-coded divergence badges
- Auto-refresh on report file change

Closes #165