### PR TITLE
feat(M80): Multi-Dataset CLI Integration (#173)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -739,7 +739,7 @@
 - `grafana.py` module: `generate_dashboard()`, `GrafanaDashboard` dataclass
 - 10 tests covering dashboard generation, panels, template vars, JSON export, CLI integration
 
-## M79: Parallel Multi-Dataset Batch Run
+## M79: Parallel Multi-Dataset Batch Run ✅
 - `batch-compare --dataset d1.jsonl --dataset d2.jsonl ...` runs multiple datasets in one command
 - Concurrent dataset execution (datasets run in parallel, samples within each dataset also concurrent)
 - Per-dataset report + combined summary report
@@ -750,3 +750,15 @@
 - Template support: `--template` applies to all datasets, or per-dataset templates via TOML config
 - TOML config: `[multi_dataset]` section with dataset list and per-dataset overrides
 - Useful for running GSM8K + MMLU + HumanEval in one command
+
+## M80: Multi-Dataset CLI Integration
+- `batch-compare --dataset d1.jsonl --dataset d2.jsonl` accepts multiple `--dataset` flags
+- When multiple datasets given, uses `run_multi_dataset()` from `multi_dataset.py`
+- Per-dataset results printed with pass/fail indicators
+- Overall divergence rate across all datasets
+- `--fail-threshold` applies per-dataset (any exceeding → exit 1)
+- JSON export via `--json` includes per-dataset breakdowns
+- Markdown export via `--markdown` includes per-dataset sections
+- Template support: `--template` applies to all datasets
+- Progress bars per dataset
+- Tests for CLI integration with multiple datasets

--- a/docs/iterations/current.md
+++ b/docs/iterations/current.md
@@ -128,3 +128,36 @@ Added `multi_dataset.py` module for running multiple evaluation datasets concurr
 - Callback invocation
 - Kwargs forwarding
 - Empty dataset map handling
+
+---
+
+## M80: Multi-Dataset CLI Integration
+
+**Date:** 2026-04-06
+**Issue:** #173
+**Status:** In progress
+
+### Problem
+M79 added `multi_dataset.py` with `run_multi_dataset()` but no CLI integration — users cannot invoke multi-dataset runs from the command line.
+
+### Solution
+- Made `--dataset` flag repeatable (argparse `action="append"`)
+- When >1 dataset given, `_run_batch_compare` delegates to `_run_multi_dataset()`
+- Added `_run_multi_dataset()` in `batch.py`: loads datasets, runs concurrent comparison, prints results
+- Per-dataset `--fail-threshold` checking
+- JSON/Markdown export support
+
+### Files Changed
+- `src/xpyd_acc/cli/parsers.py` (--dataset becomes repeatable)
+- `src/xpyd_acc/cli/batch.py` (multi-dataset routing + handler)
+- `tests/test_multi_dataset_cli.py` (new, 10 tests)
+- `ROADMAP.md` (M79 ✅, M80 added)
+
+### Tests
+10 tests covering:
+- Dataclass aggregation
+- JSON/Markdown export
+- Terminal formatting
+- CLI flag repeatability
+- Multi-dataset delegation
+- Single-dataset backward compatibility

--- a/src/xpyd_acc/cli/batch.py
+++ b/src/xpyd_acc/cli/batch.py
@@ -41,7 +41,8 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
         from xpyd_acc.dry_run import format_dry_run, run_dry_run
 
         result = await run_dry_run(
-            args.dataset, args.baseline, target_urls[0],
+            args.dataset[0] if isinstance(args.dataset, list) else args.dataset,
+            args.baseline, target_urls[0],
             template=args.template, skip_healthcheck=args.skip_healthcheck,
             model=args.model, max_tokens=args.max_tokens, api_key=args.api_key,
             concurrency=args.concurrency, retries=args.retries, retry_delay=args.retry_delay,
@@ -52,6 +53,12 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             Path(args.json_path).write_text(result.to_json())
             print(f"\nDry run report exported to {args.json_path}")
         sys.exit(0 if result.valid else 1)
+
+    # Multi-dataset mode: delegate when more than one --dataset provided
+    dataset_paths: list[str] = args.dataset if isinstance(args.dataset, list) else [args.dataset]
+    if len(dataset_paths) > 1:
+        await _run_multi_dataset(args, dataset_paths, target_urls)
+        return
 
     from xpyd_acc.batch_compare import (
         export_csv,
@@ -64,7 +71,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
     from xpyd_acc.sampling import SamplingParams
 
     sampling = SamplingParams.from_args(args)
-    samples = load_dataset(args.dataset)
+    samples = load_dataset(dataset_paths[0])
 
     if args.template:
         from xpyd_acc.templates import resolve_template
@@ -74,7 +81,7 @@ async def _run_batch_compare(args: argparse.Namespace) -> None:
             variables = {"prompt": sample.prompt, **sample.metadata}
             sample.prompt = template.render(variables)
 
-    print(f"Loaded {len(samples)} samples from {args.dataset}")
+    print(f"Loaded {len(samples)} samples from {dataset_paths[0]}")
 
     if not args.skip_healthcheck:
         await _preflight_healthcheck([args.baseline, *target_urls], api_key=args.api_key)
@@ -435,3 +442,103 @@ async def _run_rerun(args: argparse.Namespace) -> None:
     elif report.divergent_samples > 0:
         sys.exit(1)
 
+
+
+async def _run_multi_dataset(
+    args: argparse.Namespace,
+    dataset_paths: list[str],
+    target_urls: list[str],
+) -> None:
+    """Run batch comparison across multiple datasets concurrently."""
+    from pathlib import Path
+
+    from xpyd_acc.batch_compare import load_dataset
+    from xpyd_acc.multi_dataset import (
+        format_multi_dataset_report,
+        run_multi_dataset,
+    )
+    from xpyd_acc.sampling import SamplingParams
+
+    sampling = SamplingParams.from_args(args)
+
+    # Load all datasets
+    dataset_map: dict[str, list] = {}
+    for dp in dataset_paths:
+        name = Path(dp).stem
+        samples = load_dataset(dp)
+        if args.template:
+            from xpyd_acc.templates import resolve_template
+            template = resolve_template(args.template)
+            for sample in samples:
+                variables = {"prompt": sample.prompt, **sample.metadata}
+                sample.prompt = template.render(variables)
+        dataset_map[name] = samples
+        print(f"Loaded {len(samples)} samples from {dp}")
+
+    target_url = target_urls[0]
+    if not args.skip_healthcheck:
+        await _preflight_healthcheck([args.baseline, target_url], api_key=args.api_key)
+
+    from xpyd_acc.output_compare import MatchConfig
+    match_config = MatchConfig(
+        normalize_whitespace=args.normalize_whitespace,
+        ignore_case=args.ignore_case,
+        numeric_tolerance=args.numeric_tolerance,
+    )
+    effective_match = match_config if (
+        match_config.normalize_whitespace or match_config.ignore_case
+        or match_config.numeric_tolerance is not None
+    ) else None
+
+    from xpyd_acc.headers import parse_env_headers, parse_header_args, resolve_headers
+    cli_hdrs = parse_header_args(getattr(args, "headers", None))
+    env_hdrs = parse_env_headers()
+    cfg_hdrs = args._config.get("defaults", {}).get("headers") if args._config else None
+    custom_headers = resolve_headers(
+        cli_headers=cli_hdrs, env_headers=env_hdrs, config_headers=cfg_hdrs,
+    ) or None
+
+    report = await run_multi_dataset(
+        dataset_map,
+        args.baseline,
+        target_url,
+        model=args.model,
+        max_tokens=args.max_tokens,
+        api_key=args.api_key,
+        logprob_gap_threshold=args.logprob_gap_threshold,
+        concurrency=args.concurrency,
+        retries=args.retries,
+        retry_delay=args.retry_delay,
+        match_config=effective_match,
+        sampling_params=sampling,
+        timeout=args.timeout,
+        skip_validation=getattr(args, "skip_validation", False),
+        custom_headers=custom_headers,
+    )
+
+    print()
+    print(format_multi_dataset_report(report))
+
+    if args.json_path:
+        Path(args.json_path).write_text(report.to_json())
+        print(f"\nJSON exported to {args.json_path}")
+
+    if args.markdown:
+        Path(args.markdown).write_text(report.to_markdown())
+        print(f"\nMarkdown exported to {args.markdown}")
+
+    fail_threshold = _resolve_fail_threshold(args, getattr(args, "_config", None))
+    if fail_threshold is not None:
+        for name in report.datasets:
+            dr = report.per_dataset[name].divergence_rate
+            if dr > fail_threshold:
+                print(
+                    f"\n✗ FAIL: dataset '{name}' divergence rate {dr:.1%}"
+                    f" exceeds threshold {fail_threshold:.1%}",
+                )
+                sys.exit(1)
+        print(
+            f"\n✓ PASS: all datasets within threshold {fail_threshold:.1%}",
+        )
+    elif report.total_divergent > 0:
+        sys.exit(1)

--- a/src/xpyd_acc/cli/parsers.py
+++ b/src/xpyd_acc/cli/parsers.py
@@ -113,7 +113,10 @@ def _register_batch(sub):
         "--snapshot", default=None, metavar="SNAPSHOT_JSON",
         help="Use saved snapshot as baseline (mutually exclusive with --baseline)",
     )
-    bc.add_argument("--dataset", required=True, help="Path to JSONL dataset file")
+    bc.add_argument(
+        "--dataset", required=True, action="append",
+        help="Path to dataset file (repeatable for multi-dataset runs)",
+    )
     bc.add_argument("--model", default=None, help="Model name (default: default)")
     bc.add_argument("--max-tokens", type=int, default=None, help="Max tokens (default: 64)")
     bc.add_argument("--api-key", default=None, help="API key for endpoints")

--- a/tests/test_multi_dataset_cli.py
+++ b/tests/test_multi_dataset_cli.py
@@ -1,0 +1,207 @@
+"""Tests for multi-dataset CLI integration (M80)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from xpyd_acc.batch_compare import BatchReport, SampleResult
+from xpyd_acc.multi_dataset import MultiDatasetReport, format_multi_dataset_report
+
+
+def _make_report(total: int, divergent: int) -> BatchReport:
+    """Create a minimal BatchReport for testing."""
+    results = []
+    for i in range(total):
+        results.append(
+            SampleResult(
+                sample_id=f"s{i}",
+                prompt=f"prompt {i}",
+                baseline_output=f"output {i}",
+                target_output=f"output {i}" if i >= divergent else f"diff {i}",
+                exact_match=i >= divergent,
+                first_divergence_index=0 if i < divergent else -1,
+                logprob_gap=0.5 if i < divergent else 0.0,
+                classification="likely_bug" if i < divergent else "match",
+                baseline_logprob_at_divergence=-1.0 if i < divergent else 0.0,
+                target_logprob_at_divergence=-1.5 if i < divergent else 0.0,
+                context_length=10,
+            )
+        )
+    return BatchReport(
+        total_samples=total,
+        match_samples=total - divergent,
+        divergent_samples=divergent,
+        divergence_rate=divergent / total if total else 0.0,
+        results=results,
+    )
+
+
+class TestMultiDatasetReport:
+    """Tests for MultiDatasetReport dataclass."""
+
+    def test_aggregate_stats(self) -> None:
+        r1 = _make_report(10, 2)
+        r2 = _make_report(5, 1)
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=["d1", "d2"],
+            per_dataset={"d1": r1, "d2": r2},
+        )
+        assert mdr.total_samples == 15
+        assert mdr.total_divergent == 3
+        assert abs(mdr.overall_divergence_rate - 0.2) < 1e-9
+
+    def test_empty_datasets(self) -> None:
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=[],
+            per_dataset={},
+        )
+        assert mdr.total_samples == 0
+        assert mdr.overall_divergence_rate == 0.0
+
+    def test_to_json_roundtrip(self) -> None:
+        r1 = _make_report(3, 1)
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=["ds1"],
+            per_dataset={"ds1": r1},
+        )
+        data = json.loads(mdr.to_json())
+        assert data["total_samples"] == 3
+        assert data["total_divergent"] == 1
+        assert "ds1" in data["per_dataset"]
+
+    def test_to_markdown(self) -> None:
+        r1 = _make_report(4, 2)
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=["alpha"],
+            per_dataset={"alpha": r1},
+        )
+        md = mdr.to_markdown()
+        assert "Multi-Dataset" in md
+        assert "alpha" in md
+        assert "50.0%" in md
+
+    def test_format_terminal(self) -> None:
+        r1 = _make_report(10, 0)
+        r2 = _make_report(10, 3)
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=["good", "bad"],
+            per_dataset={"good": r1, "bad": r2},
+        )
+        out = format_multi_dataset_report(mdr)
+        assert "good" in out
+        assert "bad" in out
+
+
+class TestMultiDatasetCLIIntegration:
+    """Tests for CLI batch.py multi-dataset path."""
+
+    def test_dataset_flag_is_repeatable(self) -> None:
+        """Verify argparse accepts multiple --dataset flags."""
+        from xpyd_acc.cli.parsers import register_all
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        register_all(sub)
+        args = parser.parse_args([
+            "batch-compare",
+            "--baseline", "http://base",
+            "--target", "http://target",
+            "--dataset", "a.jsonl",
+            "--dataset", "b.jsonl",
+            "--model", "m",
+        ])
+        assert args.dataset == ["a.jsonl", "b.jsonl"]
+
+    def test_single_dataset_still_works(self) -> None:
+        """Single --dataset should still produce a list with one element."""
+        from xpyd_acc.cli.parsers import register_all
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers()
+        register_all(sub)
+        args = parser.parse_args([
+            "batch-compare",
+            "--baseline", "http://base",
+            "--target", "http://target",
+            "--dataset", "only.jsonl",
+            "--model", "m",
+        ])
+        assert args.dataset == ["only.jsonl"]
+
+    @pytest.mark.asyncio
+    async def test_multi_dataset_delegates(self, tmp_path: Path) -> None:
+        """When 2+ datasets are given, _run_multi_dataset is called."""
+        d1 = tmp_path / "d1.jsonl"
+        d2 = tmp_path / "d2.jsonl"
+        d1.write_text('{"prompt": "hello", "id": "s1"}\n')
+        d2.write_text('{"prompt": "world", "id": "s2"}\n')
+
+        with patch(
+            "xpyd_acc.cli.batch._run_multi_dataset", new_callable=AsyncMock,
+        ) as mock_fn:
+            mock_fn.return_value = None
+            from xpyd_acc.cli.batch import _run_batch_compare
+
+            args = argparse.Namespace(
+                dataset=[str(d1), str(d2)],
+                baseline="http://base",
+                target=["http://target"],
+                snapshot=None,
+                rerun=None,
+                dry_run=False,
+                _config=None,
+            )
+            await _run_batch_compare(args)
+            mock_fn.assert_called_once()
+
+    def test_json_export_multi_dataset(self, tmp_path: Path) -> None:
+        """JSON export includes per-dataset breakdown."""
+        r1 = _make_report(5, 1)
+        r2 = _make_report(5, 2)
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=["gsm8k", "mmlu"],
+            per_dataset={"gsm8k": r1, "mmlu": r2},
+        )
+        out = tmp_path / "out.json"
+        out.write_text(mdr.to_json())
+        data = json.loads(out.read_text())
+        assert "gsm8k" in data["per_dataset"]
+        assert "mmlu" in data["per_dataset"]
+        assert data["per_dataset"]["gsm8k"]["total_samples"] == 5
+
+    def test_markdown_export_multi_dataset(self) -> None:
+        """Markdown includes per-dataset sections."""
+        r1 = _make_report(3, 1)
+        mdr = MultiDatasetReport(
+            baseline_url="http://base",
+            target_url="http://target",
+            model="m",
+            datasets=["test_ds"],
+            per_dataset={"test_ds": r1},
+        )
+        md = mdr.to_markdown()
+        assert "## Dataset: test_ds" in md
+        assert "Per-Dataset Summary" in md


### PR DESCRIPTION
## Summary
Wire `multi_dataset.py` (M79) into the CLI so users can run multi-dataset batch comparisons from the command line.

## Changes
- `--dataset` flag on `batch-compare` is now repeatable (`action=append`)
- When >1 dataset is provided, delegates to `run_multi_dataset()`
- New `_run_multi_dataset()` handler in `batch.py`:
  - Loads all datasets, applies templates
  - Runs concurrent comparison via `run_multi_dataset()`
  - Prints per-dataset pass/fail summary
  - JSON/Markdown export with per-dataset breakdowns
  - Per-dataset `--fail-threshold` checking
- 10 new tests covering CLI integration, dataclass ops, export

## Testing
All 1186 tests pass (including 10 new).
Lint clean: `ruff check` + `isort --check`.

Closes #173